### PR TITLE
regression: fix EVM should change source addresses (zero-pad to 32B) on calculateManualExecProof

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.6] - 2025-04-29
+- regression: change source addresses for EVMv1.6 calculateManualExecProof (#31)
+
 ## [0.2.5] - 2025-04-28
 - fix decoding of solana addresses in EVMv1.6 hasher (#30)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chainlink/ccip-tools-ts",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chainlink/ccip-tools-ts",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "7.5.0",
@@ -36,9 +36,9 @@
         "jest": "29.7.0",
         "prettier": "3.5.3",
         "ts-jest": "29.3.2",
-        "tsx": "4.19.3",
+        "tsx": "4.19.4",
         "typescript": "5.8.3",
-        "typescript-eslint": "8.31.0"
+        "typescript-eslint": "8.31.1"
       }
     },
     "node_modules/@adraffy/ens-normalize": {
@@ -2643,17 +2643,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.31.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.31.0.tgz",
-      "integrity": "sha512-evaQJZ/J/S4wisevDvC1KFZkPzRetH8kYZbkgcTRyql3mcKsf+ZFDV1BVWUGTCAW5pQHoqn5gK5b8kn7ou9aFQ==",
+      "version": "8.31.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.31.1.tgz",
+      "integrity": "sha512-oUlH4h1ABavI4F0Xnl8/fOtML/eu8nI2A1nYd+f+55XI0BLu+RIqKoCiZKNo6DtqZBEQm5aNKA20G3Z5w3R6GQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.31.0",
-        "@typescript-eslint/type-utils": "8.31.0",
-        "@typescript-eslint/utils": "8.31.0",
-        "@typescript-eslint/visitor-keys": "8.31.0",
+        "@typescript-eslint/scope-manager": "8.31.1",
+        "@typescript-eslint/type-utils": "8.31.1",
+        "@typescript-eslint/utils": "8.31.1",
+        "@typescript-eslint/visitor-keys": "8.31.1",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
@@ -2673,16 +2673,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.31.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.31.0.tgz",
-      "integrity": "sha512-67kYYShjBR0jNI5vsf/c3WG4u+zDnCTHTPqVMQguffaWWFs7artgwKmfwdifl+r6XyM5LYLas/dInj2T0SgJyw==",
+      "version": "8.31.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.31.1.tgz",
+      "integrity": "sha512-oU/OtYVydhXnumd0BobL9rkJg7wFJ9bFFPmSmB/bf/XWN85hlViji59ko6bSKBXyseT9V8l+CN1nwmlbiN0G7Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.31.0",
-        "@typescript-eslint/types": "8.31.0",
-        "@typescript-eslint/typescript-estree": "8.31.0",
-        "@typescript-eslint/visitor-keys": "8.31.0",
+        "@typescript-eslint/scope-manager": "8.31.1",
+        "@typescript-eslint/types": "8.31.1",
+        "@typescript-eslint/typescript-estree": "8.31.1",
+        "@typescript-eslint/visitor-keys": "8.31.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -2698,14 +2698,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.31.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.31.0.tgz",
-      "integrity": "sha512-knO8UyF78Nt8O/B64i7TlGXod69ko7z6vJD9uhSlm0qkAbGeRUSudcm0+K/4CrRjrpiHfBCjMWlc08Vav1xwcw==",
+      "version": "8.31.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.31.1.tgz",
+      "integrity": "sha512-BMNLOElPxrtNQMIsFHE+3P0Yf1z0dJqV9zLdDxN/xLlWMlXK/ApEsVEKzpizg9oal8bAT5Sc7+ocal7AC1HCVw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.31.0",
-        "@typescript-eslint/visitor-keys": "8.31.0"
+        "@typescript-eslint/types": "8.31.1",
+        "@typescript-eslint/visitor-keys": "8.31.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2716,14 +2716,14 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.31.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.31.0.tgz",
-      "integrity": "sha512-DJ1N1GdjI7IS7uRlzJuEDCgDQix3ZVYVtgeWEyhyn4iaoitpMBX6Ndd488mXSx0xah/cONAkEaYyylDyAeHMHg==",
+      "version": "8.31.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.31.1.tgz",
+      "integrity": "sha512-fNaT/m9n0+dpSp8G/iOQ05GoHYXbxw81x+yvr7TArTuZuCA6VVKbqWYVZrV5dVagpDTtj/O8k5HBEE/p/HM5LA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.31.0",
-        "@typescript-eslint/utils": "8.31.0",
+        "@typescript-eslint/typescript-estree": "8.31.1",
+        "@typescript-eslint/utils": "8.31.1",
         "debug": "^4.3.4",
         "ts-api-utils": "^2.0.1"
       },
