### PR TITLE
calculateManualExecProof unit test for 1.6 solana message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3] - 2025-04-24
+- fix an edge case for solana hasher (#28)
+
 ## [0.2.2] - 2025-04-23
 - `--wallet ledger:<n>` supports an integer as wallet index on standard Ethereum derivation path (#24)
 - Fixes for Solana leafhasher (#27)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chainlink/ccip-tools-ts",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chainlink/ccip-tools-ts",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "7.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/ccip-tools-ts",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "CLI and library to interact with CCIP",
   "author": "Chainlink devs",
   "license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ import { Providers } from './providers.ts'
 util.inspect.defaultOptions.depth = 6 // print down to tokenAmounts in requests
 // generate:nofail
 // `const VERSION = '${require('./package.json').version}-${require('child_process').execSync('git rev-parse --short HEAD').toString().trim()}'`
-const VERSION = '0.2.2-db97ca5'
+const VERSION = '0.2.3-0083c05'
 // generate:end
 
 async function main() {

--- a/src/lib/execution.test.ts
+++ b/src/lib/execution.test.ts
@@ -161,6 +161,52 @@ describe('calculateManualExecProof', () => {
       /^Merkle root created from send events doesn't match ReportAccepted merkle root: expected=0xMerkleRoot, got=0x.*/,
     )
   })
+
+  describe('calculate manual execution proof for v1.6', () => {
+    const merkleRoot1_6 = '0xdd90b4c5787af181896f4b8cd7ff54e875c9ae940aec6cb52a83a6c8535affa7'
+    const messages1_6: CCIPMessage<typeof CCIPVersion.V1_6>[] = [
+      {
+        data: 'SGVsbG8gV29ybGQ=',
+        header: {
+          nonce: 0n,
+          messageId: '0x0fc6a9112085da645b3a2ac94c10e1a1761d3998649e1223fd62aa260fa5d8dc',
+          sequenceNumber: 491n,
+          destChainSelector: 16423721717087811551n,
+          sourceChainSelector: 16015286601757825753n,
+        },
+        sender: '0x9d087fC03ae39b088326b67fA3C788236645b717',
+        accounts: [
+          '9XDoTJ5mYNnxqdtWV5dA583VCiGUhmL3oEMWirqys3tF',
+          'CB7ptrDkY9EgwqHoJwa3TF8u4rhwYmTob2YqzaSpPMtE',
+        ],
+        feeToken: '0x779877A7B0D9E8603169DdbD7836e478b4624789',
+        receiver: 'BqmcnLFSbKwyMEgi7VhVeJCis1wW26VySztF34CJrKFq',
+        extraArgs:
+          '0x1f3b3aba00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000030d4000000000000000000000000000000000000000000000000000000000000000030000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000027e9b64cb72241a9053e1e3d7c80002e6b03dfcebe50c282201c6bf9794c8d4f4a608150a5cc4840ff37e559cef8b10c3b0647ca4c4be3e782709b68fdf49032b',
+        computeUnits: 200000n,
+        tokenAmounts: [],
+        feeValueJuels: 4500000000522683n,
+        tokenReceiver: '11111111111111111111111111111111',
+        feeTokenAmount: 4500000000522683n,
+        accountIsWritableBitmap: 3n,
+        allowOutOfOrderExecution: true,
+      },
+    ] as unknown as CCIPMessage<typeof CCIPVersion.V1_6>[]
+
+    const lane1_6: Lane<typeof CCIPVersion.V1_6> = {
+      sourceChainSelector: 16015286601757825753n,
+      destChainSelector: 16423721717087811551n,
+      onRamp: '0x32f88479dc6e9eebe603ee032161387b96337fff',
+      version: CCIPVersion.V1_6,
+    }
+
+    it('should calculate manual execution proof for 1.6 solana  correctly', () => {
+      const messageIds1_6 = [messages1_6[0].header.messageId]
+      expect(() =>
+        calculateManualExecProof(messages1_6, lane1_6, messageIds1_6, merkleRoot1_6),
+      ).not.toThrow()
+    })
+  })
 })
 
 describe('validateOffRamp', () => {

--- a/src/lib/hasher/solana.ts
+++ b/src/lib/hasher/solana.ts
@@ -5,6 +5,7 @@ import {
   dataLength,
   decodeBase58,
   getBytes,
+  hexlify,
   keccak256,
   toBeHex,
   toUtf8Bytes,
@@ -50,6 +51,7 @@ export function getV16SolanaLeafHasher(
 
     const dataBytes = getDataBytes(message.data)
     const onRampBytes = getAddressBytes(onRamp)
+    const receiver = getAddressBytes(message.receiver)
     const tokenReceiver = getAddressBytes(parsedArgs.tokenReceiver)
     const sender = getAddressBytes(message.sender)
 
@@ -81,6 +83,7 @@ export function getV16SolanaLeafHasher(
       toBeHex(dataLength(dataBytes), 2),
       dataBytes,
       tokenAmountsEncoded,
+      ...[receiver].filter((a) => hexlify(a) !== ZeroHash),
       ...parsedArgs.accounts.map((a) => toBeHex(decodeBase58(a), 32)),
     ]
     console.debug('v1.6 solana leafHasher', packedValues)


### PR DESCRIPTION
Added unit test for calculateManualExecProof using real 1.6 solana message data from atlas.
Test breaks due to error:

> Merkle root created from send events doesn't match ReportAccepted merkle root: expected=0xdd90b4c5787af181896f4b8cd7ff54e875c9ae940aec6cb52a83a6c8535affa7, got=0xe37611dd2fcfebd155e4911167c9b861217b7ec28263b47c16bfc913337034fb

Test message: https://ccip-ui-staging.vercel.app/#/side-drawer/msg/0x0fc6a9112085da645b3a2ac94c10e1a1761d3998649e1223fd62aa260fa5d8dc

Notes:
- messages are the output of `decodeMessage` run with infoRaw (text info representation)
- lane: verified valid selectors for solana-devnet and sepolia, onramp address comes from atlas
- merkle root comes from atlas
- I had to cast messages `as unknown as CCIPMessage<typeof CCIPVersion.V1_6>[]` because seems like decodeMessage output has some extra properties and does not fit the type