### PR TITLE
Misc improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.2] - 2024-11-25
+- Add public `recursiveParseErrors` function to lib, to return nested/inner ABI errors
+- Use it everywhere: `parseBytes` command, thrown exceptions, and `prettyReceipt` output of failed execs
+- Supports explicit `--fee-token 0x00...00` for native fees (default if omitted)
+- Embeds and shows `--version|-V` in cli, with shortRev commit
+
+## [0.1.1] - 2024-11-08
+- Small improvements to inner wrap errors in `parseBytes` command
+- Disclaimer in README
+
 ## [0.1.0] - 2024-10-31
 ### Added
 - Initial release

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -14,7 +14,7 @@ export default tseslint.config(
     languageOptions: {
       parserOptions: {
         projectService: {
-          allowDefaultProject: ['*.js', '*.cjs'],
+          allowDefaultProject: ['*.js'],
         },
         tsconfigRootDir: import.meta.dirname,
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/prompts": "7.0.1",
+        "@inquirer/prompts": "7.1.0",
         "abitype": "1.0.6",
         "ethers": "6.13.4",
         "tslib": "2.8.1",
@@ -19,12 +19,12 @@
         "ccip-tools-ts": "dist/ccip-tools-ts"
       },
       "devDependencies": {
-        "@eslint/js": "9.14.0",
+        "@eslint/js": "9.15.0",
         "@types/eslint__js": "8.42.3",
         "@types/jest": "29.5.14",
-        "@types/node": "22.9.0",
+        "@types/node": "22.9.3",
         "@types/yargs": "17.0.33",
-        "eslint": "9.14.0",
+        "eslint": "9.15.0",
         "eslint-config-prettier": "9.1.0",
         "eslint-import-resolver-typescript": "3.6.3",
         "eslint-plugin-import": "2.31.0",
@@ -35,9 +35,9 @@
         "prettier": "3.3.3",
         "ts-jest": "29.2.5",
         "tsx": "4.19.2",
-        "typescript": "5.6.3",
-        "typescript-eslint": "8.13.0",
-        "yaml": "2.6.0"
+        "typescript": "5.7.2",
+        "typescript-eslint": "8.15.0",
+        "yaml": "2.6.1"
       }
     },
     "node_modules/@adraffy/ens-normalize": {
@@ -1112,9 +1112,9 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.18.0.tgz",
-      "integrity": "sha512-fTxvnS1sRMu3+JjXwJG0j/i4RT9u4qJ+lqS/yCGap4lH4zZGzQ7tu+xZqQmcMZq5OBZDL4QRxQzRjkWcGt8IVw==",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.19.0.tgz",
+      "integrity": "sha512-zdHg2FPIFNKPdcHWtiNT+jEFCHYVplAXRDlQDyqy0zGx/q2parwh7brGJSiTxRk/TSMkbM//zt/f5CHgyTyaSQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1127,9 +1127,9 @@
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.7.0.tgz",
-      "integrity": "sha512-xp5Jirz5DyPYlPiKat8jaq0EmYvDXKKpzTbxXMpT9eqlRJkRKIz9AGMdlvYjih+im+QlhWrpvVjl8IPC/lHlUw==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.9.0.tgz",
+      "integrity": "sha512-7ATR9F0e4W85D/0w7cU0SNj7qkAexMG+bAHEZOjo9akvGuhHE2m7umzWzfnpa0XAg5Kxc1BWmtPMV67jJ+9VUg==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -1137,9 +1137,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.1.0.tgz",
-      "integrity": "sha512-4Bfj15dVJdoy3RfZmmo86RK1Fwzn6SstsvK9JS+BaVKqC6QQQQyXekNaC+g+LKNgkQ+2VhGAzm6hO40AhMR3zQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.2.0.tgz",
+      "integrity": "sha512-grOjVNN8P3hjJn/eIETF1wwd12DdnwFDoyceUJLYYdkpbwq3nLi+4fqrTAONx7XDALqlL220wC/RHSC/QTI/0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1161,9 +1161,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.14.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.14.0.tgz",
-      "integrity": "sha512-pFoEtFWCPyDOl+C6Ift+wC7Ro89otjigCf5vcuWqWgqNSQbRrpjSvdeE6ofLz4dHmyxD5f7gIdGT4+p36L6Twg==",
+      "version": "9.15.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.15.0.tgz",
+      "integrity": "sha512-tMTqrY+EzbXmKJR5ToI8lxu7jaN5EdmrBFJpQk5JmSlyLsx6o4t27r883K5xsLuCYCpfKBCGswMSWXsM+jB7lg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1181,9 +1181,9 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.0.tgz",
-      "integrity": "sha512-vH9PiIMMwvhCx31Af3HiGzsVNULDbyVkHXwlemn/B0TFj/00ho3y55efXrUZTfQipxoHC5u4xq6zblww1zm1Ig==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.3.tgz",
+      "integrity": "sha512-2b/g5hRmpbb1o4GnTZax9N9m0FXzz9OV42ZzI4rDDMDuHUqigAiQCEWChBWCY4ztAGVRjoWT19v0yMmc5/L5kA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1260,14 +1260,14 @@
       }
     },
     "node_modules/@inquirer/checkbox": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.0.1.tgz",
