### PR TITLE
Add Aptos execution hasher

### DIFF
--- a/src/lib/execution.test.ts
+++ b/src/lib/execution.test.ts
@@ -28,7 +28,9 @@ import {
   type ContractRunner,
   type Provider,
   Interface,
+  ZeroAddress,
   ZeroHash,
+  getBigInt,
   hexlify,
   randomBytes,
 } from 'ethers'
@@ -47,6 +49,7 @@ import {
   CCIPVersion,
   CCIP_ABIs,
   ExecutionState,
+  parseExtraArgs,
 } from './types.js'
 import { chainSelectorFromId, lazyCached } from './utils.js'
 
@@ -158,6 +161,70 @@ describe('calculateManualExecProof', () => {
     expect(() => calculateManualExecProof(messages, lane, messageIds, merkleRoot)).toThrow(
       /^Merkle root created from send events doesn't match ReportAccepted merkle root: expected=0xMerkleRoot, got=0x.*/,
     )
+  })
+
+  // TODO: temporary to show edge case in `calculateManualExecProof`
+  it('should fail when computing messages with different versions', () => {
+    const v1_5_header = {
+      messageId: '0x1001',
+      sequenceNumber: 1337n,
+      nonce: 1337n,
+    }
+    const v1_5_message = {
+      header: v1_5_header,
+      sourceChainSelector: lane.sourceChainSelector,
+      sender: '0x1110000000000000000000000000000000000001',
+      receiver: '0x2220000000000000000000000000000000000001',
+      sequenceNumber: v1_5_header.sequenceNumber,
+      gasLimit: 100n,
+      strict: false,
+      nonce: v1_5_header.nonce,
+      feeToken: ZeroAddress,
+      feeTokenAmount: 1n,
+      data: '0x',
+      tokenAmounts: [
+        { token: '0x4440000000000000000000000000000000000001', amount: 12345678900n } as any,
+      ],
+      sourceTokenData: [],
+      messageId: v1_5_header.messageId,
+    } as CCIPMessage<CCIPVersion.V1_5>
+
+    const v1_6_header = {
+      messageId: '0xf82dd9f9977f06d5c789d33299f15c3c693c9b7b084206c8c524c3620f966edd',
+      sequenceNumber: 17624761845632355147n,
+      nonce: 13974814057813369789n,
+      sourceChainSelector: lane.sourceChainSelector,
+      destChainSelector: lane.destChainSelector,
+    }
+    const extraArgs =
+      '0x181dcf100000000000000000000000000000000000000000000000005eb3e65ecb9fb54e0000000000000000000000000000000000000000000000000000000000000001'
+
+    const v1_6_message: CCIPMessage<CCIPVersion.V1_6> = {
+      header: v1_6_header,
+      sender: '0x00000000000000000000000021aa8a422bfb1a82e254331259c1cbbea7408b44',
+      receiver: '0x56ad368c27ab9a428e9992c3843c79a35830794a',
+      feeToken: '0x6627c714a7ba7cc17bddeffa83b36a3b969e4e6c',
+      feeTokenAmount: 15188903849671844750n,
+      feeValueJuels: 0n,
+      extraArgs,
+      gasLimit: parseExtraArgs(extraArgs)!.gasLimit!,
+      data: '0xeed38ce567ddd944bb1c24619d50d373181a4faf1feed3f726a473df6c0a8dcd4c0fe0a09c843e930dabdd6ac5994025e99828e1d74df0641ec1f1d82c0ad1ab4c277721ba388a7742d711bbefb62182ae2c7ab1b80edaaf97f5527642e0ed167f69030792970994443aabfeceb0b12435f28cdb4925f82beacc1df9232b4f9734eed4c54b2cbe9276428a25ce2f3bea2735d205b40f8f0c488f3d584e6e197801c6d308b1e1d3f42b7cbfbeed21c72300b7126afa0002e20fadf43a8238fb8ac6f6612144fac1733fb1ef927c9d0cdf29eb08fe964e1afeeb845d547ace4ef2313df69b2f8f3d0b9714aa26e5d0a9a6d8f5b37680c617f524b7414e2f96e236b4d8efb037d025b1bcaff2f76b2696811c853283abb56d990197f21f7fbfef06044c31d42f7c8cac72a5a5b0a3f3a19cd24fec76d90efaf00a2b83e7eb9c817fbc667841c27a79168e49b68ecddb44a8e2877cf326a342a2b377dcafe3f692688dac17de842889bb0e2ee717092d2c53ce44a2d33760ab9791cbf9d1273eb2db7b59e741869037aeacfeb10132aa81f2bbc4b2626870f38d9e6a15636561bcbe93b16aef84c92d2b81798c1d332bc031911b8128765e2e74537c2416076ee587caf9178f6fc963ff0fc0a8c3d4551c7ab98bc26c42c4aa63ddbb1886f47456bf26275ef26dd1bde3ed3cabc064a3f1275240be0d799c649e30a3b9c36ba9a7a97e97cec75d6d2d1a6da15413614ebf3246126da03d41febaa07daaa205731336c1cffb3531d69c847f4fd9fb0daf1ee0975ab8a3bfc5251d9c32cca4def2f13540a6978c075d00856aa59c47ac80fb5598ab5646037121aa2b0f0512f7091a5ce33fb5a501c490b2390420c614e105f29abed474a4399c9823d56c88deef0e9de87af5b408cf0f506da2c2092da239383d1019734334125bdb489a8798e86000b6e9e8927d9193c4b0069cb5a3a54b149530229220193766e9f4e73e74d36a50b4166a65ce02aaad5ba014348d4c48562d781cbc246a4d56f5852d50f133a97d0bdf5cc176ac798d094a310f0fadb69bcd247b58199c4e7fa8e4e9662a046209af363e3cc1ebf501938b3bc2ebcbabf867e599c1f50f09be10e1c910973af651be066ed59ae9f136eba74a49f6c944c3b67b5bebdee8a1114781121ea15c9a2e53c8507d425c0cdd34e257e645427a7da23801a381366f74c75bc1c5fe9269423ad3a8be38702c91fee10bd88a6f4968819205f18a46ad290248cbfdf3f36e0ed15f0213326cdd284d40790a475b8e0678b0cdf5331e882e84236673a414259723b36d53d13dd956fef3d105bd5545da',
+      tokenAmounts: [
+        {
+          sourcePoolAddress: '0x0000000000000000000000006987756a2fc8e4f3f0a5e026cb200cc2b5221b1f',
+          destTokenAddress: '0xcc44ff0e5a1fc9a6f3224ef0f47f0c03b3f8eaee',
+          extraData: '0xd8e78c2c6144d59c308cee0365b6d223a9cea73dd7a46e990505271b4abb47b4',
+          amount: 4679472148560135273n,
+          destExecData: '0x000000000000000000000000000000000000000000000000000000005a51fc6c',
+        },
+      ].map((ta) => ({ ...ta, destGasAmount: getBigInt(ta.destExecData) })),
+    }
+
+    const msgs = [v1_5_message, v1_6_message]
+    const msgsIds = [v1_5_message.messageId, v1_6_message.header.messageId]
+    const result = calculateManualExecProof(msgs, lane, msgsIds)
+
+    expect(result).toBe(null)
   })
 })
 

--- a/src/lib/execution.test.ts
+++ b/src/lib/execution.test.ts
@@ -28,9 +28,7 @@ import {
   type ContractRunner,
   type Provider,
   Interface,
-  ZeroAddress,
   ZeroHash,
-  getBigInt,
   hexlify,
   randomBytes,
 } from 'ethers'
@@ -49,7 +47,6 @@ import {
   CCIPVersion,
   CCIP_ABIs,
   ExecutionState,
-  parseExtraArgs,
 } from './types.js'
 import { chainSelectorFromId, lazyCached } from './utils.js'
 
