### PR TITLE
calculateManualExecProof: fix sender and sourcePoolAddress encoding only for EVM v1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.4] - 2025-04-25
+- fix zero-padding of source addreses on calculateManualExecProof (#29)
+
 ## [0.2.3] - 2025-04-24
 - fix an edge case for solana hasher (#28)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chainlink/ccip-tools-ts",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chainlink/ccip-tools-ts",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "7.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/ccip-tools-ts",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "CLI and library to interact with CCIP",
   "author": "Chainlink devs",
   "license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ import { Providers } from './providers.ts'
 util.inspect.defaultOptions.depth = 6 // print down to tokenAmounts in requests
 // generate:nofail
 // `const VERSION = '${require('./package.json').version}-${require('child_process').execSync('git rev-parse --short HEAD').toString().trim()}'`
-const VERSION = '0.2.3-0083c05'
+const VERSION = '0.2.4-371b8e5'
 // generate:end
 
 async function main() {

--- a/src/lib/execution.ts
+++ b/src/lib/execution.ts
@@ -5,7 +5,6 @@ import {
   Contract,
   Interface,
   toBeHex,
-  zeroPadValue,
 } from 'ethers'
 import type { TypedContract } from 'ethers-abitype'
 
@@ -60,24 +59,13 @@ export function calculateManualExecProof<V extends CCIPVersion = CCIPVersion>(
   const seen = new Set<string>()
 
   messagesInBatch.forEach((message, index) => {
-    // messages on dest side needs to encode source addresses
-    const msg = { ...message }
-    if (lane.version >= CCIPVersion.V1_6) {
-      msg.sender = zeroPadValue(msg.sender, 32)
-      msg.tokenAmounts = (msg as CCIPMessage<typeof CCIPVersion.V1_6>).tokenAmounts.map(
-        ({ sourcePoolAddress, ...rest }) => ({
-          ...rest,
-          sourcePoolAddress: zeroPadValue(sourcePoolAddress, 32),
-        }),
-      )
-    }
     // Hash leaf node
-    leaves.push(hasher(msg))
-    const msgId = msg.header.messageId
+    leaves.push(hasher(message))
+    const msgId = message.header.messageId
     seen.add(msgId)
     // Find the providng leaf index with the matching sequence number
     if (messageIds.includes(msgId)) {
-      messages.push(msg)
+      messages.push(message)
       prove.push(index)
     }
   })

--- a/src/lib/hasher/evm.ts
+++ b/src/lib/hasher/evm.ts
@@ -103,7 +103,7 @@ export function getV16LeafHasher(
       [
         message.tokenAmounts.map((ta) => ({
           ...ta,
-          sourcePoolAddress: getDataBytes(ta.sourcePoolAddress),
+          sourcePoolAddress: zeroPadValue(getDataBytes(ta.sourcePoolAddress), 32),
           extraData: getDataBytes(ta.extraData),
         })),
       ],
@@ -139,7 +139,7 @@ export function getV16LeafHasher(
         zeroPadValue(LEAF_DOMAIN_SEPARATOR, 32),
         keccak256(metadataInput),
         keccak256(fixedSizeValues),
-        keccak256(getDataBytes(message.sender)),
+        keccak256(zeroPadValue(getDataBytes(message.sender), 32)),
         keccak256(getDataBytes(message.data)),
         keccak256(encodedTokens),
       ],


### PR DESCRIPTION
Fix another edge case of sender packing on Solana