### PR TITLE
replace enums with const objects, string unions, tsc --erasableSyntaxOnly

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,12 +65,21 @@
     "printWidth": 100
   },
   "jest": {
-    "preset": "ts-jest/presets/default-esm",
+    "preset": "ts-jest/presets/js-with-ts-esm",
     "modulePathIgnorePatterns": [
       "<rootDir>/dist/"
     ],
     "moduleNameMapper": {
-      "(.+)\\.js": "$1"
+      "(.+)\\.[jt]s$": "$1"
+    },
+    "transform": {
+      "^.+\\.ts$": [
+        "ts-jest",
+        {
+          "useESM": true,
+          "isolatedModules": true
+        }
+      ]
     },
     "collectCoverage": true
   }

--- a/src/commands/lane.ts
+++ b/src/commands/lane.ts
@@ -72,7 +72,7 @@ export async function showLaneConfigs(
     onRampRouter = dynamicConfig.router as string
   } else {
     const [sequenceNumber, allowlistEnabled, onRampRouter_] = await (
-      onRampContract as CCIPContract<CCIPContractType.OnRamp, CCIPVersion.V1_6>
+      onRampContract as CCIPContract<typeof CCIPContractType.OnRamp, typeof CCIPVersion.V1_6>
     ).getDestChainConfig(lane.destChainSelector)
     onRampRouter = onRampRouter_ as string
     destChainConfig = { sequenceNumber, allowlistEnabled, router: onRampRouter }
@@ -161,7 +161,7 @@ export async function showLaneConfigs(
   } else {
     sourceChainConfig = toObject(
       await (
-        offRampContract as CCIPContract<CCIPContractType.OffRamp, CCIPVersion.V1_6>
+        offRampContract as CCIPContract<typeof CCIPContractType.OffRamp, typeof CCIPVersion.V1_6>
       ).getSourceChainConfig(lane.sourceChainSelector),
     )
     offRampRouter = sourceChainConfig.router as string

--- a/src/commands/manual-exec.ts
+++ b/src/commands/manual-exec.ts
@@ -136,11 +136,11 @@ export async function manualExec(
   if (request.lane.version === CCIPVersion.V1_2) {
     const gasOverrides = manualExecReport.messages.map(() => BigInt(argv.gasLimit ?? 0))
     manualExecTx = await (
-      offRampContract as CCIPContract<CCIPContractType.OffRamp, CCIPVersion.V1_2>
+      offRampContract as CCIPContract<typeof CCIPContractType.OffRamp, typeof CCIPVersion.V1_2>
     ).manuallyExecute(
       execReport as {
         offchainTokenData: string[][]
-        messages: CCIPMessage<CCIPVersion.V1_2>[]
+        messages: CCIPMessage<typeof CCIPVersion.V1_2>[]
         proofs: string[]
         proofFlagBits: bigint
       },
@@ -152,11 +152,11 @@ export async function manualExec(
       tokenGasOverrides: message.tokenAmounts.map(() => BigInt(argv.tokensGasLimit ?? 0)),
     }))
     manualExecTx = await (
-      offRampContract as CCIPContract<CCIPContractType.OffRamp, CCIPVersion.V1_5>
+      offRampContract as CCIPContract<typeof CCIPContractType.OffRamp, typeof CCIPVersion.V1_5>
     ).manuallyExecute(
       execReport as {
         offchainTokenData: string[][]
-        messages: CCIPMessage<CCIPVersion.V1_5>[]
+        messages: CCIPMessage<typeof CCIPVersion.V1_5>[]
         proofs: string[]
         proofFlagBits: bigint
       },
@@ -168,12 +168,12 @@ export async function manualExec(
       tokenGasOverrides: message.tokenAmounts.map(() => BigInt(argv.tokensGasLimit ?? 0)),
     }))
     manualExecTx = await (
-      offRampContract as CCIPContract<CCIPContractType.OffRamp, CCIPVersion.V1_6>
+      offRampContract as CCIPContract<typeof CCIPContractType.OffRamp, typeof CCIPVersion.V1_6>
     ).manuallyExecute(
       [
         {
           sourceChainSelector: request.lane.sourceChainSelector,
-          messages: execReport.messages as CCIPMessage<CCIPVersion.V1_6>[],
+          messages: execReport.messages as CCIPMessage<typeof CCIPVersion.V1_6>[],
           proofs: execReport.proofs,
           proofFlagBits: execReport.proofFlagBits,
           offchainTokenData: execReport.offchainTokenData,
@@ -316,11 +316,11 @@ export async function manualExecSenderQueue(
     if (firstRequest.lane.version === CCIPVersion.V1_2) {
       const gasOverrides = manualExecReport.messages.map(() => BigInt(argv.gasLimit ?? 0))
       manualExecTx = await (
-        offRampContract as CCIPContract<CCIPContractType.OffRamp, CCIPVersion.V1_2>
+        offRampContract as CCIPContract<typeof CCIPContractType.OffRamp, typeof CCIPVersion.V1_2>
       ).manuallyExecute(
         execReport as {
           offchainTokenData: string[][]
-          messages: CCIPMessage<CCIPVersion.V1_2>[]
+          messages: CCIPMessage<typeof CCIPVersion.V1_2>[]
           proofs: string[]
           proofFlagBits: bigint
         },
@@ -332,11 +332,11 @@ export async function manualExecSenderQueue(
         tokenGasOverrides: message.tokenAmounts.map(() => BigInt(argv.tokensGasLimit ?? 0)),
       }))
       manualExecTx = await (
-        offRampContract as CCIPContract<CCIPContractType.OffRamp, CCIPVersion.V1_5>
+        offRampContract as CCIPContract<typeof CCIPContractType.OffRamp, typeof CCIPVersion.V1_5>
       ).manuallyExecute(
         execReport as {
           offchainTokenData: string[][]
-          messages: CCIPMessage<CCIPVersion.V1_5>[]
+          messages: CCIPMessage<typeof CCIPVersion.V1_5>[]
           proofs: string[]
           proofFlagBits: bigint
         },
@@ -348,12 +348,12 @@ export async function manualExecSenderQueue(
         tokenGasOverrides: message.tokenAmounts.map(() => BigInt(argv.tokensGasLimit ?? 0)),
       }))
       manualExecTx = await (
-        offRampContract as CCIPContract<CCIPContractType.OffRamp, CCIPVersion.V1_6>
+        offRampContract as CCIPContract<typeof CCIPContractType.OffRamp, typeof CCIPVersion.V1_6>
       ).manuallyExecute(
         [
           {
             sourceChainSelector: firstRequest.lane.sourceChainSelector,
-            messages: execReport.messages as CCIPMessage<CCIPVersion.V1_6>[],
+            messages: execReport.messages as CCIPMessage<typeof CCIPVersion.V1_6>[],
             proofs: execReport.proofs,
             proofFlagBits: execReport.proofFlagBits,
             offchainTokenData: execReport.offchainTokenData,

--- a/src/commands/send.ts
+++ b/src/commands/send.ts
@@ -109,7 +109,7 @@ export async function sendMessage(
   // make sure to approve once per token, for the total amount (including fee, if needed)
   const amountsToApprove = tokenAmounts.reduce(
     (acc, { token, amount }) => ({ ...acc, [token]: (acc[token] ?? 0n) + amount }),
-    <Record<string, bigint>>{},
+    {} as Record<string, bigint>,
   )
   if (message.feeToken !== ZeroAddress) {
     amountsToApprove[message.feeToken as string] =

--- a/src/commands/types.ts
+++ b/src/commands/types.ts
@@ -1,5 +1,6 @@
-export enum Format {
-  log = 'log',
-  pretty = 'pretty',
-  json = 'json',
-}
+export const Format = {
+  log: 'log',
+  pretty: 'pretty',
+  json: 'json',
+} as const
+export type Format = (typeof Format)[keyof typeof Format]

--- a/src/commands/utils.ts
+++ b/src/commands/utils.ts
@@ -365,7 +365,10 @@ export async function sourceToDestTokenAmounts<S extends { token: string }>(
     throw new Error('Deprecated lane version: ' + lane.version)
   } else {
     ;({ tokenAdminRegistry: tokenAdminRegistryAddress } = await (
-      onRamp as CCIPContract<CCIPContractType.OnRamp, CCIPVersion.V1_5 | CCIPVersion.V1_6>
+      onRamp as CCIPContract<
+        typeof CCIPContractType.OnRamp,
+        typeof CCIPVersion.V1_5 | typeof CCIPVersion.V1_6
+      >
     ).getStaticConfig())
   }
   const tokenAdminRegistry = new Contract(

--- a/src/lib/commits.ts
+++ b/src/lib/commits.ts
@@ -78,8 +78,8 @@ export async function fetchCommitReport(
         try {
           const [staticConfig] = await getContractProperties(
             [log.address, commitStoreInterface, dest] as unknown as CCIPContract<
-              CCIPContractType.CommitStore,
-              CCIPVersion.V1_2 | CCIPVersion.V1_5
+              typeof CCIPContractType.CommitStore,
+              typeof CCIPVersion.V1_2 | typeof CCIPVersion.V1_5
             >,
             'getStaticConfig',
           )

--- a/src/lib/execution.test.ts
+++ b/src/lib/execution.test.ts
@@ -55,14 +55,14 @@ beforeEach(() => {
 })
 
 describe('calculateManualExecProof', () => {
-  const lane: Lane<CCIPVersion.V1_5> = {
+  const lane: Lane<typeof CCIPVersion.V1_5> = {
     sourceChainSelector: chainSelectorFromId(11155111),
     destChainSelector: chainSelectorFromId(421614),
     onRamp: '0x0000000000000000000000000000000000000007',
     version: CCIPVersion.V1_5,
   }
   const hasher = getLeafHasher(lane)
-  const messages: CCIPMessage<CCIPVersion.V1_5>[] = [
+  const messages: CCIPMessage<typeof CCIPVersion.V1_5>[] = [
     {
       header: {
         messageId: ZeroHash,

--- a/src/lib/gas.test.ts
+++ b/src/lib/gas.test.ts
@@ -4,7 +4,7 @@ import { discoverOffRamp, validateOffRamp } from './execution.ts'
 import { estimateExecGasForRequest } from './gas.ts'
 import { CCIPContractType, CCIPVersion } from './types.ts'
 
-jest.mock('./execution.js')
+jest.mock('./execution.ts')
 
 const mockProvider = {
   get provider() {

--- a/src/lib/gas.ts
+++ b/src/lib/gas.ts
@@ -75,11 +75,11 @@ export async function estimateExecGasForRequest(
   let destRouter
   if (lane.version < CCIPVersion.V1_6) {
     ;({ router: destRouter } = await (
-      offRamp as CCIPContract<CCIPContractType.OffRamp, CCIPVersion.V1_5>
+      offRamp as CCIPContract<typeof CCIPContractType.OffRamp, typeof CCIPVersion.V1_5>
     ).getDynamicConfig())
   } else {
     ;({ router: destRouter } = await (
-      offRamp as CCIPContract<CCIPContractType.OffRamp, CCIPVersion.V1_6>
+      offRamp as CCIPContract<typeof CCIPContractType.OffRamp, typeof CCIPVersion.V1_6>
     ).getSourceChainConfig(lane.sourceChainSelector))
   }
 

--- a/src/lib/hasher/aptos.test.ts
+++ b/src/lib/hasher/aptos.test.ts
@@ -8,7 +8,7 @@ describe('aptos hasher', () => {
     const msgId = '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'
     const metadataHash = '0xaabbccddeeff00112233445566778899aabbccddeeff00112233445566778899'
 
-    const msg: CCIPMessage<CCIPVersion.V1_6> = {
+    const msg: CCIPMessage<typeof CCIPVersion.V1_6> = {
       header: {
         messageId: msgId,
         sequenceNumber: 42n,

--- a/src/lib/hasher/aptos.ts
+++ b/src/lib/hasher/aptos.ts
@@ -7,8 +7,8 @@ export const getV16AptosLeafHasher =
     sourceChainSelector: bigint,
     destChainSelector: bigint,
     onRamp: string,
-  ): LeafHasher<CCIPVersion.V1_6> =>
-  (message: CCIPMessage<CCIPVersion.V1_6>): string =>
+  ): LeafHasher<typeof CCIPVersion.V1_6> =>
+  (message: CCIPMessage<typeof CCIPVersion.V1_6>): string =>
     hashAptosMessage(message, hashAptosMetadata(sourceChainSelector, destChainSelector, onRamp))
 
 const encode = (target: string, value: string | bigint | number) =>
@@ -26,7 +26,7 @@ const encodeRawBytes = (value: string): string => {
 }
 
 export const hashAptosMessage = (
-  message: CCIPMessage<CCIPVersion.V1_6>,
+  message: CCIPMessage<typeof CCIPVersion.V1_6>,
   metadataHash: string,
 ): string => {
   const innerHash = concat([

--- a/src/lib/hasher/evm.test.ts
+++ b/src/lib/hasher/evm.test.ts
@@ -33,7 +33,7 @@ describe('EVM leaf hasher', () => {
       ],
       sourceTokenData: [],
       messageId: header.messageId,
-    } as CCIPMessage<CCIPVersion.V1_5>
+    } as CCIPMessage<typeof CCIPVersion.V1_5>
 
     const msgHash = hasher(message)
     expect(msgHash).toBe('0x46ad031bfb052db2e4a2514fed8dc480b98e5ce4acb55d5640d91407e0d8a3e9')
@@ -55,7 +55,7 @@ describe('EVM leaf hasher', () => {
     }
     const extraArgs =
       '0x181dcf100000000000000000000000000000000000000000000000005eb3e65ecb9fb54e0000000000000000000000000000000000000000000000000000000000000001'
-    const message: CCIPMessage<CCIPVersion.V1_6> = {
+    const message: CCIPMessage<typeof CCIPVersion.V1_6> = {
       header,
       sender: '0x00000000000000000000000021aa8a422bfb1a82e254331259c1cbbea7408b44',
       receiver: '0x56ad368c27ab9a428e9992c3843c79a35830794a',

--- a/src/lib/hasher/evm.ts
+++ b/src/lib/hasher/evm.ts
@@ -8,7 +8,7 @@ export function getV12LeafHasher(
   sourceChainSelector: bigint,
   destChainSelector: bigint,
   onRamp: string,
-): LeafHasher<CCIPVersion.V1_2 | CCIPVersion.V1_5> {
+): LeafHasher<typeof CCIPVersion.V1_2 | typeof CCIPVersion.V1_5> {
   const metadataHash = keccak256(
     concat([
       METADATA_PREFIX_1_2,
@@ -18,7 +18,7 @@ export function getV12LeafHasher(
     ]),
   )
 
-  return (message: CCIPMessage<CCIPVersion.V1_2 | CCIPVersion.V1_5>): string => {
+  return (message: CCIPMessage<typeof CCIPVersion.V1_2 | typeof CCIPVersion.V1_5>): string => {
     const encodedTokens = defaultAbiCoder.encode(
       ['tuple(address token, uint256 amount)[]'],
       [message.tokenAmounts],
@@ -79,7 +79,7 @@ export function getV16LeafHasher(
   sourceChainSelector: bigint,
   destChainSelector: bigint,
   onRamp: string,
-): LeafHasher<CCIPVersion.V1_6> {
+): LeafHasher<typeof CCIPVersion.V1_6> {
   const metadataInput = concat([
     ANY_2_EVM_MESSAGE_HASH,
     toBeHex(sourceChainSelector, 32),
@@ -87,7 +87,7 @@ export function getV16LeafHasher(
     keccak256(zeroPadValue(onRamp, 32)),
   ])
 
-  return (message: CCIPMessage<CCIPVersion.V1_6>): string => {
+  return (message: CCIPMessage<typeof CCIPVersion.V1_6>): string => {
     const encodedTokens = defaultAbiCoder.encode(
       [
         'tuple(bytes sourcePoolAddress, address destTokenAddress, uint32 destGasAmount, bytes extraData, uint256 amount)[]',

--- a/src/lib/hasher/hasher.test.ts
+++ b/src/lib/hasher/hasher.test.ts
@@ -1,6 +1,6 @@
 import { CCIPVersion } from '../types.ts'
 
-jest.mock('./evm', () => {
+jest.mock('./evm.ts', () => {
   const originalModule = jest.requireActual('./evm')
   return {
     __esModule: true,
@@ -9,7 +9,7 @@ jest.mock('./evm', () => {
     getV16LeafHasher: jest.fn(() => () => 'v16LeafHasher'),
   }
 })
-jest.mock('./aptos', () => {
+jest.mock('./aptos.ts', () => {
   const originalModule = jest.requireActual('./aptos')
   return {
     __esModule: true,

--- a/src/lib/requests.ts
+++ b/src/lib/requests.ts
@@ -52,7 +52,7 @@ export async function getOnRampLane(source: Provider, address: string, destChain
   return lazyCached(`OnRamp ${address} lane`, async () => {
     const [iface, version] = await getOnRampInterface(source, address)
     const onRampContract = new Contract(address, iface, source) as unknown as CCIPContract<
-      CCIPContractType.OnRamp,
+      typeof CCIPContractType.OnRamp,
       typeof version
     >
     const staticConfig = toObject(await onRampContract.getStaticConfig())
@@ -78,7 +78,7 @@ export async function getOnRampLane(source: Provider, address: string, destChain
       },
       onRampContract,
     ] as {
-      [V in CCIPVersion]: readonly [Lane<V>, CCIPContract<CCIPContractType.OnRamp, V>]
+      [V in CCIPVersion]: readonly [Lane<V>, CCIPContract<typeof CCIPContractType.OnRamp, V>]
     }[CCIPVersion]
   })
 }

--- a/src/lib/selectors.ts
+++ b/src/lib/selectors.ts
@@ -306,6 +306,7 @@ const selectors: Selectors = {
   '98864': { selector: 3743020999916460931n, name: 'plume-devnet' },
   '98865': { selector: 3208172210661564830n },
   '98866': { selector: 17912061998839310979n, name: 'plume-mainnet' },
+  '98867': { selector: 13874588925447303949n, name: 'plume-testnet-sepolia' },
   '167000': { selector: 16468599424800719238n, name: 'ethereum-mainnet-taiko-1' },
   '167009': {
     selector: 7248756420937879088n,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,8 @@
     "moduleResolution": "node",
     "forceConsistentCasingInFileNames": true,
     "allowImportingTsExtensions": true,
-    "rewriteRelativeImportExtensions": true
+    "rewriteRelativeImportExtensions": true,
+    "verbatimModuleSyntax": true,
+    "erasableSyntaxOnly": true
   }
 }


### PR DESCRIPTION
This makes code more future-proof, by enforcing modern JS only syntax and allowing the .ts files to be executable by nodejs 23+ directly