-      "integrity": "sha512-ehJjmNPdguajc1hStvjN7DJNVjwG5LC1mgGMGFjCmdkn2fxB2GtULftMnlaqNmvMdPpqdaSoOFpl86VkLtG4pQ==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.0.2.tgz",
+      "integrity": "sha512-+gznPl8ip8P8HYHYecDtUtdsh1t2jvb+sWCD72GAiZ9m45RqwrLmReDaqdC0umQfamtFXVRoMVJ2/qINKGm9Tg==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.0.1",
-        "@inquirer/figures": "^1.0.7",
-        "@inquirer/type": "^3.0.0",
+        "@inquirer/core": "^10.1.0",
+        "@inquirer/figures": "^1.0.8",
+        "@inquirer/type": "^3.0.1",
         "ansi-escapes": "^4.3.2",
         "yoctocolors-cjs": "^2.1.2"
       },
@@ -1279,13 +1279,13 @@
       }
     },
     "node_modules/@inquirer/confirm": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.0.1.tgz",
-      "integrity": "sha512-6ycMm7k7NUApiMGfVc32yIPp28iPKxhGRMqoNDiUjq2RyTAkbs5Fx0TdzBqhabcKvniDdAAvHCmsRjnNfTsogw==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.0.2.tgz",
+      "integrity": "sha512-KJLUHOaKnNCYzwVbryj3TNBxyZIrr56fR5N45v6K9IPrbT6B7DcudBMfylkV1A8PUdJE15mybkEQyp2/ZUpxUA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.0.1",
-        "@inquirer/type": "^3.0.0"
+        "@inquirer/core": "^10.1.0",
+        "@inquirer/type": "^3.0.1"
       },
       "engines": {
         "node": ">=18"
@@ -1295,13 +1295,13 @@
       }
     },
     "node_modules/@inquirer/core": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.0.1.tgz",
-      "integrity": "sha512-KKTgjViBQUi3AAssqjUFMnMO3CM3qwCHvePV9EW+zTKGKafFGFF01sc1yOIYjLJ7QU52G/FbzKc+c01WLzXmVQ==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.0.tgz",
+      "integrity": "sha512-I+ETk2AL+yAVbvuKx5AJpQmoaWhpiTFOg/UJb7ZkMAK4blmtG8ATh5ct+T/8xNld0CZG/2UhtkdMwpgvld92XQ==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/figures": "^1.0.7",
-        "@inquirer/type": "^3.0.0",
+        "@inquirer/figures": "^1.0.8",
+        "@inquirer/type": "^3.0.1",
         "ansi-escapes": "^4.3.2",
         "cli-width": "^4.1.0",
         "mute-stream": "^2.0.0",
@@ -1315,13 +1315,13 @@
       }
     },
     "node_modules/@inquirer/editor": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.0.1.tgz",
-      "integrity": "sha512-qAHHJ6hs343eNtCKgV2wV5CImFxYG8J1pl/YCeI5w9VoW7QpulRUU26+4NsMhjR6zDRjKBsH/rRjCIcaAOHsrg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.1.0.tgz",
+      "integrity": "sha512-K1gGWsxEqO23tVdp5MT3H799OZ4ER1za7Dlc8F4um0W7lwSv0KGR/YyrUEyimj0g7dXZd8XknM/5QA2/Uy+TbA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.0.1",
-        "@inquirer/type": "^3.0.0",
+        "@inquirer/core": "^10.1.0",
+        "@inquirer/type": "^3.0.1",
         "external-editor": "^3.1.0"
       },
       "engines": {
@@ -1332,13 +1332,13 @@
       }
     },
     "node_modules/@inquirer/expand": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.1.tgz",
-      "integrity": "sha512-9anjpdc802YInXekwePsa5LWySzVMHbhVS6v6n5IJxrl8w09mODOeP69wZ1d0WrOvot2buQSmYp4lW/pq8y+zQ==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.2.tgz",
+      "integrity": "sha512-WdgCX1cUtinz+syKyZdJomovULYlKUWZbVYZzhf+ZeeYf4htAQ3jLymoNs3koIAKfZZl3HUBb819ClCBfyznaw==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.0.1",
-        "@inquirer/type": "^3.0.0",
+        "@inquirer/core": "^10.1.0",
+        "@inquirer/type": "^3.0.1",
         "yoctocolors-cjs": "^2.1.2"
       },
       "engines": {
@@ -1349,22 +1349,22 @@
       }
     },
     "node_modules/@inquirer/figures": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.7.tgz",
