### PR TITLE
Alternative offramp discovery method (Prep for SVM)

### DIFF
--- a/src/commands/manual-exec.ts
+++ b/src/commands/manual-exec.ts
@@ -1,3 +1,4 @@
+import { discoverOffRampLegacy } from '../lib/execution.ts'
 import {
   type CCIPContract,
   type CCIPContractType,
@@ -8,7 +9,6 @@ import {
   bigIntReplacer,
   calculateManualExecProof,
   chainIdFromSelector,
-  discoverOffRamp,
   estimateExecGasForRequest,
   fetchAllMessagesInBatch,
   fetchCCIPMessageInLog,
@@ -105,7 +105,7 @@ export async function manualExec(
   const execReport = { ...manualExecReport, offchainTokenData: [offchainTokenData] }
 
   const wallet = (await getWallet(argv)).connect(dest)
-  const offRampContract = await discoverOffRamp(wallet, request.lane, {
+  const offRampContract = await discoverOffRampLegacy(wallet, request.lane, {
     fromBlock: commit.log.blockNumber,
     page: argv.page,
   })
@@ -285,7 +285,7 @@ export async function manualExecSenderQueue(
 
   const wallet = (await getWallet(argv)).connect(dest)
 
-  const offRampContract = await discoverOffRamp(wallet, firstRequest.lane, {
+  const offRampContract = await discoverOffRampLegacy(wallet, firstRequest.lane, {
     fromBlock: destFromBlock,
     page: argv.page,
   })

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ import { Providers } from './providers.ts'
 util.inspect.defaultOptions.depth = 6 // print down to tokenAmounts in requests
 // generate:nofail
 // `const VERSION = '${require('./package.json').version}-${require('child_process').execSync('git rev-parse --short HEAD').toString().trim()}'`
-const VERSION = '0.2.6-1630b9e'
+const VERSION = '0.2.6-870a584'
 // generate:end
 
 async function main() {

--- a/src/lib/execution.test.ts
+++ b/src/lib/execution.test.ts
@@ -35,7 +35,7 @@ import {
 } from 'ethers'
 import {
   calculateManualExecProof,
-  discoverOffRamp,
+  discoverOffRampLegacy,
   fetchExecutionReceipts,
   validateOffRamp,
 } from './execution.ts'
@@ -397,7 +397,7 @@ describe('discoverOffRamp', () => {
     })
     const hints = { fromBlock: 50 }
 
-    const result = await discoverOffRamp(provider as unknown as ContractRunner, lane, hints)
+    const result = await discoverOffRampLegacy(provider as unknown as ContractRunner, lane, hints)
 
     expect(result).toMatchObject({ runner: provider })
     expect(provider.getLogs).toHaveBeenNthCalledWith(
@@ -420,7 +420,7 @@ describe('discoverOffRamp', () => {
       onRamp: hexlify(randomBytes(20)),
     })
 
-    await expect(discoverOffRamp(provider as unknown as ContractRunner, lane)).rejects.toThrow(
+    await expect(discoverOffRampLegacy(provider as unknown as ContractRunner, lane)).rejects.toThrow(
       /Could not find OffRamp on "ethereum-testnet-sepolia-arbitrum-1" for OnRamp=0x[a-zA-Z0-9]{40} on "ethereum-testnet-sepolia"/,
     )
   })

--- a/src/lib/gas.ts
+++ b/src/lib/gas.ts
@@ -14,7 +14,7 @@ import type { TypedContract } from 'ethers-abitype'
 
 import TokenABI from '../abi/BurnMintERC677Token.ts'
 import RouterABI from '../abi/Router.ts'
-import { discoverOffRamp, validateOffRamp } from './execution.ts'
+import { discoverOffRampLegacy, validateOffRamp } from './execution.ts'
 import {
   type CCIPContract,
   type CCIPContractType,
@@ -76,7 +76,7 @@ export async function estimateExecGasForRequest(
         `Invalid offRamp for "${networkInfo(lane.sourceChainSelector).name}" -> "${networkInfo(lane.destChainSelector).name}" (onRamp=${lane.onRamp}) lane`,
       )
   } else {
-    offRamp = await discoverOffRamp(dest, lane, hints)
+    offRamp = await discoverOffRampLegacy(dest, lane, hints)
   }
   let destRouter
   if (lane.version < CCIPVersion.V1_6) {

--- a/src/lib/requests.ts
+++ b/src/lib/requests.ts
@@ -60,6 +60,8 @@ export async function getOnRampLane(source: Provider, address: string, destChain
       typeof version
     >
     const staticConfig = toObject(await onRampContract.getStaticConfig())
+
+    let destRouter = ZeroAddress
     if (!('destChainSelector' in staticConfig)) {
       if (!destChainSelector) {
         throw new Error('destChainSelector is required for v1.6 OnRamp')
@@ -71,7 +73,9 @@ export async function getOnRampLane(source: Provider, address: string, destChain
         )
       }
     } else {
+      const dynamicConfig = await onRampContract.getDynamicConfig()
       destChainSelector = staticConfig.destChainSelector
+      destRouter = dynamicConfig.router
     }
     return [
       {
@@ -80,9 +84,10 @@ export async function getOnRampLane(source: Provider, address: string, destChain
         onRamp: address,
         version,
       },
+      destRouter,
       onRampContract,
     ] as {
-      [V in CCIPVersion]: readonly [Lane<V>, CCIPContract<typeof CCIPContractType.OnRamp, V>]
+      [V in CCIPVersion]: readonly [Lane<V>, string, CCIPContractEVM<typeof CCIPContractType.OnRamp, V>]
     }[CCIPVersion]
   })
 }


### PR DESCRIPTION
Some work I carved off the solana manual exec implementation.

This attempts to implement the algorithm described by @andrevmatos in this [slack thread](https://chainlink-core.slack.com/archives/C08ELMNJ9NJ/p1747077110368609?thread_ts=1746807045.423849&cid=C08ELMNJ9NJ). Please note that I'm really unfamiliar with Typescript best practices, so don't be shy about reviewing for basic language habitability.

This new approach is currently only called in the `lane` command. I'll later expand it to support quering SVM, and integrate it with the `manualExec` command.