@@ -2740,9 +2740,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.31.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.31.0.tgz",
-      "integrity": "sha512-Ch8oSjVyYyJxPQk8pMiP2FFGYatqXQfQIaMp+TpuuLlDachRWpUAeEu1u9B/v/8LToehUIWyiKcA/w5hUFRKuQ==",
+      "version": "8.31.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.31.1.tgz",
+      "integrity": "sha512-SfepaEFUDQYRoA70DD9GtytljBePSj17qPxFHA/h3eg6lPTqGJ5mWOtbXCk1YrVU1cTJRd14nhaXWFu0l2troQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2754,14 +2754,14 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.31.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.31.0.tgz",
-      "integrity": "sha512-xLmgn4Yl46xi6aDSZ9KkyfhhtnYI15/CvHbpOy/eR5NWhK/BK8wc709KKwhAR0m4ZKRP7h07bm4BWUYOCuRpQQ==",
+      "version": "8.31.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.31.1.tgz",
+      "integrity": "sha512-kaA0ueLe2v7KunYOyWYtlf/QhhZb7+qh4Yw6Ni5kgukMIG+iP773tjgBiLWIXYumWCwEq3nLW+TUywEp8uEeag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.31.0",
-        "@typescript-eslint/visitor-keys": "8.31.0",
+        "@typescript-eslint/types": "8.31.1",
+        "@typescript-eslint/visitor-keys": "8.31.1",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -2820,16 +2820,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.31.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.31.0.tgz",
-      "integrity": "sha512-qi6uPLt9cjTFxAb1zGNgTob4x9ur7xC6mHQJ8GwEzGMGE9tYniublmJaowOJ9V2jUzxrltTPfdG2nKlWsq0+Ww==",
+      "version": "8.31.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.31.1.tgz",
+      "integrity": "sha512-2DSI4SNfF5T4oRveQ4nUrSjUqjMND0nLq9rEkz0gfGr3tg0S5KB6DhwR+WZPCjzkZl3cH+4x2ce3EsL50FubjQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.31.0",
-        "@typescript-eslint/types": "8.31.0",
-        "@typescript-eslint/typescript-estree": "8.31.0"
+        "@typescript-eslint/scope-manager": "8.31.1",
+        "@typescript-eslint/types": "8.31.1",
+        "@typescript-eslint/typescript-estree": "8.31.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2844,13 +2844,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.31.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.31.0.tgz",
-      "integrity": "sha512-QcGHmlRHWOl93o64ZUMNewCdwKGU6WItOU52H0djgNmn1EOrhVudrDzXz4OycCRSCPwFCDrE2iIt5vmuUdHxuQ==",
+      "version": "8.31.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.31.1.tgz",
+      "integrity": "sha512-I+/rgqOVBn6f0o7NDTmAPWWC6NuqhV174lfYvAm9fUaWeiefLdux9/YI3/nLugEn9L8fcSi0XmpKi/r5u0nmpw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.31.0",
+        "@typescript-eslint/types": "8.31.1",
         "eslint-visitor-keys": "^4.2.0"
       },
       "engines": {
@@ -5329,6 +5329,21 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -9134,9 +9149,9 @@
       "license": "0BSD"
     },
     "node_modules/tsx": {
-      "version": "4.19.3",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.19.3.tgz",
-      "integrity": "sha512-4H8vUNGNjQ4V2EOoGw005+c+dGuPSnhpPBPHBtsZdGZBk/iJb4kguGlPWaZTZ3q5nMtFOEsY0nRDlh9PJyd6SQ==",
+      "version": "4.19.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.19.4.tgz",
+      "integrity": "sha512-gK5GVzDkJK1SI1zwHf32Mqxf2tSJkNx+eYcNly5+nHvWqXUJYUkWBQtKauoESz3ymezAI++ZwT855x5p5eop+Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9292,15 +9307,15 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.31.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.31.0.tgz",
-      "integrity": "sha512-u+93F0sB0An8WEAPtwxVhFby573E8ckdjwUUQUj9QA4v8JAvgtoDdIyYR3XFwFHq2W1KJ1AurwJCO+w+Y1ixyQ==",
+      "version": "8.31.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.31.1.tgz",
+      "integrity": "sha512-j6DsEotD/fH39qKzXTQRwYYWlt7D+0HmfpOK+DVhwJOFLcdmn92hq3mBb7HlKJHbjjI/gTOqEcc9d6JfpFf/VA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.31.0",
-        "@typescript-eslint/parser": "8.31.0",
-        "@typescript-eslint/utils": "8.31.0"
+        "@typescript-eslint/eslint-plugin": "8.31.1",
+        "@typescript-eslint/parser": "8.31.1",
+        "@typescript-eslint/utils": "8.31.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/ccip-tools-ts",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "CLI and library to interact with CCIP",
   "author": "Chainlink devs",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "jest": "29.7.0",
     "prettier": "3.5.3",
     "ts-jest": "29.3.2",
-    "tsx": "4.19.3",
+    "tsx": "4.19.4",
     "typescript": "5.8.3",
-    "typescript-eslint": "8.31.0"
+    "typescript-eslint": "8.31.1"
   },
   "dependencies": {
     "@inquirer/prompts": "7.5.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ import { Providers } from './providers.ts'
 util.inspect.defaultOptions.depth = 6 // print down to tokenAmounts in requests
 // generate:nofail
 // `const VERSION = '${require('./package.json').version}-${require('child_process').execSync('git rev-parse --short HEAD').toString().trim()}'`
-const VERSION = '0.2.5-e251c95'
+const VERSION = '0.2.6-1630b9e'
 // generate:end
 
 async function main() {

--- a/src/lib/execution.test.ts
+++ b/src/lib/execution.test.ts
@@ -205,18 +205,14 @@ describe('calculateManualExecProof', () => {
     const messageIds1_6 = [messages1_6[0].header.messageId]
     const result = calculateManualExecProof(messages1_6, lane1_6, messageIds1_6, merkleRoot1_6)
 
-    expect(result).toEqual({
-      messages: messages1_6,
-      proofs: [],
-      proofFlagBits: 0n,
-    })
-    const resultMessage = result.messages[0]
+    expect(result).toMatchObject({ proofs: [], proofFlagBits: 0n })
+    expect(result.messages).toHaveLength(1)
     // sender and sourcePoolAddress should be left-zero-padded 32B hex strings
-    expect(resultMessage.sender).toMatch(/^0x0{24}[a-z0-9]{40}$/)
-    expect(resultMessage.tokenAmounts[0].sourcePoolAddress).toMatch(/^0x0{24}[a-z0-9]{40}$/)
+    expect(result.messages[0].sender).toMatch(/^0x0{24}[a-z0-9]{40}$/)
+    expect(result.messages[0].tokenAmounts[0].sourcePoolAddress).toMatch(/^0x0{24}[a-z0-9]{40}$/)
     // receiver should be checksummed 20B hex address
-    expect(resultMessage.receiver).toEqual('0x95b9e79A732C0E03d04a41c30C9DF7852a3D8Da4')
-    expect(resultMessage).toHaveProperty('gasLimit', 200000n)
+    expect(result.messages[0].receiver).toEqual('0x95b9e79A732C0E03d04a41c30C9DF7852a3D8Da4')
+    expect(result.messages[0]).toHaveProperty('gasLimit', 200000n)
   })
 
   it('should calculate manual execution proof for v1.6 EVM->SVM', () => {
@@ -308,13 +304,10 @@ describe('calculateManualExecProof', () => {
     }
 
     const messageIds1_6 = [messages1_6[0].header.messageId]
-    expect(
-      calculateManualExecProof(messages1_6, lane1_6, messageIds1_6, merkleRoot1_6),
-    ).toMatchObject({
-      messages: messages1_6,
-      proofs: [],
-      proofFlagBits: 0n,
-    })
+    const result = calculateManualExecProof(messages1_6, lane1_6, messageIds1_6, merkleRoot1_6)
+    expect(result).toMatchObject({ proofs: [], proofFlagBits: 0n })
+    expect(result.messages).toHaveLength(1)
+    expect(result.messages[0].sender).toMatch(/^0x[a-z0-9]{64}$/)
   })
 })
 

--- a/src/lib/execution.test.ts
+++ b/src/lib/execution.test.ts
@@ -29,6 +29,7 @@ import {
   type Provider,
   Interface,
   ZeroHash,
+  getAddress,
   hexlify,
   randomBytes,
 } from 'ethers'
@@ -39,6 +40,7 @@ import {
   validateOffRamp,
 } from './execution.ts'
 import { getLeafHasher } from './hasher/index.ts'
+import { decodeMessage } from './requests.ts'
 import {
   type CCIPMessage,
   type CCIPRequest,
@@ -162,7 +164,62 @@ describe('calculateManualExecProof', () => {
     )
   })
 
-  describe('calculate manual execution proof for v1.6 EVM->SVM', () => {
+  it('should calculate manual execution proof for v1.6 EVM->EVM', () => {
+    const merkleRoot1_6 = '0x1b708ef99ebc240fe6e55d126944a56503eae87436319494edff8f4902175172'
+    const messages1_6: CCIPMessage<typeof CCIPVersion.V1_6>[] = [
+      decodeMessage({
+        data: '0x68656c6c6f',
+        header: {
+          nonce: 1040,
+          messageId: '0x4b42209c9cb8255171d0575555d6168824112e3b905f4bd06554bd5322fed40e',
+          sequenceNumber: 1073,
+          destChainSelector: 16281711391670634445n,
+          sourceChainSelector: 3478487238524512106n,
+        },
+        sender: '0x79de45bbbbbbd1bd179352aa5e7836a32285e8bd',
+        feeToken: '0xe591bf0a0cf924a0674d7792db046b23cebf5f34',
+        receiver: '0x00000000000000000000000095b9e79a732c0e03d04a41c30c9df7852a3d8da4',
+        extraArgs:
+          '0x181dcf100000000000000000000000000000000000000000000000000000000000030d400000000000000000000000000000000000000000000000000000000000000000',
+        tokenAmounts: [
+          {
+            amount: 1,
+            extraData: '0x0000000000000000000000000000000000000000000000000000000000000012',
+            destExecData: '0x000000000000000000000000000000000000000000000000000000000001e848',
+            destTokenAddress: '0x000000000000000000000000a4c9e2108ca478de0b91c7d9ba034bbc93c22ecc',
+            sourcePoolAddress: '0x3915fd663c32e56771d14dff40031e13956a0909',
+          },
+        ],
+        feeValueJuels: 1165428296631803n,
+        feeTokenAmount: 7474222373173n,
+      }),
+    ] as CCIPMessage<typeof CCIPVersion.V1_6>[]
+
+    const lane1_6: Lane<typeof CCIPVersion.V1_6> = {
+      sourceChainSelector: messages1_6[0].header.sourceChainSelector,
+      destChainSelector: messages1_6[0].header.destChainSelector,
+      onRamp: getAddress('0xfd04bd4cf2e51ed6c57183768d270539127b9143'),
+      version: CCIPVersion.V1_6,
+    }
+
+    const messageIds1_6 = [messages1_6[0].header.messageId]
+    const result = calculateManualExecProof(messages1_6, lane1_6, messageIds1_6, merkleRoot1_6)
+
+    expect(result).toEqual({
+      messages: messages1_6,
+      proofs: [],
+      proofFlagBits: 0n,
+    })
+    const resultMessage = result.messages[0]
+    // sender and sourcePoolAddress should be left-zero-padded 32B hex strings
+    expect(resultMessage.sender).toMatch(/^0x0{24}[a-z0-9]{40}$/)
+    expect(resultMessage.tokenAmounts[0].sourcePoolAddress).toMatch(/^0x0{24}[a-z0-9]{40}$/)
+    // receiver should be checksummed 20B hex address
+    expect(resultMessage.receiver).toEqual('0x95b9e79A732C0E03d04a41c30C9DF7852a3D8Da4')
+    expect(resultMessage).toHaveProperty('gasLimit', 200000n)
+  })
+
+  it('should calculate manual execution proof for v1.6 EVM->SVM', () => {
     const merkleRoot1_6 = '0xdd90b4c5787af181896f4b8cd7ff54e875c9ae940aec6cb52a83a6c8535affa7'
     const messages1_6: CCIPMessage<typeof CCIPVersion.V1_6>[] = [
       {
@@ -200,19 +257,17 @@ describe('calculateManualExecProof', () => {
       version: CCIPVersion.V1_6,
     }
 
-    it('should calculate manual execution proof for 1.6 solana correctly', () => {
-      const messageIds1_6 = [messages1_6[0].header.messageId]
-      const result = calculateManualExecProof(messages1_6, lane1_6, messageIds1_6, merkleRoot1_6)
+    const messageIds1_6 = [messages1_6[0].header.messageId]
+    const result = calculateManualExecProof(messages1_6, lane1_6, messageIds1_6, merkleRoot1_6)
 
-      expect(result).toEqual({
-        messages: messages1_6,
-        proofs: [],
-        proofFlagBits: 0n,
-      })
+    expect(result).toEqual({
+      messages: messages1_6,
+      proofs: [],
+      proofFlagBits: 0n,
     })
   })
 
-  describe('calculate manual execution proof for v1.6 SVM->EVM', () => {
+  it('should calculate manual execution proof for v1.6 SVM->EVM', () => {
     const merkleRoot1_6 = '0xec1e5b01b20770547bc99aea8924e19019a4fce50f1287500acdd2b26a5e840c'
     const messages1_6: CCIPMessage<typeof CCIPVersion.V1_6>[] = [
       {
@@ -252,11 +307,13 @@ describe('calculateManualExecProof', () => {
       version: CCIPVersion.V1_6,
     }
 
-    it('should calculate manual execution proof for 1.6 solana  correctly', () => {
-      const messageIds1_6 = [messages1_6[0].header.messageId]
-      expect(() =>
-        calculateManualExecProof(messages1_6, lane1_6, messageIds1_6, merkleRoot1_6),
-      ).not.toThrow()
+    const messageIds1_6 = [messages1_6[0].header.messageId]
+    expect(
+      calculateManualExecProof(messages1_6, lane1_6, messageIds1_6, merkleRoot1_6),
+    ).toMatchObject({
+      messages: messages1_6,
+      proofs: [],
+      proofFlagBits: 0n,
     })
   })
 })

--- a/src/lib/execution.ts
+++ b/src/lib/execution.ts
@@ -59,13 +59,13 @@ export function calculateManualExecProof<V extends CCIPVersion = CCIPVersion>(
   const seen = new Set<string>()
 
   messagesInBatch.forEach((message, index) => {
+    const msg = { ...message, tokenAmounts: message.tokenAmounts.map((ta) => ({ ...ta })) }
     // Hash leaf node
-    leaves.push(hasher(message))
-    const msgId = message.header.messageId
-    seen.add(msgId)
-    // Find the providng leaf index with the matching sequence number
-    if (messageIds.includes(msgId)) {
-      messages.push(message)
+    leaves.push(hasher(msg))
+    seen.add(message.header.messageId)
+    // Find the proving leaf index with the matching sequence number
+    if (messageIds.includes(message.header.messageId)) {
+      messages.push(msg)
       prove.push(index)
     }
   })

--- a/src/lib/selectors.ts
+++ b/src/lib/selectors.ts
@@ -310,6 +310,7 @@ const selectors: Selectors = {
   '80069': { selector: 7728255861635209484n, name: 'berachain-testnet-bepolia' },
   '80084': { selector: 8999465244383784164n, name: 'berachain-testnet-bartio' },
   '80085': { selector: 12336603543561911511n, name: 'berachain-testnet-artio' },
+  '80087': { selector: 2285225387454015855n, name: 'zero-g-testnet-galileo' },
   '80094': { selector: 1294465214383781161n, name: 'berachain-mainnet' },
   '81457': { selector: 4411394078118774322n, name: 'ethereum-mainnet-blast-1' },
   '84531': {


### PR DESCRIPTION
EVM OffRamp expects message source addresses to be formatted as zero-left-padded 32B bytearrays