-      "integrity": "sha512-m+Trk77mp54Zma6xLkLuY+mvanPxlE4A7yNKs2HBiyZ4UkVs28Mv5c/pgWrHeInx+USHeX/WEPzjrWrcJiQgjw==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.8.tgz",
+      "integrity": "sha512-tKd+jsmhq21AP1LhexC0pPwsCxEhGgAkg28byjJAd+xhmIs8LUX8JbUc3vBf3PhLxWiB5EvyBE5X7JSPAqMAqg==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@inquirer/input": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.0.1.tgz",
-      "integrity": "sha512-m+SliZ2m43cDRIpAdQxfv5QOeAQCuhS8TGLvtzEP1An4IH1kBES4RLMRgE/fC+z29aN8qYG8Tq/eXQQKTYwqAg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.0.2.tgz",
+      "integrity": "sha512-yCLCraigU085EcdpIVEDgyfGv4vBiE4I+k1qRkc9C5dMjWF42ADMGy1RFU94+eZlz4YlkmFsiyHZy0W1wdhaNg==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.0.1",
-        "@inquirer/type": "^3.0.0"
+        "@inquirer/core": "^10.1.0",
+        "@inquirer/type": "^3.0.1"
       },
       "engines": {
         "node": ">=18"
@@ -1374,13 +1374,13 @@
       }
     },
     "node_modules/@inquirer/number": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.1.tgz",
-      "integrity": "sha512-gF3erqfm0snpwBjbyKXUUe17QJ7ebm49btXApajrM0rgCCoYX0o9W5NCuYNae87iPxaIJVjtuoQ42DX32IdbMA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.2.tgz",
+      "integrity": "sha512-MKQhYofdUNk7eqJtz52KvM1dH6R93OMrqHduXCvuefKrsiMjHiMwjc3NZw5Imm2nqY7gWd9xdhYrtcHMJQZUxA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.0.1",
-        "@inquirer/type": "^3.0.0"
+        "@inquirer/core": "^10.1.0",
+        "@inquirer/type": "^3.0.1"
       },
       "engines": {
         "node": ">=18"
@@ -1390,13 +1390,13 @@
       }
     },
     "node_modules/@inquirer/password": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.1.tgz",
-      "integrity": "sha512-D7zUuX4l4ZpL3D7/SWu9ibijP09jigwHi/gfUHLx5GMS5oXzuMfPV2xPMG1tskco4enTx70HA0VtMXecerpvbg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.2.tgz",
+      "integrity": "sha512-tQXGSu7IO07gsYlGy3VgXRVsbOWqFBMbqAUrJSc1PDTQQ5Qdm+QVwkP0OC0jnUZ62D19iPgXOMO+tnWG+HhjNQ==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.0.1",
-        "@inquirer/type": "^3.0.0",
+        "@inquirer/core": "^10.1.0",
+        "@inquirer/type": "^3.0.1",
         "ansi-escapes": "^4.3.2"
       },
       "engines": {
@@ -1407,21 +1407,21 @@
       }
     },
     "node_modules/@inquirer/prompts": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.0.1.tgz",
-      "integrity": "sha512-cu2CpGC2hz7WTt2VBvdkzahDvYice6vYA/8Dm7Fy3tRNzKuQTF2EY3CV4H2GamveWE6tA2XzyXtbWX8+t4WMQg==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.1.0.tgz",
+      "integrity": "sha512-5U/XiVRH2pp1X6gpNAjWOglMf38/Ys522ncEHIKT1voRUvSj/DQnR22OVxHnwu5S+rCFaUiPQ57JOtMFQayqYA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/checkbox": "^4.0.1",
-        "@inquirer/confirm": "^5.0.1",
-        "@inquirer/editor": "^4.0.1",
-        "@inquirer/expand": "^4.0.1",
-        "@inquirer/input": "^4.0.1",
-        "@inquirer/number": "^3.0.1",
-        "@inquirer/password": "^4.0.1",
-        "@inquirer/rawlist": "^4.0.1",
-        "@inquirer/search": "^3.0.1",
-        "@inquirer/select": "^4.0.1"
+        "@inquirer/checkbox": "^4.0.2",
+        "@inquirer/confirm": "^5.0.2",
+        "@inquirer/editor": "^4.1.0",
+        "@inquirer/expand": "^4.0.2",
+        "@inquirer/input": "^4.0.2",
+        "@inquirer/number": "^3.0.2",
+        "@inquirer/password": "^4.0.2",
+        "@inquirer/rawlist": "^4.0.2",
+        "@inquirer/search": "^3.0.2",
+        "@inquirer/select": "^4.0.2"
       },
       "engines": {
         "node": ">=18"
@@ -1431,13 +1431,13 @@
       }
     },
     "node_modules/@inquirer/rawlist": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.0.1.tgz",
