### PR TITLE
Test calculating evm to svm proof

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.5] - 2025-04-28
+- fix decoding of solana addresses in EVMv1.6 hasher (#30)
+
 ## [0.2.4] - 2025-04-25
-- fix zero-padding of source addreses on calculateManualExecProof (#29)
+- fix zero-padding of source addresses on calculateManualExecProof (#29)
 
 ## [0.2.3] - 2025-04-24
 - fix an edge case for solana hasher (#28)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "@chainlink/ccip-tools-ts",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chainlink/ccip-tools-ts",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/prompts": "7.4.1",
+        "@inquirer/prompts": "7.5.0",
         "@xlabs-xyz/ledger-signer-ethers-v6": "^0.0.1",
         "abitype": "1.0.8",
         "borsh": "^2.0.0",
-        "ethers": "6.13.5",
+        "ethers": "6.13.7",
         "tslib": "2.8.1",
         "yaml": "2.7.1",
         "yargs": "17.7.2"
@@ -24,7 +24,7 @@
       "devDependencies": {
         "@eslint/js": "9.25.1",
         "@types/jest": "29.5.14",
-        "@types/node": "22.14.1",
+        "@types/node": "22.15.3",
         "@types/yargs": "17.0.33",
         "eslint": "9.25.1",
         "eslint-config-prettier": "10.1.2",
@@ -32,7 +32,7 @@
         "eslint-plugin-import": "2.31.0",
         "eslint-plugin-prettier": "5.2.6",
         "ethers-abitype": "1.0.3",
-        "glob": "11.0.1",
+        "glob": "11.0.2",
         "jest": "29.7.0",
         "prettier": "3.5.3",
         "ts-jest": "29.3.2",
@@ -1388,9 +1388,9 @@
       }
     },
     "node_modules/@inquirer/prompts": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.4.1.tgz",
-      "integrity": "sha512-UlmM5FVOZF0gpoe1PT/jN4vk8JmpIWBlMvTL8M+hlvPmzN89K6z03+IFmyeu/oFCenwdwHDr2gky7nIGSEVvlA==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.5.0.tgz",
+      "integrity": "sha512-tk8Bx7l5AX/CR0sVfGj3Xg6v7cYlFBkEahH+EgBB+cZib6Fc83dwerTbzj7f2+qKckjIUGsviWRI1d7lx6nqQA==",
       "license": "MIT",
       "dependencies": {
         "@inquirer/checkbox": "^4.1.5",
@@ -1400,9 +1400,9 @@
         "@inquirer/input": "^4.1.9",
         "@inquirer/number": "^3.0.12",
         "@inquirer/password": "^4.0.12",
-        "@inquirer/rawlist": "^4.0.12",
+        "@inquirer/rawlist": "^4.1.0",
         "@inquirer/search": "^3.0.12",
-        "@inquirer/select": "^4.1.1"
+        "@inquirer/select": "^4.2.0"
       },
       "engines": {
         "node": ">=18"
@@ -1417,9 +1417,9 @@
       }
     },
     "node_modules/@inquirer/rawlist": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.0.12.tgz",
-      "integrity": "sha512-wNPJZy8Oc7RyGISPxp9/MpTOqX8lr0r+lCCWm7hQra+MDtYRgINv1hxw7R+vKP71Bu/3LszabxOodfV/uTfsaA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.0.tgz",
+      "integrity": "sha512-6ob45Oh9pXmfprKqUiEeMz/tjtVTFQTgDDz1xAMKMrIvyrYjAmRbQZjMJfsictlL4phgjLhdLu27IkHNnNjB7g==",
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^10.1.10",
@@ -1462,9 +1462,9 @@
       }
     },
     "node_modules/@inquirer/select": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.1.1.tgz",