@@ -58,14 +55,14 @@ beforeEach(() => {
 })
 
 describe('calculateManualExecProof', () => {
-  const lane: Lane = {
+  const lane: Lane<CCIPVersion.V1_5> = {
     sourceChainSelector: chainSelectorFromId(11155111),
     destChainSelector: chainSelectorFromId(421614),
     onRamp: '0x0000000000000000000000000000000000000007',
     version: CCIPVersion.V1_5,
   }
   const hasher = getLeafHasher(lane)
-  const messages: CCIPMessage[] = [
+  const messages: CCIPMessage<CCIPVersion.V1_5>[] = [
     {
       header: {
         messageId: ZeroHash,
@@ -161,70 +158,6 @@ describe('calculateManualExecProof', () => {
     expect(() => calculateManualExecProof(messages, lane, messageIds, merkleRoot)).toThrow(
       /^Merkle root created from send events doesn't match ReportAccepted merkle root: expected=0xMerkleRoot, got=0x.*/,
     )
-  })
-
-  // TODO: temporary to show edge case in `calculateManualExecProof`
-  it('should fail when computing messages with different versions', () => {
-    const v1_5_header = {
-      messageId: '0x1001',
-      sequenceNumber: 1337n,
-      nonce: 1337n,
-    }
-    const v1_5_message = {
-      header: v1_5_header,
-      sourceChainSelector: lane.sourceChainSelector,
-      sender: '0x1110000000000000000000000000000000000001',
-      receiver: '0x2220000000000000000000000000000000000001',
-      sequenceNumber: v1_5_header.sequenceNumber,
-      gasLimit: 100n,
-      strict: false,
-      nonce: v1_5_header.nonce,
-      feeToken: ZeroAddress,
-      feeTokenAmount: 1n,
-      data: '0x',
-      tokenAmounts: [
-        { token: '0x4440000000000000000000000000000000000001', amount: 12345678900n } as any,
-      ],
-      sourceTokenData: [],
-      messageId: v1_5_header.messageId,
-    } as CCIPMessage<CCIPVersion.V1_5>
-
-    const v1_6_header = {
-      messageId: '0xf82dd9f9977f06d5c789d33299f15c3c693c9b7b084206c8c524c3620f966edd',
-      sequenceNumber: 17624761845632355147n,
-      nonce: 13974814057813369789n,
-      sourceChainSelector: lane.sourceChainSelector,
-      destChainSelector: lane.destChainSelector,
-    }
-    const extraArgs =
-      '0x181dcf100000000000000000000000000000000000000000000000005eb3e65ecb9fb54e0000000000000000000000000000000000000000000000000000000000000001'
-
-    const v1_6_message: CCIPMessage<CCIPVersion.V1_6> = {
-      header: v1_6_header,
-      sender: '0x00000000000000000000000021aa8a422bfb1a82e254331259c1cbbea7408b44',
-      receiver: '0x56ad368c27ab9a428e9992c3843c79a35830794a',
-      feeToken: '0x6627c714a7ba7cc17bddeffa83b36a3b969e4e6c',
-      feeTokenAmount: 15188903849671844750n,
-      feeValueJuels: 0n,
-      extraArgs,
-      gasLimit: parseExtraArgs(extraArgs)!.gasLimit!,
-      data: '0xeed38ce567ddd944bb1c24619d50d373181a4faf1feed3f726a473df6c0a8dcd4c0fe0a09c843e930dabdd6ac5994025e99828e1d74df0641ec1f1d82c0ad1ab4c277721ba388a7742d711bbefb62182ae2c7ab1b80edaaf97f5527642e0ed167f69030792970994443aabfeceb0b12435f28cdb4925f82beacc1df9232b4f9734eed4c54b2cbe9276428a25ce2f3bea2735d205b40f8f0c488f3d584e6e197801c6d308b1e1d3f42b7cbfbeed21c72300b7126afa0002e20fadf43a8238fb8ac6f6612144fac1733fb1ef927c9d0cdf29eb08fe964e1afeeb845d547ace4ef2313df69b2f8f3d0b9714aa26e5d0a9a6d8f5b37680c617f524b7414e2f96e236b4d8efb037d025b1bcaff2f76b2696811c853283abb56d990197f21f7fbfef06044c31d42f7c8cac72a5a5b0a3f3a19cd24fec76d90efaf00a2b83e7eb9c817fbc667841c27a79168e49b68ecddb44a8e2877cf326a342a2b377dcafe3f692688dac17de842889bb0e2ee717092d2c53ce44a2d33760ab9791cbf9d1273eb2db7b59e741869037aeacfeb10132aa81f2bbc4b2626870f38d9e6a15636561bcbe93b16aef84c92d2b81798c1d332bc031911b8128765e2e74537c2416076ee587caf9178f6fc963ff0fc0a8c3d4551c7ab98bc26c42c4aa63ddbb1886f47456bf26275ef26dd1bde3ed3cabc064a3f1275240be0d799c649e30a3b9c36ba9a7a97e97cec75d6d2d1a6da15413614ebf3246126da03d41febaa07daaa205731336c1cffb3531d69c847f4fd9fb0daf1ee0975ab8a3bfc5251d9c32cca4def2f13540a6978c075d00856aa59c47ac80fb5598ab5646037121aa2b0f0512f7091a5ce33fb5a501c490b2390420c614e105f29abed474a4399c9823d56c88deef0e9de87af5b408cf0f506da2c2092da239383d1019734334125bdb489a8798e86000b6e9e8927d9193c4b0069cb5a3a54b149530229220193766e9f4e73e74d36a50b4166a65ce02aaad5ba014348d4c48562d781cbc246a4d56f5852d50f133a97d0bdf5cc176ac798d094a310f0fadb69bcd247b58199c4e7fa8e4e9662a046209af363e3cc1ebf501938b3bc2ebcbabf867e599c1f50f09be10e1c910973af651be066ed59ae9f136eba74a49f6c944c3b67b5bebdee8a1114781121ea15c9a2e53c8507d425c0cdd34e257e645427a7da23801a381366f74c75bc1c5fe9269423ad3a8be38702c91fee10bd88a6f4968819205f18a46ad290248cbfdf3f36e0ed15f0213326cdd284d40790a475b8e0678b0cdf5331e882e84236673a414259723b36d53d13dd956fef3d105bd5545da',
-      tokenAmounts: [
-        {
-          sourcePoolAddress: '0x0000000000000000000000006987756a2fc8e4f3f0a5e026cb200cc2b5221b1f',
-          destTokenAddress: '0xcc44ff0e5a1fc9a6f3224ef0f47f0c03b3f8eaee',
-          extraData: '0xd8e78c2c6144d59c308cee0365b6d223a9cea73dd7a46e990505271b4abb47b4',
-          amount: 4679472148560135273n,
-          destExecData: '0x000000000000000000000000000000000000000000000000000000005a51fc6c',
-        },
-      ].map((ta) => ({ ...ta, destGasAmount: getBigInt(ta.destExecData) })),
-    }
-
-    const msgs = [v1_5_message, v1_6_message]
-    const msgsIds = [v1_5_message.messageId, v1_6_message.header.messageId]
-    const result = calculateManualExecProof(msgs, lane, msgsIds)
-
-    expect(result).toBe(null)
   })
 })
 

--- a/src/lib/execution.ts
+++ b/src/lib/execution.ts
@@ -10,7 +10,7 @@ import {
 import type { TypedContract } from 'ethers-abitype'
 
 import Router from '../abi/Router.js'
-import { Tree, getLeafHasher, proofFlagsToBits } from './hasher/index.js'
+import { Tree, getLeafHasher, proofFlagsToBits } from './hasher'
 import {
   type CCIPContract,
   type CCIPExecution,
@@ -42,20 +42,20 @@ import {
  * @param merkleRoot - Optional merkleRoot of the CommitReport, for validation
  * @returns ManualExec report arguments
  **/
-export function calculateManualExecProof(
-  messagesInBatch: readonly CCIPMessage[],
-  lane: Lane,
+export function calculateManualExecProof<V extends CCIPVersion>(
+  messagesInBatch: readonly CCIPMessage<V>[],
+  lane: Lane<V>,
   messageIds: string[],
   merkleRoot?: string,
 ): {
-  messages: CCIPMessage[]
+  messages: CCIPMessage<V>[]
   proofs: string[]
   proofFlagBits: bigint
 } {
   const leaves: string[] = []
   const hasher = getLeafHasher(lane)
   const prove: number[] = []
-  const messages: CCIPMessage[] = []
+  const messages: CCIPMessage<V>[] = []
   const seen = new Set<string>()
 
   messagesInBatch.forEach((message, index) => {
@@ -71,10 +71,6 @@ export function calculateManualExecProof(
       )
     }
     // Hash leaf node
-    // TODO: msg here could be of any type (1.5 or 1.6), but we are using a specific version hasher. This will throw at runtime if encounters different message versions
-    // hasher type should detect the msg version
-    // If we want to be able to hash any message type, we should have a hasher per version
-    // If we don't want to hash any message type, `messagesInBatch` should only accept one type of message
     leaves.push(hasher(msg))
     const msgId = msg.header.messageId
     seen.add(msgId)

--- a/src/lib/execution.ts
+++ b/src/lib/execution.ts
@@ -10,7 +10,7 @@ import {
 import type { TypedContract } from 'ethers-abitype'
 
 import Router from '../abi/Router.js'
-import { Tree, getLeafHasher, proofFlagsToBits } from './hasher'
+import { Tree, getLeafHasher, proofFlagsToBits } from './hasher/index.js'
 import {
   type CCIPContract,
   type CCIPExecution,
@@ -42,7 +42,7 @@ import {
  * @param merkleRoot - Optional merkleRoot of the CommitReport, for validation
  * @returns ManualExec report arguments
  **/
-export function calculateManualExecProof<V extends CCIPVersion>(
+export function calculateManualExecProof<V extends CCIPVersion = CCIPVersion>(
   messagesInBatch: readonly CCIPMessage<V>[],
   lane: Lane<V>,
   messageIds: string[],

--- a/src/lib/execution.ts
+++ b/src/lib/execution.ts
@@ -71,6 +71,10 @@ export function calculateManualExecProof(
       )
     }
     // Hash leaf node
+    // TODO: msg here could be of any type (1.5 or 1.6), but we are using a specific version hasher. This will throw at runtime if encounters different message versions
+    // hasher type should detect the msg version
+    // If we want to be able to hash any message type, we should have a hasher per version
+    // If we don't want to hash any message type, `messagesInBatch` should only accept one type of message
     leaves.push(hasher(msg))
     const msgId = msg.header.messageId
     seen.add(msgId)

--- a/src/lib/hasher/aptos.test.ts
+++ b/src/lib/hasher/aptos.test.ts
@@ -1,6 +1,6 @@
 import { hexlify, toUtf8Bytes, zeroPadValue } from 'ethers'
-import { type CCIPMessage, type CCIPVersion } from '../types'
-import { hashAptosMessage, hashAptosMetadata } from './aptos'
+import { type CCIPMessage, type CCIPVersion } from '../types.js'
+import { hashAptosMessage, hashAptosMetadata } from './aptos.js'
 
 describe('aptos hasher', () => {
   // Aptos encoding tests mimic the Move test: https://github.com/smartcontractkit/chainlink-internal-integrations/blob/develop/aptos/contracts/ccip/sources/offramp.move#L1517

--- a/src/lib/hasher/aptos.test.ts
+++ b/src/lib/hasher/aptos.test.ts
@@ -1,0 +1,60 @@
+import { hexlify, toUtf8Bytes, zeroPadValue } from 'ethers'
+import { type CCIPMessage, type CCIPVersion } from '../types'
+import { hashAptosMessage, hashAptosMetadata } from './aptos'
+
+describe('aptos hasher', () => {
+  // Aptos encoding tests mimic the Move test: https://github.com/smartcontractkit/chainlink-internal-integrations/blob/develop/aptos/contracts/ccip/sources/offramp.move#L1517
+  it('should hash Aptos msg', () => {
+    const msgId = '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'
+    const metadataHash = '0xaabbccddeeff00112233445566778899aabbccddeeff00112233445566778899'
+
+    const msg: CCIPMessage<CCIPVersion.V1_6> = {
+      header: {
+        messageId: msgId,
+        sequenceNumber: 42n,
+        nonce: 123n,
+        sourceChainSelector: 1n,
+        destChainSelector: 2n,
+      },
+      sender: '0x8765432109fedcba8765432109fedcba87654321',
+      data: hexlify(toUtf8Bytes('sample message data')),
+      receiver: zeroPadValue('0x1234', 32),
+      gasLimit: 500000n,
+      extraArgs: '',
+      feeToken: '',
+      feeTokenAmount: 0n,
+      feeValueJuels: 0n,
+      tokenAmounts: [
+        {
+          sourcePoolAddress: '0xabcdef1234567890abcdef1234567890abcdef12',
+          destTokenAddress: zeroPadValue('0x5678', 32),
+          destGasAmount: 10000n,
+          extraData: '0x00112233',
+          amount: 1000000n,
+          destExecData: '',
+        },
+        {
+          sourcePoolAddress: '0x123456789abcdef123456789abcdef123456789a',
+          destTokenAddress: zeroPadValue('0x9abc', 32),
+          destGasAmount: 20000n,
+          extraData: '0xffeeddcc',
+          amount: 5000000n,
+          destExecData: '',
+        },
+      ],
+    }
+
+    const expectedHash = '0xc8d6cf666864a60dd6ecd89e5c294734c53b3218d3f83d2d19a3c3f9e200e00d'
+    expect(hashAptosMessage(msg, metadataHash)).toBe(expectedHash)
+  })
+
+  it('should hash Aptos metadata', () => {
+    const expected = '0x812acb01df318f85be452cf6664891cf5481a69dac01e0df67102a295218dd17'
+
+    const source = 123456789n
+    const dest = 987654321n
+    const onramp = hexlify(toUtf8Bytes('source-onramp-address'))
+
+    expect(hashAptosMetadata(source, dest, onramp)).toBe(expected)
+  })
+})

--- a/src/lib/hasher/aptos.ts
+++ b/src/lib/hasher/aptos.ts
@@ -1,0 +1,76 @@
+import { concat, id, keccak256, zeroPadValue } from 'ethers'
+import { type CCIPMessage, type CCIPVersion, defaultAbiCoder } from '../types'
+import { type LeafHasher, LEAF_DOMAIN_SEPARATOR } from './common'
+
+export const getV16AptosLeafHasher =
+  (
+    sourceChainSelector: bigint,
+    destChainSelector: bigint,
+    onRamp: string,
+  ): LeafHasher<CCIPVersion.V1_6> =>
+  (message: CCIPMessage<CCIPVersion.V1_6>): string =>
+    hashAptosMessage(message, hashAptosMetadata(sourceChainSelector, destChainSelector, onRamp))
+
+const encode = (target: string, value: string | bigint | number) =>
+  defaultAbiCoder.encode([target], [value])
+
+/**
+ * Encodes dynamic bytes without the extra length prefix.
+ * The default ABI encoding for type "bytes" is: 32-byte length prefix + the actual data padded.
+ * This helper strips the 32-byte length prefix, mimicking the Move implementation.
+ */
+const encodeRawBytes = (value: string): string => {
+  const encoded = encode('bytes', value)
+  // Remove "0x" and skip the first 64 hex characters (32 bytes of length)
+  return '0x' + encoded.slice(66)
+}
+
+export const hashAptosMessage = (
+  message: CCIPMessage<CCIPVersion.V1_6>,
+  metadataHash: string,
+): string => {
+  const innerHash = concat([
+    encode('bytes32', message.header.messageId),
+    zeroPadValue(message.receiver, 32),
+    encode('uint64', message.header.sequenceNumber),
+    encode('uint256', message.gasLimit),
+    encode('uint64', message.header.nonce),
+  ])
+
+  const tokenHash = concat([
+    encode('uint256', message.tokenAmounts.length),
+    ...message.tokenAmounts.map((token) =>
+      concat([
+        encodeRawBytes(token.sourcePoolAddress),
+        zeroPadValue(token.destTokenAddress, 32),
+        encode('uint32', token.destGasAmount),
+        encodeRawBytes(token.extraData),
+        encode('uint256', token.amount),
+      ]),
+    ),
+  ])
+
+  const outerHash = concat([
+    zeroPadValue(LEAF_DOMAIN_SEPARATOR, 32),
+    metadataHash,
+    keccak256(innerHash),
+    keccak256(message.sender),
+    keccak256(message.data),
+    keccak256(tokenHash),
+  ])
+
+  return keccak256(outerHash)
+}
+
+export const hashAptosMetadata = (
+  sourceChainSelector: bigint,
+  destChainSelector: bigint,
+  onRamp: string,
+): string => {
+  const versionHash = id('Any2AptosMessageHashV1')
+  const encodedSource = encode('uint64', sourceChainSelector)
+  const encodedDest = encode('uint64', destChainSelector)
+  const onrampHash = keccak256(onRamp)
+
+  return keccak256(concat([versionHash, encodedSource, encodedDest, onrampHash]))
+}

--- a/src/lib/hasher/aptos.ts
+++ b/src/lib/hasher/aptos.ts
@@ -1,6 +1,6 @@
 import { concat, id, keccak256, zeroPadValue } from 'ethers'
-import { type CCIPMessage, type CCIPVersion, defaultAbiCoder } from '../types'
-import { type LeafHasher, LEAF_DOMAIN_SEPARATOR } from './common'
+import { type CCIPMessage, type CCIPVersion, defaultAbiCoder } from '../types.js'
+import { type LeafHasher, LEAF_DOMAIN_SEPARATOR } from './common.js'
 
 export const getV16AptosLeafHasher =
   (

--- a/src/lib/hasher/common.test.ts
+++ b/src/lib/hasher/common.test.ts
@@ -1,4 +1,4 @@
-import { hashInternal } from './common'
+import { hashInternal } from './common.js'
 
 describe('common hash', () => {
   it('should hash internal values', () => {

--- a/src/lib/hasher/common.test.ts
+++ b/src/lib/hasher/common.test.ts
@@ -1,0 +1,10 @@
+import { hashInternal } from './common'
+
+describe('common hash', () => {
+  it('should hash internal values', () => {
+    const a = '0x01'
+    const b = '0x02'
+    const result = hashInternal(a, b)
+    expect(result).toBe('0x93b82a55d406c553471937ba1e3176dfdacfc274e84c75b0cbf212388a8bd37b')
+  })
+})

--- a/src/lib/hasher/common.ts
+++ b/src/lib/hasher/common.ts
@@ -1,5 +1,5 @@
 import { concat, hexlify, keccak256, toBeHex } from 'ethers'
-import { type CCIPMessage, type CCIPVersion } from '../types.js'
+import type { CCIPMessage, CCIPVersion } from '../types.js'
 
 export type LeafHasher<V extends CCIPVersion = CCIPVersion> = (message: CCIPMessage<V>) => string
 

--- a/src/lib/hasher/common.ts
+++ b/src/lib/hasher/common.ts
@@ -1,0 +1,22 @@
+import { concat, hexlify, keccak256, toBeHex } from 'ethers'
+import { type CCIPMessage, type CCIPVersion } from '../types.js'
+
+export type LeafHasher<V extends CCIPVersion = CCIPVersion> = (message: CCIPMessage<V>) => string
+
+const INTERNAL_DOMAIN_SEPARATOR = toBeHex(1, 32)
+export const LEAF_DOMAIN_SEPARATOR = '0x00'
+export const ZERO_HASH = hexlify(new Uint8Array(32).fill(0xff))
+
+/**
+ * Computes the Keccak-256 hash of the concatenation of two hash values.
+ * @param a The first hash as a Hash type.
+ * @param b The second hash as a Hash type.
+ * @returns The Keccak-256 hash result as a Hash type.
+ */
+export function hashInternal(a: string, b: string): string {
+  if (a > b) {
+    ;[a, b] = [b, a]
+  }
+  const combinedData = concat([INTERNAL_DOMAIN_SEPARATOR, a, b])
+  return keccak256(combinedData)
+}

--- a/src/lib/hasher/evm.test.ts
+++ b/src/lib/hasher/evm.test.ts
@@ -1,0 +1,130 @@
+import { ZeroAddress, getBigInt } from 'ethers'
+import { type CCIPMessage, type CCIPVersion, parseExtraArgs } from '../types'
+import { getV12LeafHasher, getV16LeafHasher } from './evm'
+
+describe('EVM leaf hasher', () => {
+  it('should hash v1.5 msg', () => {
+    const sourceChainSelector = 1n,
+      destChainSelector = 4n
+
+    const onRamp = '0x5550000000000000000000000000000000000001'
+    const hasher = getV12LeafHasher(sourceChainSelector, destChainSelector, onRamp)
+
+    const header = {
+      messageId: '0x1001',
+      sequenceNumber: 1337n,
+      nonce: 1337n,
+    }
+    const message = {
+      header,
+      sourceChainSelector: sourceChainSelector,
+      sender: '0x1110000000000000000000000000000000000001',
+      receiver: '0x2220000000000000000000000000000000000001',
+      sequenceNumber: header.sequenceNumber,
+      gasLimit: 100n,
+      strict: false,
+      nonce: header.nonce,
+      feeToken: ZeroAddress,
+      feeTokenAmount: 1n,
+      data: '0x',
+      tokenAmounts: [
+        { token: '0x4440000000000000000000000000000000000001', amount: 12345678900n } as any,
+      ],
+      sourceTokenData: [],
+      messageId: header.messageId,
+    } as CCIPMessage<CCIPVersion.V1_5>
+
+    const msgHash = hasher(message)
+    expect(msgHash).toBe('0x46ad031bfb052db2e4a2514fed8dc480b98e5ce4acb55d5640d91407e0d8a3e9')
+  })
+
+  it('should hash v1.6 msg', () => {
+    const sourceChainSelector = 5009297550715157269n,
+      destChainSelector = 51875932522786413n
+
+    const onRamp = '0x7d571a25eb5a09013580c60aeb40ed89c924082a'
+    const hasher = getV16LeafHasher(sourceChainSelector, destChainSelector, onRamp)
+
+    const header = {
+      messageId: '0xf82dd9f9977f06d5c789d33299f15c3c693c9b7b084206c8c524c3620f966edd',
+      sequenceNumber: 17624761845632355147n,
+      nonce: 13974814057813369789n,
+      sourceChainSelector,
+      destChainSelector,
+    }
+    const extraArgs =
+      '0x181dcf100000000000000000000000000000000000000000000000005eb3e65ecb9fb54e0000000000000000000000000000000000000000000000000000000000000001'
+    const message: CCIPMessage<CCIPVersion.V1_6> = {
+      header,
+      sender: '0x00000000000000000000000021aa8a422bfb1a82e254331259c1cbbea7408b44',
+      receiver: '0x56ad368c27ab9a428e9992c3843c79a35830794a',
+      feeToken: '0x6627c714a7ba7cc17bddeffa83b36a3b969e4e6c',
+      feeTokenAmount: 15188903849671844750n,
+      feeValueJuels: 0n,
+      extraArgs,
+      gasLimit: parseExtraArgs(extraArgs)!.gasLimit!,
+      data: '0xeed38ce567ddd944bb1c24619d50d373181a4faf1feed3f726a473df6c0a8dcd4c0fe0a09c843e930dabdd6ac5994025e99828e1d74df0641ec1f1d82c0ad1ab4c277721ba388a7742d711bbefb62182ae2c7ab1b80edaaf97f5527642e0ed167f69030792970994443aabfeceb0b12435f28cdb4925f82beacc1df9232b4f9734eed4c54b2cbe9276428a25ce2f3bea2735d205b40f8f0c488f3d584e6e197801c6d308b1e1d3f42b7cbfbeed21c72300b7126afa0002e20fadf43a8238fb8ac6f6612144fac1733fb1ef927c9d0cdf29eb08fe964e1afeeb845d547ace4ef2313df69b2f8f3d0b9714aa26e5d0a9a6d8f5b37680c617f524b7414e2f96e236b4d8efb037d025b1bcaff2f76b2696811c853283abb56d990197f21f7fbfef06044c31d42f7c8cac72a5a5b0a3f3a19cd24fec76d90efaf00a2b83e7eb9c817fbc667841c27a79168e49b68ecddb44a8e2877cf326a342a2b377dcafe3f692688dac17de842889bb0e2ee717092d2c53ce44a2d33760ab9791cbf9d1273eb2db7b59e741869037aeacfeb10132aa81f2bbc4b2626870f38d9e6a15636561bcbe93b16aef84c92d2b81798c1d332bc031911b8128765e2e74537c2416076ee587caf9178f6fc963ff0fc0a8c3d4551c7ab98bc26c42c4aa63ddbb1886f47456bf26275ef26dd1bde3ed3cabc064a3f1275240be0d799c649e30a3b9c36ba9a7a97e97cec75d6d2d1a6da15413614ebf3246126da03d41febaa07daaa205731336c1cffb3531d69c847f4fd9fb0daf1ee0975ab8a3bfc5251d9c32cca4def2f13540a6978c075d00856aa59c47ac80fb5598ab5646037121aa2b0f0512f7091a5ce33fb5a501c490b2390420c614e105f29abed474a4399c9823d56c88deef0e9de87af5b408cf0f506da2c2092da239383d1019734334125bdb489a8798e86000b6e9e8927d9193c4b0069cb5a3a54b149530229220193766e9f4e73e74d36a50b4166a65ce02aaad5ba014348d4c48562d781cbc246a4d56f5852d50f133a97d0bdf5cc176ac798d094a310f0fadb69bcd247b58199c4e7fa8e4e9662a046209af363e3cc1ebf501938b3bc2ebcbabf867e599c1f50f09be10e1c910973af651be066ed59ae9f136eba74a49f6c944c3b67b5bebdee8a1114781121ea15c9a2e53c8507d425c0cdd34e257e645427a7da23801a381366f74c75bc1c5fe9269423ad3a8be38702c91fee10bd88a6f4968819205f18a46ad290248cbfdf3f36e0ed15f0213326cdd284d40790a475b8e0678b0cdf5331e882e84236673a414259723b36d53d13dd956fef3d105bd5545da',
+      tokenAmounts: [
+        {
+          sourcePoolAddress: '0x0000000000000000000000006987756a2fc8e4f3f0a5e026cb200cc2b5221b1f',
+          destTokenAddress: '0xcc44ff0e5a1fc9a6f3224ef0f47f0c03b3f8eaee',
+          extraData: '0xd8e78c2c6144d59c308cee0365b6d223a9cea73dd7a46e990505271b4abb47b4',
+          amount: 4679472148560135273n,
+          destExecData: '0x000000000000000000000000000000000000000000000000000000005a51fc6c',
+        },
+        {
+          sourcePoolAddress: '0x00000000000000000000000036fdcc65c7703d0b34e88417b39e23c147e4c2b5',
+          destTokenAddress: '0xfe217692ac9020d4003781c7b41b06fce0b1d936',
+          extraData: '0x0180b0ebc736546d03caef8be134ba6da6cd18571e5b93c2cadbd136e8f105a7',
+          amount: 2622048486368728793n,
+          destExecData: '0x000000000000000000000000000000000000000000000000000000002b25ca57',
+        },
+        {
+          sourcePoolAddress: '0x0000000000000000000000000c4aff7c5d8d71d059f7dd60642ecf43032be209',
+          destTokenAddress: '0x83333769972daa43e880904c8aba7204fdfdfb1d',
+          extraData: '0x0ccc82d97ad2fc9d273842e49b97d62c6a98620458afbbc947c06aedd8ce2825',
+          amount: 4287026855703039806n,
+          destExecData: '0x0000000000000000000000000000000000000000000000000000000042b81487',
+        },
+        {
+          sourcePoolAddress: '0x00000000000000000000000016f7b1716017ecd77b1fc3adc01935361b60c21b',
+          destTokenAddress: '0x4f65755dcf6dcd2cc097cf1bbf3edf63c10f47cc',
+          extraData: '0x637ce69111efbf21ada2c3500d21a464f507b35cb773072f1f0e3e6b3727b4a2',
+          amount: 12541689545585536263n,
+          destExecData: '0x00000000000000000000000000000000000000000000000000000000cb9fbccb',
+        },
+        {
+          sourcePoolAddress: '0x000000000000000000000000a04f5214f63cf4c5533854b504610ce396cf0e32',
+          destTokenAddress: '0x3d2fd2372ee5e0861c1f9613becccc1d3a865e15',
+          extraData: '0xf4ae17af521472c6dec069c2c457f440a69c0f4e17f2b4fbb86b230f91e9b6ca',
+          amount: 14339435592708759294n,
+          destExecData: '0x00000000000000000000000000000000000000000000000000000000c5bb273b',
+        },
+        {
+          sourcePoolAddress: '0x000000000000000000000000b501a3cd1d7e1ca53d36de77657c3cd4d74e5a24',
+          destTokenAddress: '0x2353f292d183dabfceaeab694e55260cd8962ec3',
+          extraData: '0xba8ce764a1fd28accf94bfee7348e405c00195130dc0ba5631c3eee16edd8a44',
+          amount: 14452973941833137994n,
+          destExecData: '0x000000000000000000000000000000000000000000000000000000004a3374de',
+        },
+        {
+          sourcePoolAddress: '0x000000000000000000000000a88d2eded1a56475eba868472d6d5f05cdc648d6',
+          destTokenAddress: '0x01fae0388a4cd02b254eb91cc355062e6e79cb8e',
+          extraData: '0x7779713152f2ba379cb8aa67afdb7ad48e7d4d9a3c526f2eb0e67c2cfbdcb914',
+          amount: 15462212191244582558n,
+          destExecData: '0x000000000000000000000000000000000000000000000000000000006858d6a3',
+        },
+        {
+          sourcePoolAddress: '0x0000000000000000000000001c424bfd1ae4ce9505c446b7ccab820eff5ab9f4',
+          destTokenAddress: '0x89256f8b9ff25cc28fa816f245814db8876fcbc6',
+          extraData: '0x55aad1f0daf430642f21bee2349dab6f5fb7f784b1e7ef60b8e117e12124f75f',
+          amount: 4088793534626193712n,
+          destExecData: '0x0000000000000000000000000000000000000000000000000000000006b0cfb7',
+        },
+      ].map((ta) => ({ ...ta, destGasAmount: getBigInt(ta.destExecData) })),
+    }
+
+    const msgHash = hasher(message)
+    expect(msgHash).toBe('0xd56d9f4c0b0bb9cb8c83aeb676a02d5666583eee7d6d4660c87a06a9b36aa352')
+  })
+})

--- a/src/lib/hasher/evm.test.ts
+++ b/src/lib/hasher/evm.test.ts
@@ -1,6 +1,6 @@
 import { ZeroAddress, getBigInt } from 'ethers'
-import { type CCIPMessage, type CCIPVersion, parseExtraArgs } from '../types'
-import { getV12LeafHasher, getV16LeafHasher } from './evm'
+import { type CCIPMessage, type CCIPVersion, parseExtraArgs } from '../types.js'
+import { getV12LeafHasher, getV16LeafHasher } from './evm.js'
 
 describe('EVM leaf hasher', () => {
   it('should hash v1.5 msg', () => {

--- a/src/lib/hasher/evm.ts
+++ b/src/lib/hasher/evm.ts
@@ -1,0 +1,144 @@
+// For reference implementation, see https://github.com/smartcontractkit/ccip/blob/ccip-develop/core/services/ocr2/plugins/ccip/hasher/leaf_hasher.go
+import { concat, id, keccak256, toBeHex, zeroPadValue } from 'ethers'
+import { type CCIPMessage, type CCIPVersion, defaultAbiCoder } from '../types.js'
+import { type LeafHasher, LEAF_DOMAIN_SEPARATOR } from './common.js'
+
+const METADATA_PREFIX_1_2 = id('EVM2EVMMessageHashV2')
+export function getV12LeafHasher(
+  sourceChainSelector: bigint,
+  destChainSelector: bigint,
+  onRamp: string,
+): LeafHasher<CCIPVersion.V1_2 | CCIPVersion.V1_5> {
+  const metadataHash = keccak256(
+    concat([
+      METADATA_PREFIX_1_2,
+      toBeHex(sourceChainSelector, 32),
+      toBeHex(destChainSelector, 32),
+      zeroPadValue(onRamp, 32),
+    ]),
+  )
+
+  return (message: CCIPMessage<CCIPVersion.V1_2 | CCIPVersion.V1_5>): string => {
+    const encodedTokens = defaultAbiCoder.encode(
+      ['tuple(address token, uint256 amount)[]'],
+      [message.tokenAmounts],
+    )
+
+    const encodedSourceTokenData = defaultAbiCoder.encode(['bytes[]'], [message.sourceTokenData])
+
+    const fixedSizeValues = defaultAbiCoder.encode(
+      [
+        'address sender',
+        'address receiver',
+        'uint64 sequenceNumber',
+        'uint256 gasLimit',
+        'bool strict',
+        'uint64 nonce',
+        'address feeToken',
+        'uint256 feeTokenAmount',
+      ],
+      [
+        message.sender,
+        message.receiver,
+        message.sequenceNumber,
+        message.gasLimit,
+        message.strict,
+        message.nonce,
+        message.feeToken,
+        message.feeTokenAmount,
+      ],
+    )
+
+    const fixedSizeValuesHash = keccak256(fixedSizeValues)
+
+    const packedValues = defaultAbiCoder.encode(
+      [
+        'bytes1 leafDomainSeparator',
+        'bytes32 metadataHash',
+        'bytes32 fixedSizeValuesHash',
+        'bytes32 dataHash',
+        'bytes32 tokenAmountsHash',
+        'bytes32 sourceTokenDataHash',
+      ],
+      [
+        LEAF_DOMAIN_SEPARATOR,
+        metadataHash,
+        fixedSizeValuesHash,
+        keccak256(message.data),
+        keccak256(encodedTokens),
+        keccak256(encodedSourceTokenData),
+      ],
+    )
+
+    return keccak256(packedValues)
+  }
+}
+
+const ANY_2_EVM_MESSAGE_HASH = id('Any2EVMMessageHashV1')
+export function getV16LeafHasher(
+  sourceChainSelector: bigint,
+  destChainSelector: bigint,
+  onRamp: string,
+): LeafHasher<CCIPVersion.V1_6> {
+  const metadataInput = concat([
+    ANY_2_EVM_MESSAGE_HASH,
+    toBeHex(sourceChainSelector, 32),
+    toBeHex(destChainSelector, 32),
+    keccak256(zeroPadValue(onRamp, 32)),
+  ])
+
+  return (message: CCIPMessage<CCIPVersion.V1_6>): string => {
+    const encodedTokens = defaultAbiCoder.encode(
+      [
+        'tuple(bytes sourcePoolAddress, address destTokenAddress, uint32 destGasAmount, bytes extraData, uint256 amount)[]',
+      ],
+      [message.tokenAmounts],
+    )
+
+    const fixedSizeValues = defaultAbiCoder.encode(
+      [
+        'bytes32 messageId',
+        'address receiver',
+        'uint64 sequenceNumber',
+        'uint256 gasLimit',
+        'uint64 nonce',
+      ],
+      [
+        message.header.messageId,
+        message.receiver,
+        message.header.sequenceNumber,
+        message.gasLimit,
+        message.header.nonce,
+      ],
+    )
+
+    const packedValues = defaultAbiCoder.encode(
+      [
+        'bytes32 leafDomainSeparator',
+        'bytes32 metadataHash',
+        'bytes32 fixedSizeValuesHash',
+        'bytes32 sender',
+        'bytes32 dataHash',
+        'bytes32 tokenAmountsHash',
+      ],
+      [
+        zeroPadValue(LEAF_DOMAIN_SEPARATOR, 32),
+        keccak256(metadataInput),
+        keccak256(fixedSizeValues),
+        keccak256(message.sender),
+        keccak256(message.data),
+        keccak256(encodedTokens),
+      ],
+    )
+
+    console.debug('v1.6 leafHasher:', {
+      messageId: message.header.messageId,
+      encodedTokens,
+      fixedSizeValues,
+      packedValues,
+      metadataInput,
+    })
+
+    return keccak256(packedValues)
+  }
+}

--- a/src/lib/hasher/hasher.test.ts
+++ b/src/lib/hasher/hasher.test.ts
@@ -1,197 +1,57 @@
-import { ZeroAddress, getBigInt, hexlify, toUtf8Bytes, zeroPadValue } from 'ethers'
+import { CCIPVersion } from '../types.js'
 
-import { type AptosCCIPMessage, type CCIPMessage, CCIPVersion, parseExtraArgs } from '../types.js'
-import { getLeafHasher, hashAptosMessage, hashAptosMetadata, hashInternal } from './hasher.js'
+jest.mock('./evm', () => {
+  const originalModule = jest.requireActual('./evm')
+  return {
+    __esModule: true,
+    ...originalModule,
+    getV12LeafHasher: jest.fn(() => () => 'v12LeafHasher'),
+    getV16LeafHasher: jest.fn(() => () => 'v16LeafHasher'),
+  }
+})
+jest.mock('./aptos', () => {
+  const originalModule = jest.requireActual('./aptos')
+  return {
+    __esModule: true,
+    ...originalModule,
+    getV16AptosLeafHasher: jest.fn(() => () => 'v16AptosLeafHasher'),
+  }
+})
 
-describe('leaf hasher', () => {
-  it('should hash v1.5 msg', () => {
-    const sourceChainSelector = 1n,
-      destChainSelector = 4n
+import { getLeafHasher } from './hasher.js'
 
-    const onRamp = '0x5550000000000000000000000000000000000001'
-    const hasher = getLeafHasher({
-      sourceChainSelector,
-      destChainSelector,
-      onRamp,
-      version: CCIPVersion.V1_5,
+describe('get leaf hasher', () => {
+  it('should return the V1_2 EVM leaf hasher when version is CCIPVersion.V1_2', () => {
+    const hash = getLeafHasher({
+      sourceChainSelector: 1n,
+      destChainSelector: 5009297550715157269n, // eth mainnet
+      onRamp: 'onRamp',
+      version: CCIPVersion.V1_2,
     })
-
-    const header = {
-      messageId: '0x1001',
-      sequenceNumber: 1337n,
-      nonce: 1337n,
-    }
-    const message = {
-      header,
-      sourceChainSelector: sourceChainSelector,
-      sender: '0x1110000000000000000000000000000000000001',
-      receiver: '0x2220000000000000000000000000000000000001',
-      sequenceNumber: header.sequenceNumber,
-      gasLimit: 100n,
-      strict: false,
-      nonce: header.nonce,
-      feeToken: ZeroAddress,
-      feeTokenAmount: 1n,
-      data: '0x',
-      tokenAmounts: [
-        { token: '0x4440000000000000000000000000000000000001', amount: 12345678900n } as any,
-      ],
-      sourceTokenData: [],
-      messageId: header.messageId,
-    } as CCIPMessage<CCIPVersion.V1_5>
-
-    const msgHash = hasher(message)
-    expect(msgHash).toBe('0x46ad031bfb052db2e4a2514fed8dc480b98e5ce4acb55d5640d91407e0d8a3e9')
+    expect(hash({} as any)).toBe('v12LeafHasher')
   })
 
-  it('should hash v1.6 msg', () => {
-    const sourceChainSelector = 5009297550715157269n,
-      destChainSelector = 51875932522786413n
-
-    const onRamp = '0x7d571a25eb5a09013580c60aeb40ed89c924082a'
-    const hasher = getLeafHasher({
-      sourceChainSelector,
-      destChainSelector,
-      onRamp,
+  it('should return the V1_6 EVM leaf hasher when version is CCIPVersion.V1_6', () => {
+    const hash = getLeafHasher({
+      sourceChainSelector: 1n,
+      destChainSelector: 5009297550715157269n, // eth mainnet
+      onRamp: 'onRamp',
       version: CCIPVersion.V1_6,
     })
-
-    const header = {
-      messageId: '0xf82dd9f9977f06d5c789d33299f15c3c693c9b7b084206c8c524c3620f966edd',
-      sequenceNumber: 17624761845632355147n,
-      nonce: 13974814057813369789n,
-      sourceChainSelector,
-      destChainSelector,
-    }
-    const extraArgs =
-      '0x181dcf100000000000000000000000000000000000000000000000005eb3e65ecb9fb54e0000000000000000000000000000000000000000000000000000000000000001'
-    const message: CCIPMessage<CCIPVersion.V1_6> = {
-      header,
-      sender: '0x00000000000000000000000021aa8a422bfb1a82e254331259c1cbbea7408b44',
-      receiver: '0x56ad368c27ab9a428e9992c3843c79a35830794a',
-      feeToken: '0x6627c714a7ba7cc17bddeffa83b36a3b969e4e6c',
-      feeTokenAmount: 15188903849671844750n,
-      feeValueJuels: 0n,
-      extraArgs,
-      gasLimit: parseExtraArgs(extraArgs)!.gasLimit!,
-      data: '0xeed38ce567ddd944bb1c24619d50d373181a4faf1feed3f726a473df6c0a8dcd4c0fe0a09c843e930dabdd6ac5994025e99828e1d74df0641ec1f1d82c0ad1ab4c277721ba388a7742d711bbefb62182ae2c7ab1b80edaaf97f5527642e0ed167f69030792970994443aabfeceb0b12435f28cdb4925f82beacc1df9232b4f9734eed4c54b2cbe9276428a25ce2f3bea2735d205b40f8f0c488f3d584e6e197801c6d308b1e1d3f42b7cbfbeed21c72300b7126afa0002e20fadf43a8238fb8ac6f6612144fac1733fb1ef927c9d0cdf29eb08fe964e1afeeb845d547ace4ef2313df69b2f8f3d0b9714aa26e5d0a9a6d8f5b37680c617f524b7414e2f96e236b4d8efb037d025b1bcaff2f76b2696811c853283abb56d990197f21f7fbfef06044c31d42f7c8cac72a5a5b0a3f3a19cd24fec76d90efaf00a2b83e7eb9c817fbc667841c27a79168e49b68ecddb44a8e2877cf326a342a2b377dcafe3f692688dac17de842889bb0e2ee717092d2c53ce44a2d33760ab9791cbf9d1273eb2db7b59e741869037aeacfeb10132aa81f2bbc4b2626870f38d9e6a15636561bcbe93b16aef84c92d2b81798c1d332bc031911b8128765e2e74537c2416076ee587caf9178f6fc963ff0fc0a8c3d4551c7ab98bc26c42c4aa63ddbb1886f47456bf26275ef26dd1bde3ed3cabc064a3f1275240be0d799c649e30a3b9c36ba9a7a97e97cec75d6d2d1a6da15413614ebf3246126da03d41febaa07daaa205731336c1cffb3531d69c847f4fd9fb0daf1ee0975ab8a3bfc5251d9c32cca4def2f13540a6978c075d00856aa59c47ac80fb5598ab5646037121aa2b0f0512f7091a5ce33fb5a501c490b2390420c614e105f29abed474a4399c9823d56c88deef0e9de87af5b408cf0f506da2c2092da239383d1019734334125bdb489a8798e86000b6e9e8927d9193c4b0069cb5a3a54b149530229220193766e9f4e73e74d36a50b4166a65ce02aaad5ba014348d4c48562d781cbc246a4d56f5852d50f133a97d0bdf5cc176ac798d094a310f0fadb69bcd247b58199c4e7fa8e4e9662a046209af363e3cc1ebf501938b3bc2ebcbabf867e599c1f50f09be10e1c910973af651be066ed59ae9f136eba74a49f6c944c3b67b5bebdee8a1114781121ea15c9a2e53c8507d425c0cdd34e257e645427a7da23801a381366f74c75bc1c5fe9269423ad3a8be38702c91fee10bd88a6f4968819205f18a46ad290248cbfdf3f36e0ed15f0213326cdd284d40790a475b8e0678b0cdf5331e882e84236673a414259723b36d53d13dd956fef3d105bd5545da',
-      tokenAmounts: [
-        {
-          sourcePoolAddress: '0x0000000000000000000000006987756a2fc8e4f3f0a5e026cb200cc2b5221b1f',
-          destTokenAddress: '0xcc44ff0e5a1fc9a6f3224ef0f47f0c03b3f8eaee',
-          extraData: '0xd8e78c2c6144d59c308cee0365b6d223a9cea73dd7a46e990505271b4abb47b4',
-          amount: 4679472148560135273n,
-          destExecData: '0x000000000000000000000000000000000000000000000000000000005a51fc6c',
-        },
-        {
-          sourcePoolAddress: '0x00000000000000000000000036fdcc65c7703d0b34e88417b39e23c147e4c2b5',
-          destTokenAddress: '0xfe217692ac9020d4003781c7b41b06fce0b1d936',
-          extraData: '0x0180b0ebc736546d03caef8be134ba6da6cd18571e5b93c2cadbd136e8f105a7',
-          amount: 2622048486368728793n,
-          destExecData: '0x000000000000000000000000000000000000000000000000000000002b25ca57',
-        },
-        {
-          sourcePoolAddress: '0x0000000000000000000000000c4aff7c5d8d71d059f7dd60642ecf43032be209',
-          destTokenAddress: '0x83333769972daa43e880904c8aba7204fdfdfb1d',
-          extraData: '0x0ccc82d97ad2fc9d273842e49b97d62c6a98620458afbbc947c06aedd8ce2825',
-          amount: 4287026855703039806n,
-          destExecData: '0x0000000000000000000000000000000000000000000000000000000042b81487',
-        },
-        {
-          sourcePoolAddress: '0x00000000000000000000000016f7b1716017ecd77b1fc3adc01935361b60c21b',
-          destTokenAddress: '0x4f65755dcf6dcd2cc097cf1bbf3edf63c10f47cc',
-          extraData: '0x637ce69111efbf21ada2c3500d21a464f507b35cb773072f1f0e3e6b3727b4a2',
-          amount: 12541689545585536263n,
-          destExecData: '0x00000000000000000000000000000000000000000000000000000000cb9fbccb',
-        },
-        {
-          sourcePoolAddress: '0x000000000000000000000000a04f5214f63cf4c5533854b504610ce396cf0e32',
-          destTokenAddress: '0x3d2fd2372ee5e0861c1f9613becccc1d3a865e15',
-          extraData: '0xf4ae17af521472c6dec069c2c457f440a69c0f4e17f2b4fbb86b230f91e9b6ca',
-          amount: 14339435592708759294n,
-          destExecData: '0x00000000000000000000000000000000000000000000000000000000c5bb273b',
-        },
-        {
-          sourcePoolAddress: '0x000000000000000000000000b501a3cd1d7e1ca53d36de77657c3cd4d74e5a24',
-          destTokenAddress: '0x2353f292d183dabfceaeab694e55260cd8962ec3',
-          extraData: '0xba8ce764a1fd28accf94bfee7348e405c00195130dc0ba5631c3eee16edd8a44',
-          amount: 14452973941833137994n,
-          destExecData: '0x000000000000000000000000000000000000000000000000000000004a3374de',
-        },
-        {
-          sourcePoolAddress: '0x000000000000000000000000a88d2eded1a56475eba868472d6d5f05cdc648d6',
-          destTokenAddress: '0x01fae0388a4cd02b254eb91cc355062e6e79cb8e',
-          extraData: '0x7779713152f2ba379cb8aa67afdb7ad48e7d4d9a3c526f2eb0e67c2cfbdcb914',
-          amount: 15462212191244582558n,
-          destExecData: '0x000000000000000000000000000000000000000000000000000000006858d6a3',
-        },
-        {
-          sourcePoolAddress: '0x0000000000000000000000001c424bfd1ae4ce9505c446b7ccab820eff5ab9f4',
-          destTokenAddress: '0x89256f8b9ff25cc28fa816f245814db8876fcbc6',
-          extraData: '0x55aad1f0daf430642f21bee2349dab6f5fb7f784b1e7ef60b8e117e12124f75f',
-          amount: 4088793534626193712n,
-          destExecData: '0x0000000000000000000000000000000000000000000000000000000006b0cfb7',
-        },
-      ].map((ta) => ({ ...ta, destGasAmount: getBigInt(ta.destExecData) })),
-    }
-
-    const msgHash = hasher(message)
-    expect(msgHash).toBe('0xd56d9f4c0b0bb9cb8c83aeb676a02d5666583eee7d6d4660c87a06a9b36aa352')
+    expect(hash({} as any)).toBe('v16LeafHasher')
   })
 
-  it('should hash internal values', () => {
-    const a = '0x01'
-    const b = '0x02'
-    const result = hashInternal(a, b)
-    expect(result).toBe('0x93b82a55d406c553471937ba1e3176dfdacfc274e84c75b0cbf212388a8bd37b')
+  it('should return the V1_6 APTOS leaf hasher when version is CCIPVersion.V1_6 with Aptos chain selector', () => {
+    const hash = getLeafHasher({
+      sourceChainSelector: 1n,
+      destChainSelector: 4741433654826277614n, // aptos mainnet
+      onRamp: 'onRamp',
+      version: CCIPVersion.V1_6,
+    })
+    expect(hash({} as any)).toBe('v16AptosLeafHasher')
   })
 
-  // Aptos encoding tests mimic the Move test: https://github.com/smartcontractkit/chainlink-internal-integrations/blob/develop/aptos/contracts/ccip/sources/offramp.move#L1517
-  it('should hash Aptos msg', () => {
-    const msgId = '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'
-    const metadataHash = '0xaabbccddeeff00112233445566778899aabbccddeeff00112233445566778899'
-
-    const msg: AptosCCIPMessage = {
-      header: {
-        messageId: msgId,
-        sequenceNumber: 42n,
-        nonce: 123n,
-        sourceChainSelector: 1n,
-        destChainSelector: 2n,
-      },
-      sender: '0x8765432109fedcba8765432109fedcba87654321',
-      data: hexlify(toUtf8Bytes('sample message data')),
-      receiver: zeroPadValue('0x1234', 32),
-      gasLimit: 500000n,
-      tokenAmounts: [
-        {
-          sourcePoolAddress: '0xabcdef1234567890abcdef1234567890abcdef12',
-          destTokenAddress: zeroPadValue('0x5678', 32),
-          destGasAmount: 10000n,
-          extraData: '0x00112233',
-          amount: 1000000n,
-        },
-        {
-          sourcePoolAddress: '0x123456789abcdef123456789abcdef123456789a',
-          destTokenAddress: zeroPadValue('0x9abc', 32),
-          destGasAmount: 20000n,
-          extraData: '0xffeeddcc',
-          amount: 5000000n,
-        },
-      ],
-    }
-
-    const expectedHash = '0xc8d6cf666864a60dd6ecd89e5c294734c53b3218d3f83d2d19a3c3f9e200e00d'
-    expect(hashAptosMessage(msg, metadataHash)).toBe(expectedHash)
-  })
-
-  it('should hash Aptos metadata', () => {
-    const expected = '0x812acb01df318f85be452cf6664891cf5481a69dac01e0df67102a295218dd17'
-
-    const source = 123456789n
-    const dest = 987654321n
-    const onramp = hexlify(toUtf8Bytes('source-onramp-address'))
-
-    expect(hashAptosMetadata(source, dest, onramp)).toBe(expected)
+  afterAll(() => {
+    jest.clearAllMocks()
   })
 })

--- a/src/lib/hasher/hasher.ts
+++ b/src/lib/hasher/hasher.ts
@@ -174,13 +174,13 @@ export function getLeafHasher<V extends CCIPVersion = CCIPVersion>({
   destChainSelector,
   onRamp,
   version,
-}: Lane<V>): LeafHasher {
+}: Lane<V>): LeafHasher<V> {
   switch (version) {
     case CCIPVersion.V1_2:
     case CCIPVersion.V1_5:
-      return getV12LeafHasher(sourceChainSelector, destChainSelector, onRamp)
+      return getV12LeafHasher(sourceChainSelector, destChainSelector, onRamp) as LeafHasher<V>
     case CCIPVersion.V1_6:
-      return getV16LeafHasher(sourceChainSelector, destChainSelector, onRamp)
+      return getV16LeafHasher(sourceChainSelector, destChainSelector, onRamp) as LeafHasher<V>
     default:
       throw new Error(`Unsupported CCIP version: ${version}`)
   }

--- a/src/lib/hasher/hasher.ts
+++ b/src/lib/hasher/hasher.ts
@@ -1,8 +1,8 @@
-import { isAptosChain } from '../selectors'
-import { type Lane, CCIPVersion } from '../types'
-import { getV16AptosLeafHasher } from './aptos'
-import { type LeafHasher } from './common'
-import { getV12LeafHasher, getV16LeafHasher } from './evm'
+import { isAptosChain } from '../selectors.js'
+import { type Lane, CCIPVersion } from '../types.js'
+import { getV16AptosLeafHasher } from './aptos.js'
+import { type LeafHasher } from './common.js'
+import { getV12LeafHasher, getV16LeafHasher } from './evm.js'
 
 // Factory function that returns the right encoder based on the version of the lane
 export function getLeafHasher<V extends CCIPVersion = CCIPVersion>({

--- a/src/lib/hasher/hasher.ts
+++ b/src/lib/hasher/hasher.ts
@@ -1,174 +1,10 @@
-// For reference implementation, see https://github.com/smartcontractkit/ccip/blob/ccip-develop/core/services/ocr2/plugins/ccip/hasher/leaf_hasher.go
-import { concat, hexlify, id, keccak256, toBeHex, zeroPadValue } from 'ethers'
+import { isAptosChain } from '../selectors'
+import { type Lane, CCIPVersion } from '../types'
+import { getV16AptosLeafHasher } from './aptos'
+import { type LeafHasher } from './common'
+import { getV12LeafHasher, getV16LeafHasher } from './evm'
 
-import {
-  type AptosCCIPMessage,
-  type CCIPMessage,
-  type Lane,
-  CCIPVersion,
-  defaultAbiCoder,
-} from '../types.js'
-
-export const ZERO_HASH = hexlify(new Uint8Array(32).fill(0xff))
-
-export type LeafHasher<V extends CCIPVersion = CCIPVersion> = (message: CCIPMessage<V>) => string
-const INTERNAL_DOMAIN_SEPARATOR = toBeHex(1, 32)
-
-/**
- * Computes the Keccak-256 hash of the concatenation of two hash values.
- * @param a The first hash as a Hash type.
- * @param b The second hash as a Hash type.
- * @returns The Keccak-256 hash result as a Hash type.
- */
-export function hashInternal(a: string, b: string): string {
-  if (a > b) {
-    ;[a, b] = [b, a]
-  }
-  const combinedData = concat([INTERNAL_DOMAIN_SEPARATOR, a, b])
-  return keccak256(combinedData)
-}
-
-const LEAF_DOMAIN_SEPARATOR = '0x00'
-const METADATA_PREFIX_1_2 = id('EVM2EVMMessageHashV2')
-function getV12LeafHasher(
-  sourceChainSelector: bigint,
-  destChainSelector: bigint,
-  onRamp: string,
-): LeafHasher<CCIPVersion.V1_2 | CCIPVersion.V1_5> {
-  const metadataHash = keccak256(
-    concat([
-      METADATA_PREFIX_1_2,
-      toBeHex(sourceChainSelector, 32),
-      toBeHex(destChainSelector, 32),
-      zeroPadValue(onRamp, 32),
-    ]),
-  )
-
-  return (message: CCIPMessage<CCIPVersion.V1_2 | CCIPVersion.V1_5>): string => {
-    const encodedTokens = defaultAbiCoder.encode(
-      ['tuple(address token, uint256 amount)[]'],
-      [message.tokenAmounts],
-    )
-
-    const encodedSourceTokenData = defaultAbiCoder.encode(['bytes[]'], [message.sourceTokenData])
-
-    const fixedSizeValues = defaultAbiCoder.encode(
-      [
-        'address sender',
-        'address receiver',
-        'uint64 sequenceNumber',
-        'uint256 gasLimit',
-        'bool strict',
-        'uint64 nonce',
-        'address feeToken',
-        'uint256 feeTokenAmount',
-      ],
-      [
-        message.sender,
-        message.receiver,
-        message.sequenceNumber,
-        message.gasLimit,
-        message.strict,
-        message.nonce,
-        message.feeToken,
-        message.feeTokenAmount,
-      ],
-    )
-
-    const fixedSizeValuesHash = keccak256(fixedSizeValues)
-
-    const packedValues = defaultAbiCoder.encode(
-      [
-        'bytes1 leafDomainSeparator',
-        'bytes32 metadataHash',
-        'bytes32 fixedSizeValuesHash',
-        'bytes32 dataHash',
-        'bytes32 tokenAmountsHash',
-        'bytes32 sourceTokenDataHash',
-      ],
-      [
-        LEAF_DOMAIN_SEPARATOR,
-        metadataHash,
-        fixedSizeValuesHash,
-        keccak256(message.data),
-        keccak256(encodedTokens),
-        keccak256(encodedSourceTokenData),
-      ],
-    )
-
-    return keccak256(packedValues)
-  }
-}
-
-const ANY_2_EVM_MESSAGE_HASH = id('Any2EVMMessageHashV1')
-function getV16LeafHasher(
-  sourceChainSelector: bigint,
-  destChainSelector: bigint,
-  onRamp: string,
-): LeafHasher<CCIPVersion.V1_6> {
-  const metadataInput = concat([
-    ANY_2_EVM_MESSAGE_HASH,
-    toBeHex(sourceChainSelector, 32),
-    toBeHex(destChainSelector, 32),
-    keccak256(zeroPadValue(onRamp, 32)),
-  ])
-
-  return (message: CCIPMessage<CCIPVersion.V1_6>): string => {
-    const encodedTokens = defaultAbiCoder.encode(
-      [
-        'tuple(bytes sourcePoolAddress, address destTokenAddress, uint32 destGasAmount, bytes extraData, uint256 amount)[]',
-      ],
-      [message.tokenAmounts],
-    )
-
-    const fixedSizeValues = defaultAbiCoder.encode(
-      [
-        'bytes32 messageId',
-        'address receiver',
-        'uint64 sequenceNumber',
-        'uint256 gasLimit',
-        'uint64 nonce',
-      ],
-      [
-        message.header.messageId,
-        message.receiver,
-        message.header.sequenceNumber,
-        message.gasLimit,
-        message.header.nonce,
-      ],
-    )
-
-    const packedValues = defaultAbiCoder.encode(
-      [
-        'bytes32 leafDomainSeparator',
-        'bytes32 metadataHash',
-        'bytes32 fixedSizeValuesHash',
-        'bytes32 sender',
-        'bytes32 dataHash',
-        'bytes32 tokenAmountsHash',
-      ],
-      [
-        zeroPadValue(LEAF_DOMAIN_SEPARATOR, 32),
-        keccak256(metadataInput),
-        keccak256(fixedSizeValues),
-        keccak256(message.sender),
-        keccak256(message.data),
-        keccak256(encodedTokens),
-      ],
-    )
-
-    console.debug('v1.6 leafHasher:', {
-      messageId: message.header.messageId,
-      encodedTokens,
-      fixedSizeValues,
-      packedValues,
-      metadataInput,
-    })
-
-    return keccak256(packedValues)
-  }
-}
-
+// Factory function that returns the right encoder based on the version of the lane
 export function getLeafHasher<V extends CCIPVersion = CCIPVersion>({
   sourceChainSelector,
   destChainSelector,
@@ -180,76 +16,15 @@ export function getLeafHasher<V extends CCIPVersion = CCIPVersion>({
     case CCIPVersion.V1_5:
       return getV12LeafHasher(sourceChainSelector, destChainSelector, onRamp) as LeafHasher<V>
     case CCIPVersion.V1_6:
+      if (isAptosChain(destChainSelector)) {
+        return getV16AptosLeafHasher(
+          sourceChainSelector,
+          destChainSelector,
+          onRamp,
+        ) as LeafHasher<V>
+      }
       return getV16LeafHasher(sourceChainSelector, destChainSelector, onRamp) as LeafHasher<V>
     default:
       throw new Error(`Unsupported CCIP version: ${version}`)
   }
-}
-
-export type AptosLeafHasher = (message: AptosCCIPMessage) => string
-
-export const makeAptosHasher =
-  (sourceChainSelector: bigint, destChainSelector: bigint, onRamp: string): AptosLeafHasher =>
-  (message: AptosCCIPMessage): string =>
-    hashAptosMessage(message, hashAptosMetadata(sourceChainSelector, destChainSelector, onRamp))
-
-const encode = (target: string, value: string | bigint | number) =>
-  defaultAbiCoder.encode([target], [value])
-
-/**
- * Encodes dynamic bytes without the extra length prefix.
- * The default ABI encoding for type "bytes" is: 32-byte length prefix + the actual data padded.
- * This helper strips the 32-byte length prefix, mimicking the Move implementation.
- */
-const encodeRawBytes = (value: string): string => {
-  const encoded = encode('bytes', value)
-  // Remove "0x" and skip the first 64 hex characters (32 bytes of length)
-  return '0x' + encoded.slice(66)
-}
-
-export const hashAptosMessage = (message: AptosCCIPMessage, metadataHash: string): string => {
-  const innerHash = concat([
-    encode('bytes32', message.header.messageId),
-    encode('bytes32', zeroPadValue(message.receiver, 32)),
-    encode('uint64', message.header.sequenceNumber),
-    encode('uint256', message.gasLimit),
-    encode('uint64', message.header.nonce),
-  ])
-
-  const tokenHash = concat([
-    encode('uint256', message.tokenAmounts.length),
-    ...message.tokenAmounts.map((token) =>
-      concat([
-        encodeRawBytes(token.sourcePoolAddress),
-        encode('bytes32', zeroPadValue(token.destTokenAddress, 32)),
-        encode('uint32', token.destGasAmount),
-        encodeRawBytes(token.extraData),
-        encode('uint256', token.amount),
-      ]),
-    ),
-  ])
-
-  const outerHash = concat([
-    encode('bytes32', zeroPadValue(LEAF_DOMAIN_SEPARATOR, 32)),
-    metadataHash,
-    keccak256(innerHash),
-    keccak256(message.sender),
-    keccak256(message.data),
-    keccak256(tokenHash),
-  ])
-
-  return keccak256(outerHash)
-}
-
-export const hashAptosMetadata = (
-  sourceChainSelector: bigint,
-  destChainSelector: bigint,
-  onRamp: string,
-): string => {
-  const versionHash = id('Any2AptosMessageHashV1')
-  const encodedSource = encode('uint64', sourceChainSelector)
-  const encodedDest = encode('uint64', destChainSelector)
-  const onrampHash = keccak256(onRamp)
-
-  return keccak256(concat([versionHash, encodedSource, encodedDest, onrampHash]))
 }

--- a/src/lib/hasher/index.ts
+++ b/src/lib/hasher/index.ts
@@ -1,2 +1,3 @@
-export { type LeafHasher, ZERO_HASH, getLeafHasher, hashInternal } from './hasher.js'
+export { type LeafHasher, ZERO_HASH, hashInternal } from './common.js'
 export { MAX_NUMBER_TREE_LEAVES, Tree, proofFlagsToBits, verifyComputeRoot } from './merklemulti.js'
+export { getLeafHasher } from './hasher.js'

--- a/src/lib/hasher/merklemulti.test.ts
+++ b/src/lib/hasher/merklemulti.test.ts
@@ -2,7 +2,7 @@
 import { concat, keccak256 } from 'ethers'
 
 import { testVectors } from './__mocks__/merklemultiTestVectors.js'
-import { ZERO_HASH, hashInternal } from './hasher.js'
+import { ZERO_HASH, hashInternal } from './common.js'
 import { Proof, Tree, verifyComputeRoot } from './merklemulti.js'
 // import { CombinationGenerator } from './utils'
 

--- a/src/lib/hasher/merklemulti.ts
+++ b/src/lib/hasher/merklemulti.ts
@@ -1,5 +1,5 @@
 // For reference implementation, see https://github.com/smartcontractkit/ccip/blob/ccip-develop/core/services/ocr2/plugins/ccip/merklemulti/merkle_multi.go
-import { ZERO_HASH, hashInternal } from './hasher.js'
+import { ZERO_HASH, hashInternal } from './common.js'
 
 export const MAX_NUMBER_TREE_LEAVES = 256
 

--- a/src/lib/selectors.test.ts
+++ b/src/lib/selectors.test.ts
@@ -1,0 +1,12 @@
+import { aptosSelectors, isAptosChain } from './selectors'
+
+describe('selectors', () => {
+  it('should idenfify Aptos selectors', () => {
+    const selectors = Object.values(aptosSelectors).map((s) => s.selector)
+    for (const selector of selectors) {
+      expect(isAptosChain(selector)).toBe(true)
+    }
+
+    expect(isAptosChain(12n)).toBe(false)
+  })
+})

--- a/src/lib/selectors.test.ts
+++ b/src/lib/selectors.test.ts
@@ -1,4 +1,4 @@
-import { aptosSelectors, isAptosChain } from './selectors'
+import { aptosSelectors, isAptosChain } from './selectors.js'
 
 describe('selectors', () => {
   it('should idenfify Aptos selectors', () => {

--- a/src/lib/selectors.ts
+++ b/src/lib/selectors.ts
@@ -1,4 +1,6 @@
-const selectors: Record<number, { readonly selector: bigint; readonly name?: string }> = {
+type Selectors = Record<number, { readonly selector: bigint; readonly name?: string }>
+
+const evmSelectors: Selectors = {
   // generate:
   // fetch('https://github.com/smartcontractkit/chain-selectors/raw/main/selectors.yml')
   //   .then((res) => res.text())
@@ -382,4 +384,17 @@ const selectors: Record<number, { readonly selector: bigint; readonly name?: str
   },
   // end:generate
 }
+
+export const aptosSelectors: Selectors = {
+  '1': { name: 'aptos-mainnet', selector: 4741433654826277614n },
+  '2': { name: 'aptos-testnet', selector: 743186221051783445n },
+  '4': { name: 'aptos-localnet', selector: 4457093679053095497n },
+}
+
+const selectors: Selectors = { ...evmSelectors, ...aptosSelectors }
+
+export const isAptosChain = (selector: bigint): boolean => {
+  return Object.values(aptosSelectors).some((aptosSelector) => aptosSelector.selector === selector)
+}
+
 export default selectors

--- a/src/lib/selectors.ts
+++ b/src/lib/selectors.ts
@@ -1,6 +1,6 @@
 type Selectors = Record<number, { readonly selector: bigint; readonly name?: string }>
 
-const evmSelectors: Selectors = {
+const selectors: Selectors = {
   // generate:
   // fetch('https://github.com/smartcontractkit/chain-selectors/raw/main/selectors.yml')
   //   .then((res) => res.text())
@@ -386,12 +386,16 @@ const evmSelectors: Selectors = {
 }
 
 export const aptosSelectors: Selectors = {
+  // generate:
+  // fetch('https://github.com/smartcontractkit/chain-selectors/raw/main/selectors_aptos.yml')
+  //   .then((res) => res.text())
+  //   .then((body) => require('yaml').parse(body, { intAsBigInt: true }).selectors)
+  //   .then((obj) => require('util').inspect(obj).split('\n').slice(1, -1))
   '1': { name: 'aptos-mainnet', selector: 4741433654826277614n },
   '2': { name: 'aptos-testnet', selector: 743186221051783445n },
   '4': { name: 'aptos-localnet', selector: 4457093679053095497n },
+  // end:generate
 }
-
-const selectors: Selectors = { ...evmSelectors, ...aptosSelectors }
 
 export const isAptosChain = (selector: bigint): boolean => {
   return Object.values(aptosSelectors).some((aptosSelector) => aptosSelector.selector === selector)

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -109,6 +109,30 @@ export type CCIPMessage<V extends CCIPVersion = CCIPVersion> = V extends
       tokenAmounts: readonly (EVM2AnyMessageSent['tokenAmounts'][number] & SourceTokenData)[]
     }
 
+type AptosTokenTransfer = {
+  sourcePoolAddress: string
+  destTokenAddress: string
+  destGasAmount: bigint
+  extraData: string
+  amount: bigint
+}
+// TODO Rodrigo: Refactor it to be included in CCIPMessage type
+export type AptosCCIPMessage = {
+  header: {
+    messageId: string
+    sourceChainSelector: bigint
+    destChainSelector: bigint
+    sequenceNumber: bigint
+    nonce: bigint
+  }
+  sender: string
+  // data should be a hex encoded message
+  data: string
+  receiver: string
+  gasLimit: bigint
+  tokenAmounts: AptosTokenTransfer[]
+}
+
 // type Bla = CCIPMessage<CCIPVersion.V1_6> //['tokenAmounts'][number]
 
 type Log_ = Pick<Log, 'topics' | 'index' | 'address' | 'data' | 'blockNumber' | 'transactionHash'>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -133,6 +133,7 @@ export type AptosCCIPMessage = {
   tokenAmounts: AptosTokenTransfer[]
 }
 
+export type CCIPMessageAny<V extends CCIPVersion> = CCIPMessage<V> | AptosCCIPMessage
 // type Bla = CCIPMessage<CCIPVersion.V1_6> //['tokenAmounts'][number]
 
 type Log_ = Pick<Log, 'topics' | 'index' | 'address' | 'data' | 'blockNumber' | 'transactionHash'>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -109,33 +109,6 @@ export type CCIPMessage<V extends CCIPVersion = CCIPVersion> = V extends
       tokenAmounts: readonly (EVM2AnyMessageSent['tokenAmounts'][number] & SourceTokenData)[]
     }
 
-type AptosTokenTransfer = {
-  sourcePoolAddress: string
-  destTokenAddress: string
-  destGasAmount: bigint
-  extraData: string
-  amount: bigint
-}
-// TODO Rodrigo: Refactor it to be included in CCIPMessage type
-export type AptosCCIPMessage = {
-  header: {
-    messageId: string
-    sourceChainSelector: bigint
-    destChainSelector: bigint
-    sequenceNumber: bigint
-    nonce: bigint
-  }
-  sender: string
-  // data should be a hex encoded message
-  data: string
-  receiver: string
-  gasLimit: bigint
-  tokenAmounts: AptosTokenTransfer[]
-}
-
-export type CCIPMessageAny<V extends CCIPVersion> = CCIPMessage<V> | AptosCCIPMessage
-// type Bla = CCIPMessage<CCIPVersion.V1_6> //['tokenAmounts'][number]
-
 type Log_ = Pick<Log, 'topics' | 'index' | 'address' | 'data' | 'blockNumber' | 'transactionHash'>
 
 export interface CCIPRequest<V extends CCIPVersion = CCIPVersion> {


### PR DESCRIPTION
- Adds the ability to calculate the merkle proofs based on CCIP messages targeting Aptos. This enables users calling the Aptos Offramp `manuallyExecute` function to calculate part of the execution report.
- Also refactors the structure of the `/hasher` dir to be more explicit between chains, and adds some more tests
- Adds the Aptos Chain selectors