-      "integrity": "sha512-0LuMOgaWs7W8JNcbiKkoFwyWFDEeCmLqDCygF0hidQUVa6J5grFVRZxrpompiWDFM49Km2rf7WoZwRo1uf1yWQ==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.0.2.tgz",
+      "integrity": "sha512-3XGcskMoVF8H0Dl1S5TSZ3rMPPBWXRcM0VeNVsS4ByWeWjSeb0lPqfnBg6N7T0608I1B2bSVnbi2cwCrmOD1Yw==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.0.1",
-        "@inquirer/type": "^3.0.0",
+        "@inquirer/core": "^10.1.0",
+        "@inquirer/type": "^3.0.1",
         "yoctocolors-cjs": "^2.1.2"
       },
       "engines": {
@@ -1448,14 +1448,14 @@
       }
     },
     "node_modules/@inquirer/search": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.0.1.tgz",
-      "integrity": "sha512-ehMqjiO0pAf+KtdONKeCLVy4i3fy3feyRRhDrvzWhiwB8JccgKn7eHFr39l+Nx/FaZAhr0YxIJvkK5NuNvG+Ww==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.0.2.tgz",
+      "integrity": "sha512-Zv4FC7w4dJ13BOJfKRQCICQfShinGjb1bCEIHxTSnjj2telu3+3RHwHubPG9HyD4aix5s+lyAMEK/wSFD75HLA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.0.1",
-        "@inquirer/figures": "^1.0.7",
-        "@inquirer/type": "^3.0.0",
+        "@inquirer/core": "^10.1.0",
+        "@inquirer/figures": "^1.0.8",
+        "@inquirer/type": "^3.0.1",
         "yoctocolors-cjs": "^2.1.2"
       },
       "engines": {
@@ -1466,14 +1466,14 @@
       }
     },
     "node_modules/@inquirer/select": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.0.1.tgz",
-      "integrity": "sha512-tVRatFRGU49bxFCKi/3P+C0E13KZduNFbWuHWRx0L2+jbiyKRpXgHp9qiRHWRk/KarhYBXzH/di6w3VQ5aJd5w==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.0.2.tgz",
+      "integrity": "sha512-uSWUzaSYAEj0hlzxa1mUB6VqrKaYx0QxGBLZzU4xWFxaSyGaXxsSE4OSOwdU24j0xl8OajgayqFXW0l2bkl2kg==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.0.1",
-        "@inquirer/figures": "^1.0.7",
-        "@inquirer/type": "^3.0.0",
+        "@inquirer/core": "^10.1.0",
+        "@inquirer/figures": "^1.0.8",
+        "@inquirer/type": "^3.0.1",
         "ansi-escapes": "^4.3.2",
         "yoctocolors-cjs": "^2.1.2"
       },
@@ -1485,9 +1485,9 @@
       }
     },
     "node_modules/@inquirer/type": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.0.tgz",
-      "integrity": "sha512-YYykfbw/lefC7yKj7nanzQXILM7r3suIvyFlCcMskc99axmsSewXWkAfXKwMbgxL76iAFVmRwmYdwNZNc8gjog==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.1.tgz",
+      "integrity": "sha512-+ksJMIy92sOAiAccGpcKZUc3bYO07cADnscIxHBknEm3uNts3movSmBofc1908BNy5edKscxYeAdaX1NXkHS6A==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -2313,9 +2313,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.9.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.9.0.tgz",
-      "integrity": "sha512-vuyHg81vvWA1Z1ELfvLko2c8f34gyA0zaic0+Rllc5lbCnbSyuvb2Oxpm6TAUAC/2xZN3QGqxBNggD1nNR2AfQ==",
+      "version": "22.9.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.9.3.tgz",
+      "integrity": "sha512-F3u1fs/fce3FFk+DAxbxc78DF8x0cY09RRL8GnXLmkJ1jvx3TtPdWoTT5/NiYfI5ASqXBmfqJi9dZ3gxMx4lzw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.8"
@@ -2346,17 +2346,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.13.0.tgz",
-      "integrity": "sha512-nQtBLiZYMUPkclSeC3id+x4uVd1SGtHuElTxL++SfP47jR0zfkZBJHc+gL4qPsgTuypz0k8Y2GheaDYn6Gy3rg==",
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.15.0.tgz",
+      "integrity": "sha512-+zkm9AR1Ds9uLWN3fkoeXgFppaQ+uEVtfOV62dDmsy9QCNqlRHWNEck4yarvRNrvRcHQLGfqBNui3cimoz8XAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.13.0",
-        "@typescript-eslint/type-utils": "8.13.0",
-        "@typescript-eslint/utils": "8.13.0",
-        "@typescript-eslint/visitor-keys": "8.13.0",
+        "@typescript-eslint/scope-manager": "8.15.0",
+        "@typescript-eslint/type-utils": "8.15.0",
+        "@typescript-eslint/utils": "8.15.0",
+        "@typescript-eslint/visitor-keys": "8.15.0",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
@@ -2380,16 +2380,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.13.0.tgz",
-      "integrity": "sha512-w0xp+xGg8u/nONcGw1UXAr6cjCPU1w0XVyBs6Zqaj5eLmxkKQAByTdV/uGgNN5tVvN/kKpoQlP2cL7R+ajZZIQ==",
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.15.0.tgz",
+      "integrity": "sha512-7n59qFpghG4uazrF9qtGKBZXn7Oz4sOMm8dwNWDQY96Xlm2oX67eipqcblDj+oY1lLCbf1oltMZFpUso66Kl1A==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.13.0",
-        "@typescript-eslint/types": "8.13.0",
-        "@typescript-eslint/typescript-estree": "8.13.0",
-        "@typescript-eslint/visitor-keys": "8.13.0",
+        "@typescript-eslint/scope-manager": "8.15.0",
+        "@typescript-eslint/types": "8.15.0",
+        "@typescript-eslint/typescript-estree": "8.15.0",
+        "@typescript-eslint/visitor-keys": "8.15.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -2409,14 +2409,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.13.0.tgz",
-      "integrity": "sha512-XsGWww0odcUT0gJoBZ1DeulY1+jkaHUciUq4jKNv4cpInbvvrtDoyBH9rE/n2V29wQJPk8iCH1wipra9BhmiMA==",
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.15.0.tgz",
+      "integrity": "sha512-QRGy8ADi4J7ii95xz4UoiymmmMd/zuy9azCaamnZ3FM8T5fZcex8UfJcjkiEZjJSztKfEBe3dZ5T/5RHAmw2mA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.13.0",
-        "@typescript-eslint/visitor-keys": "8.13.0"
+        "@typescript-eslint/types": "8.15.0",
+        "@typescript-eslint/visitor-keys": "8.15.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2427,14 +2427,14 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.13.0.tgz",
-      "integrity": "sha512-Rqnn6xXTR316fP4D2pohZenJnp+NwQ1mo7/JM+J1LWZENSLkJI8ID8QNtlvFeb0HnFSK94D6q0cnMX6SbE5/vA==",
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.15.0.tgz",
+      "integrity": "sha512-UU6uwXDoI3JGSXmcdnP5d8Fffa2KayOhUUqr/AiBnG1Gl7+7ut/oyagVeSkh7bxQ0zSXV9ptRh/4N15nkCqnpw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.13.0",
-        "@typescript-eslint/utils": "8.13.0",
+        "@typescript-eslint/typescript-estree": "8.15.0",
+        "@typescript-eslint/utils": "8.15.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.3.0"
       },