-      "integrity": "sha512-IUXzzTKVdiVNMA+2yUvPxWsSgOG4kfX93jOM4Zb5FgujeInotv5SPIJVeXQ+fO4xu7tW8VowFhdG5JRmmCyQ1Q==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.2.0.tgz",
+      "integrity": "sha512-KkXQ4aSySWimpV4V/TUJWdB3tdfENZUU765GjOIZ0uPwdbGIG6jrxD4dDf1w68uP+DVtfNhr1A92B+0mbTZ8FA==",
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^10.1.10",
@@ -2596,9 +2596,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.14.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.14.1.tgz",
-      "integrity": "sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw==",
+      "version": "22.15.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.3.tgz",
+      "integrity": "sha512-lX7HFZeHf4QG/J7tBZqrCAXwz9J5RD56Y6MpP0eJkka8p+K0RY/yBTW7CYFJ4VGCclxqOLKmiGP5juQc6MKgcw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -4926,9 +4926,9 @@
       }
     },
     "node_modules/ethers": {
-      "version": "6.13.5",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.13.5.tgz",
-      "integrity": "sha512-+knKNieu5EKRThQJWwqaJ10a6HE9sSehGeqWN65//wE7j47ZpFhKAnHB/JJFibwwg61I/koxaPsXbXpD/skNOQ==",
+      "version": "6.13.7",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.13.7.tgz",
+      "integrity": "sha512-qbaJ0uIrjh+huP1Lad2f2QtzW5dcqSVjIzVH6yWB4dKoMuj2WqYz5aMeeQTCNpAKgTJBM5J9vcc2cYJ23UAimQ==",
       "funding": [
         {
           "type": "individual",
@@ -5485,9 +5485,9 @@
       "license": "MIT"
     },
     "node_modules/glob": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.1.tgz",
-      "integrity": "sha512-zrQDm8XPnYEKawJScsnM0QzobJxlT/kHOOlRTio8IH/GrmxRE5fjllkzdaHclIuNjUQTJYH2xHNIGfdpJkDJUw==",
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.2.tgz",
+      "integrity": "sha512-YT7U7Vye+t5fZ/QMkBFrTJ7ZQxInIUjwyAjVj84CYXqgBdv30MFUPGnBR6sQaVq6Is15wYJUsnzTuWaGRBhBAQ==",
       "dev": true,
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/ccip-tools-ts",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "CLI and library to interact with CCIP",
   "author": "Chainlink devs",
   "license": "MIT",
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@eslint/js": "9.25.1",
     "@types/jest": "29.5.14",
-    "@types/node": "22.14.1",
+    "@types/node": "22.15.3",
     "@types/yargs": "17.0.33",
     "eslint": "9.25.1",
     "eslint-config-prettier": "10.1.2",
@@ -35,7 +35,7 @@
     "eslint-plugin-import": "2.31.0",
     "eslint-plugin-prettier": "5.2.6",
     "ethers-abitype": "1.0.3",
-    "glob": "11.0.1",
+    "glob": "11.0.2",
     "jest": "29.7.0",
     "prettier": "3.5.3",
     "ts-jest": "29.3.2",
@@ -44,11 +44,11 @@
     "typescript-eslint": "8.31.0"
   },
   "dependencies": {
-    "@inquirer/prompts": "7.4.1",
+    "@inquirer/prompts": "7.5.0",
     "@xlabs-xyz/ledger-signer-ethers-v6": "^0.0.1",
     "abitype": "1.0.8",
     "borsh": "^2.0.0",
-    "ethers": "6.13.5",
+    "ethers": "6.13.7",
     "tslib": "2.8.1",
     "yaml": "2.7.1",
     "yargs": "17.7.2"

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ import { Providers } from './providers.ts'
 util.inspect.defaultOptions.depth = 6 // print down to tokenAmounts in requests
 // generate:nofail
 // `const VERSION = '${require('./package.json').version}-${require('child_process').execSync('git rev-parse --short HEAD').toString().trim()}'`
-const VERSION = '0.2.4-371b8e5'
+const VERSION = '0.2.5-e251c95'
 // generate:end
 
 async function main() {

--- a/src/lib/execution.test.ts
+++ b/src/lib/execution.test.ts
@@ -162,7 +162,7 @@ describe('calculateManualExecProof', () => {
     )
   })
 
-  describe('calculate manual execution proof for v1.6', () => {
+  describe('calculate manual execution proof for v1.6 EVM->SVM', () => {
     const merkleRoot1_6 = '0xdd90b4c5787af181896f4b8cd7ff54e875c9ae940aec6cb52a83a6c8535affa7'
     const messages1_6: CCIPMessage<typeof CCIPVersion.V1_6>[] = [
       {
@@ -197,6 +197,58 @@ describe('calculateManualExecProof', () => {
       sourceChainSelector: 16015286601757825753n,
       destChainSelector: 16423721717087811551n,
       onRamp: '0x32f88479dc6e9eebe603ee032161387b96337fff',
+      version: CCIPVersion.V1_6,
+    }
+
+    it('should calculate manual execution proof for 1.6 solana  correctly', () => {
+      const messageIds1_6 = [messages1_6[0].header.messageId]
+      const result = calculateManualExecProof(messages1_6, lane1_6, messageIds1_6, merkleRoot1_6)
+
+      expect(result).toEqual({
+        messages: messages1_6,
+        proofs: [],
+        proofFlagBits: 0n,
+      })
+    })
+  })
+
+  describe('calculate manual execution proof for v1.6 SVM->EVM', () => {
+    const merkleRoot1_6 = '0xec1e5b01b20770547bc99aea8924e19019a4fce50f1287500acdd2b26a5e840c'
+    const messages1_6: CCIPMessage<typeof CCIPVersion.V1_6>[] = [
+      {
+        data: '0x4920616d206120434349502074657374206d657373616765',
+        header: {
+          nonce: 0n,
+          messageId: '0xc6c76e6efff57774cc0ae8f6c4138e11cd26a3e13a41d19ef74f6b9182bd8684',
+          sequenceNumber: 1821n,
+          destChainSelector: 16015286601757825753n,
+          sourceChainSelector: 16423721717087811551n,
+        },
+        sender: '7oZnxiocDK1aa9XAQC3CZ1VHKFkKwLuwRK8NddhU3FT2',
+        feeToken: 'So11111111111111111111111111111111111111112',
+        gasLimit: 0n,
+        receiver: '0xbd27CdAB5c9109B3390B25b4Dff7d970918cc550',
+        extraArgs: '0x181dcf100000000000000000000000000000000001',
+        tokenAmounts: [
+          {
+            amount: 1000000000n,
+            extraData: '0x0000000000000000000000000000000000000000000000000000000000000009',
+            destExecData: '0x000493e0',
+            destTokenAddress: '0x316496C5dA67D052235B9952bc42db498d6c520b',
+            sourcePoolAddress: 'DJqV7aFn32Un1M7j2dwVDc77jXZiUXoufJyHhEqoEY6x',
+            destGasAmount: 300000n,
+          },
+        ],
+        feeValueJuels: 50000000000n,
+        feeTokenAmount: 5n,
+        allowOutOfOrderExecution: true,
+      },
+    ] as unknown as CCIPMessage<typeof CCIPVersion.V1_6>[]
+
+    const lane1_6: Lane<typeof CCIPVersion.V1_6> = {
+      sourceChainSelector: 16423721717087811551n,
+      destChainSelector: 16015286601757825753n,
+      onRamp: 'Ccip8ZTcM2qHjVt8FYHtuCAqjc637yLKnsJ5q5r2e6eL',
       version: CCIPVersion.V1_6,
     }
 

--- a/src/lib/execution.test.ts
+++ b/src/lib/execution.test.ts
@@ -200,7 +200,7 @@ describe('calculateManualExecProof', () => {
       version: CCIPVersion.V1_6,
     }
 
-    it('should calculate manual execution proof for 1.6 solana  correctly', () => {
+    it('should calculate manual execution proof for 1.6 solana correctly', () => {
       const messageIds1_6 = [messages1_6[0].header.messageId]
       const result = calculateManualExecProof(messages1_6, lane1_6, messageIds1_6, merkleRoot1_6)
 

--- a/src/lib/hasher/evm.ts
+++ b/src/lib/hasher/evm.ts
@@ -2,7 +2,7 @@
 import { concat, id, keccak256, toBeHex, zeroPadValue } from 'ethers'
 import { parseExtraArgs } from '../extra-args.ts'
 import { type CCIPMessage, type CCIPVersion, defaultAbiCoder } from '../types.ts'
-import { getDataBytes } from '../utils.ts'
+import { getAddressBytes, getDataBytes } from '../utils.ts'
 import { type LeafHasher, LEAF_DOMAIN_SEPARATOR } from './common.ts'
 
 const METADATA_PREFIX_1_2 = id('EVM2EVMMessageHashV2')
@@ -86,7 +86,7 @@ export function getV16LeafHasher(
     ANY_2_EVM_MESSAGE_HASH,
     toBeHex(sourceChainSelector, 32),
     toBeHex(destChainSelector, 32),
-    keccak256(zeroPadValue(onRamp, 32)),
+    keccak256(zeroPadValue(getAddressBytes(onRamp), 32)),
   ])
 
   return (message: CCIPMessage<typeof CCIPVersion.V1_6>): string => {
@@ -103,7 +103,7 @@ export function getV16LeafHasher(
       [
         message.tokenAmounts.map((ta) => ({
           ...ta,
-          sourcePoolAddress: zeroPadValue(getDataBytes(ta.sourcePoolAddress), 32),
+          sourcePoolAddress: zeroPadValue(getAddressBytes(ta.sourcePoolAddress), 32),
           extraData: getDataBytes(ta.extraData),
         })),
       ],
@@ -139,7 +139,7 @@ export function getV16LeafHasher(
         zeroPadValue(LEAF_DOMAIN_SEPARATOR, 32),
         keccak256(metadataInput),
         keccak256(fixedSizeValues),
-        keccak256(zeroPadValue(getDataBytes(message.sender), 32)),
+        keccak256(zeroPadValue(getAddressBytes(message.sender), 32)),
         keccak256(getDataBytes(message.data)),
         keccak256(encodedTokens),
       ],


### PR DESCRIPTION
Test calculatin manual exec proof EVM->SVM using real message data.

test message: https://ccip.chain.link/status#/side-drawer/msg/0xc6c76e6efff57774cc0ae8f6c4138e11cd26a3e13a41d19ef74f6b9182bd8684

issue:

```
TypeError: invalid BytesLike value (argument="value", value="Ccip8ZTcM2qHjVt8FYHtuCAqjc637yLKnsJ5q5r2e6eL", code=INVALID_ARGUMENT, version=6.13.5)
```

seems like non hex address (solana) cannot be converted to bytes using ethers directly.