@@ -2445,6 +2445,9 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0"
+      },
       "peerDependenciesMeta": {
         "typescript": {
           "optional": true
@@ -2452,9 +2455,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.13.0.tgz",
-      "integrity": "sha512-4cyFErJetFLckcThRUFdReWJjVsPCqyBlJTi6IDEpc1GWCIIZRFxVppjWLIMcQhNGhdWJJRYFHpHoDWvMlDzng==",
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.15.0.tgz",
+      "integrity": "sha512-n3Gt8Y/KyJNe0S3yDCD2RVKrHBC4gTUcLTebVBXacPy091E6tNspFLKRXlk3hwT4G55nfr1n2AdFqi/XMxzmPQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2466,14 +2469,14 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.13.0.tgz",
-      "integrity": "sha512-v7SCIGmVsRK2Cy/LTLGN22uea6SaUIlpBcO/gnMGT/7zPtxp90bphcGf4fyrCQl3ZtiBKqVTG32hb668oIYy1g==",
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.15.0.tgz",
+      "integrity": "sha512-1eMp2JgNec/niZsR7ioFBlsh/Fk0oJbhaqO0jRyQBMgkz7RrFfkqF9lYYmBoGBaSiLnu8TAPQTwoTUiSTUW9dg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@typescript-eslint/types": "8.13.0",
-        "@typescript-eslint/visitor-keys": "8.13.0",
+        "@typescript-eslint/types": "8.15.0",
+        "@typescript-eslint/visitor-keys": "8.15.0",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -2534,16 +2537,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.13.0.tgz",
-      "integrity": "sha512-A1EeYOND6Uv250nybnLZapeXpYMl8tkzYUxqmoKAWnI4sei3ihf2XdZVd+vVOmHGcp3t+P7yRrNsyyiXTvShFQ==",
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.15.0.tgz",
+      "integrity": "sha512-k82RI9yGhr0QM3Dnq+egEpz9qB6Un+WLYhmoNcvl8ltMEededhh7otBVVIDDsEEttauwdY/hQoSsOv13lxrFzQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.13.0",
-        "@typescript-eslint/types": "8.13.0",
-        "@typescript-eslint/typescript-estree": "8.13.0"
+        "@typescript-eslint/scope-manager": "8.15.0",
+        "@typescript-eslint/types": "8.15.0",
+        "@typescript-eslint/typescript-estree": "8.15.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2554,17 +2557,22 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.13.0.tgz",
-      "integrity": "sha512-7N/+lztJqH4Mrf0lb10R/CbI1EaAMMGyF5y0oJvFoAhafwgiRA7TXyd8TFn8FC8k5y2dTsYogg238qavRGNnlw==",
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.15.0.tgz",
+      "integrity": "sha512-h8vYOulWec9LhpwfAdZf2bjr8xIp0KNKnpgqSz0qqYYKAW/QZKw3ktRndbiAtUz4acH4QLQavwZBYCc0wulA/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.13.0",
-        "eslint-visitor-keys": "^3.4.3"
+        "@typescript-eslint/types": "8.15.0",
+        "eslint-visitor-keys": "^4.2.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2572,19 +2580,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/abitype": {
@@ -3317,9 +3312,9 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3781,27 +3776,27 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.14.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.14.0.tgz",
-      "integrity": "sha512-c2FHsVBr87lnUtjP4Yhvk4yEhKrQavGafRA/Se1ouse8PfbfC/Qh9Mxa00yWsZRlqeUB9raXip0aiiUZkgnr9g==",
+      "version": "9.15.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.15.0.tgz",
+      "integrity": "sha512-7CrWySmIibCgT1Os28lUU6upBshZ+GxybLOrmRzi08kS8MBuO8QA7pXEgYgY5W8vK3e74xv0lpjo9DbaGU9Rkw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.18.0",
-        "@eslint/core": "^0.7.0",
-        "@eslint/eslintrc": "^3.1.0",
-        "@eslint/js": "9.14.0",
-        "@eslint/plugin-kit": "^0.2.0",
+        "@eslint/config-array": "^0.19.0",
+        "@eslint/core": "^0.9.0",
+        "@eslint/eslintrc": "^3.2.0",
+        "@eslint/js": "9.15.0",
+        "@eslint/plugin-kit": "^0.2.3",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
-        "@humanwhocodes/retry": "^0.4.0",
+        "@humanwhocodes/retry": "^0.4.1",
         "@types/estree": "^1.0.6",
         "@types/json-schema": "^7.0.15",
         "ajv": "^6.12.4",
         "chalk": "^4.0.0",
-        "cross-spawn": "^7.0.2",
+        "cross-spawn": "^7.0.5",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
         "eslint-scope": "^8.2.0",
@@ -3820,8 +3815,7 @@
         "lodash.merge": "^4.6.2",
         "minimatch": "^3.1.2",
         "natural-compare": "^1.4.0",
-        "optionator": "^0.9.3",
-        "text-table": "^0.2.0"
+        "optionator": "^0.9.3"
       },
       "bin": {
         "eslint": "bin/eslint.js"
@@ -7547,13 +7541,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/text-table": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -7846,9 +7833,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
-      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
+      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
       "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
@@ -7860,15 +7847,15 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.13.0.tgz",
-      "integrity": "sha512-vIMpDRJrQd70au2G8w34mPps0ezFSPMEX4pXkTzUkrNbRX+36ais2ksGWN0esZL+ZMaFJEneOBHzCgSqle7DHw==",
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.15.0.tgz",
+      "integrity": "sha512-wY4FRGl0ZI+ZU4Jo/yjdBu0lVTSML58pu6PgGtJmCufvzfV565pUF6iACQt092uFOd49iLOTX/sEVmHtbSrS+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.13.0",
-        "@typescript-eslint/parser": "8.13.0",
-        "@typescript-eslint/utils": "8.13.0"
+        "@typescript-eslint/eslint-plugin": "8.15.0",
+        "@typescript-eslint/parser": "8.15.0",
+        "@typescript-eslint/utils": "8.15.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -7876,6 +7863,9 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -8175,9 +8165,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.0.tgz",
-      "integrity": "sha512-a6ae//JvKDEra2kdi1qzCyrJW/WZCgFi8ydDV+eXExl95t+5R+ijnqHJbz9tmMh8FUjx3iv2fCQ4dclAQlO2UQ==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.1.tgz",
+      "integrity": "sha512-7r0XPzioN/Q9kXBro/XPnA6kznR73DHq+GXh5ON7ZozRO6aMjbmiBuKste2wslTFkC5d1dw0GooOCepZXJ2SAg==",
       "dev": true,
       "license": "ISC",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -25,12 +25,12 @@
     "./dist/**"
   ],
   "devDependencies": {
-    "@eslint/js": "9.14.0",
+    "@eslint/js": "9.15.0",
     "@types/eslint__js": "8.42.3",
     "@types/jest": "29.5.14",
-    "@types/node": "22.9.0",
+    "@types/node": "22.9.3",
     "@types/yargs": "17.0.33",
-    "eslint": "9.14.0",
+    "eslint": "9.15.0",
     "eslint-config-prettier": "9.1.0",
     "eslint-import-resolver-typescript": "3.6.3",
     "eslint-plugin-import": "2.31.0",
@@ -41,12 +41,12 @@
     "prettier": "3.3.3",
     "ts-jest": "29.2.5",
     "tsx": "4.19.2",
-    "typescript": "5.6.3",
-    "typescript-eslint": "8.13.0",
-    "yaml": "2.6.0"
+    "typescript": "5.7.2",
+    "typescript-eslint": "8.15.0",
+    "yaml": "2.6.1"
   },
   "dependencies": {
-    "@inquirer/prompts": "7.0.1",
+    "@inquirer/prompts": "7.1.0",
     "abitype": "1.0.6",
     "ethers": "6.13.4",
     "tslib": "2.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/ccip-tools-ts",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "CLI and library to interact with CCIP",
   "author": "Chainlink devs",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint": "prettier --check ./src && eslint ./src",
     "lint:fix": "prettier --write ./src && eslint --fix ./src",
     "typecheck": "tsc --noEmit",
-    "generate": "node ./generate.cjs ./src/abi/* ./src/lib/selectors.ts",
+    "generate": "node ./generate.cjs ./src/abi/* ./src/lib/selectors.ts ./src/index.ts",
     "build": "npm run clean && npm run generate && tsc -p ./tsconfig.build.json && npm run make-script",
     "make-script": "sed -e '1s|#!/.*|#!/usr/bin/env node|' ./dist/index.js > ./dist/ccip-tools-ts && chmod +x ./dist/ccip-tools-ts && rm -v ./dist/index.js",
     "start": "tsx src",

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ import { logParsedError } from './utils.js'
 util.inspect.defaultOptions.depth = 6 // print down to tokenAmounts in requests
 // generate:nofail
 // `const VERSION = '${require('./package.json').version}-${require('child_process').execSync('git rev-parse --short HEAD').toString().trim()}'`
-const VERSION = '0.1.1-a733214'
+const VERSION = '0.1.2-15d5cc5'
 // generate:end
 
 async function main() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,10 @@ import { Providers } from './providers.js'
 import { logParsedError } from './utils.js'
 
 util.inspect.defaultOptions.depth = 6 // print down to tokenAmounts in requests
+// generate:nofail
+// `const VERSION = '${require('./package.json').version}-${require('child_process').execSync('git rev-parse --short HEAD').toString().trim()}'`
+const VERSION = '0.1.1-a733214'
+// generate:end
 
 async function main() {
   await yargs(hideBin(process.argv))
@@ -356,6 +360,7 @@ async function main() {
     .demandCommand()
     .strict()
     .help()
+    .version(VERSION)
     .alias({ h: 'help', V: 'version' })
     .parse()
 }

--- a/src/lib/errors.test.ts
+++ b/src/lib/errors.test.ts
@@ -1,5 +1,5 @@
 import { ErrorFragment, EventFragment, FunctionFragment, Result } from 'ethers'
-import { getErrorData, parseWithFragment } from './errors.js'
+import { getErrorData, parseWithFragment, recursiveParseError } from './errors.js'
 import { chainSelectorFromId } from './utils.js'
 
 beforeEach(() => {
@@ -97,5 +97,18 @@ describe('getErrorData', () => {
     expect(getErrorData(null)).toBeUndefined()
     expect(getErrorData(123)).toBeUndefined()
     expect(getErrorData({ info: { error: { data: 'Unknown' } } })).toBeUndefined()
+  })
+})
+
+describe('recursiveParseError', () => {
+  it('should parse error data', () => {
+    const data =
+      '0xcf19edfd000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000440a8d6e8c0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+    const res = recursiveParseError('revert', data)
+    expect(res).toHaveLength(3)
+    expect(res[0]).toEqual(['revert', expect.stringContaining('ExecutionError')])
+    expect(res[1]).toEqual(['revert.err', expect.stringContaining('ReceiverError')])
+    expect(res[2]).toEqual(['revert.err.err', expect.stringMatching(/\b0x\b/)])
+    expect(res[2][1]).toContain('out-of-gas')
   })
 })

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -6,6 +6,9 @@ import {
   type InterfaceAbi,
   type Result,
   Interface,
+  dataLength,
+  dataSlice,
+  isBytesLike,
   isHexString,
 } from 'ethers'
 
@@ -90,6 +93,13 @@ export function parseWithFragment(
       parsed?: Result,
     ]
   | undefined {
+  if (!dataLength(data ?? '0x') && isBytesLike(selector)) {
+    const len = dataLength(selector)
+    if (len > 4 && len !== 32) {
+      data = dataSlice(selector, 4)
+      selector = dataSlice(selector, 0, 4)
+    }
+  }
   let res: readonly [ErrorFragment | FunctionFragment | EventFragment, string] | undefined
   for (const [name, iface] of Object.entries(ifaces)) {
     try {

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,5 +1,5 @@
 export { fetchCommitReport } from './commits.js'
-export { getErrorData, parseWithFragment } from './errors.js'
+export { getErrorData, parseWithFragment, recursiveParseError } from './errors.js'
 export { calculateManualExecProof, discoverOffRamp, fetchExecutionReceipts } from './execution.js'
 export { estimateExecGasForRequest } from './gas.js'
 export { fetchOffchainTokenData } from './offchain.js'

--- a/src/lib/selectors.ts
+++ b/src/lib/selectors.ts
@@ -40,8 +40,13 @@ const selectors: Record<number, { readonly selector: bigint; readonly name?: str
   },
   '100': { selector: 465200170687744372n, name: 'gnosis_chain-mainnet' },
   '106': { selector: 374210358663784372n, name: 'velas-mainnet' },
+  '109': { selector: 3993510008929295315n, name: 'shibarium-mainnet' },
   '111': { selector: 572210378683744374n, name: 'velas-testnet' },
   '137': { selector: 4051577828743386545n, name: 'polygon-mainnet' },
+  '157': {
+    selector: 17833296867764334567n,
+    name: 'shibarium-testnet-puppynet',
+  },
   '195': {
     selector: 2066098519157881736n,
     name: 'ethereum-testnet-sepolia-xlayer-1',
@@ -313,6 +318,7 @@ const selectors: Record<number, { readonly selector: bigint; readonly name?: str
     selector: 10443705513486043421n,
     name: 'ethereum-testnet-sepolia-arbitrum-1-treasure-1',
   },
+  '978658': { selector: 3676916124122457866n, name: 'treasure-testnet-topaz' },
   '978670': {
     selector: 1010349088906777999n,
     name: 'ethereum-mainnet-arbitrum-1-treasure-1',
@@ -322,7 +328,7 @@ const selectors: Record<number, { readonly selector: bigint; readonly name?: str
     selector: 5224473277236331295n,
     name: 'ethereum-testnet-sepolia-optimism-1',
   },
-  '21000000': {
+  '21000001': {
     selector: 1467427327723633929n,
     name: 'ethereum-testnet-sepolia-corn-1',
   },

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -18,14 +18,14 @@ export const VersionedContractABI = parseAbi(['function typeAndVersion() view re
 export const defaultAbiCoder = AbiCoder.defaultAbiCoder()
 
 export type CCIPMessage = AbiParametersToPrimitiveTypes<
-  ExtractAbiEvent<typeof EVM2EVMOnRamp_1_2_ABI, 'CCIPSendRequested'>['inputs']
+  ExtractAbiEvent<typeof EVM2EVMOnRamp_1_5_ABI, 'CCIPSendRequested'>['inputs']
 >[0]
 
-export const CCIPVersion_1_2 = '1.2.0'
-export type CCIPVersion_1_2 = typeof CCIPVersion_1_2
 export const CCIPVersion_1_5 = '1.5.0'
 export type CCIPVersion_1_5 = typeof CCIPVersion_1_5
-export type CCIPVersion = CCIPVersion_1_2 | CCIPVersion_1_5
+export const CCIPVersion_1_2 = '1.2.0'
+export type CCIPVersion_1_2 = typeof CCIPVersion_1_2
+export type CCIPVersion = CCIPVersion_1_5 | CCIPVersion_1_2
 
 export const CCIPContractTypeOnRamp = 'EVM2EVMOnRamp'
 export type CCIPContractTypeOnRamp = typeof CCIPContractTypeOnRamp
@@ -40,16 +40,16 @@ export type CCIPContractType =
 
 export const CCIP_ABIs = {
   [CCIPContractTypeOnRamp]: {
-    [CCIPVersion_1_2]: EVM2EVMOnRamp_1_2_ABI,
     [CCIPVersion_1_5]: EVM2EVMOnRamp_1_5_ABI,
+    [CCIPVersion_1_2]: EVM2EVMOnRamp_1_2_ABI,
   },
   [CCIPContractTypeOffRamp]: {
-    [CCIPVersion_1_2]: EVM2EVMOffRamp_1_2_ABI,
     [CCIPVersion_1_5]: EVM2EVMOffRamp_1_5_ABI,
+    [CCIPVersion_1_2]: EVM2EVMOffRamp_1_2_ABI,
   },
   [CCIPContractTypeCommitStore]: {
-    [CCIPVersion_1_2]: CommitStore_1_2_ABI,
     [CCIPVersion_1_5]: CommitStore_1_5_ABI,
+    [CCIPVersion_1_2]: CommitStore_1_2_ABI,
   },
 } as const
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -177,7 +177,7 @@ export async function prettyRequest(source: Provider, request: CCIPRequest) {
     transactionHash: request.log.transactionHash,
     logIndex: request.log.index,
     blockNumber: request.log.blockNumber,
-    timestamp: formatDate(request.timestamp),
+    timestamp: `${formatDate(request.timestamp)} (${formatDuration(Date.now() / 1e3 - request.timestamp)} ago)`,
     finalized:
       finalized &&
       (finalized.timestamp < request.timestamp

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -8,6 +8,7 @@
   ],
   "exclude": [
     "node_modules",
-    "**/*.test.ts"
+    "**/*.test.ts",
+    "**/__mocks__"
   ]
 }


### PR DESCRIPTION
- some fixes for properly showing recursive errors in `prettyReceipt` and `parseBytes`
- update selectors
- show relative time in `prettyRequest`'s `timestamp`
- embed `version` (with commit) for npmjs
- accept `0x0` explicitly as `--fee-token`