### PR TITLE
Add lookup-table support on Solana manual-exec

### DIFF
--- a/src/commands/manual-exec.ts
+++ b/src/commands/manual-exec.ts
@@ -1,7 +1,12 @@
 import type { AnchorProvider } from '@coral-xyz/anchor'
+import {
+  type Keypair,
+  type TransactionSignature,
+  type VersionedTransaction,
+  SendTransactionError,
+} from '@solana/web3.js'
 import type { JsonRpcApiProvider, Provider } from 'ethers'
 import { discoverOffRamp } from '../lib/execution.ts'
-import { type Keypair, type TransactionSignature, type VersionedTransaction } from '@solana/web3.js'
 import {
   type CCIPContract,
   type CCIPContractType,
@@ -30,6 +35,7 @@ import {
   newAnchorProvider,
 } from '../lib/solana/manuallyExecuteSolana.ts'
 import type { SupportedSolanaCCIPVersion } from '../lib/solana/programs/versioning.ts'
+import { waitForFinalization } from '../lib/solana/utils.ts'
 import type { Providers } from '../providers.ts'
 import { Format } from './types.ts'
 import {
@@ -39,7 +45,6 @@ import {
   selectRequest,
   withDateTimestamp,
 } from './utils.ts'
-import { waitForFinalization } from '../lib/solana/utils.ts'
 
 export async function manualExec(
   providers: Providers,
@@ -108,6 +113,16 @@ export async function manualExec(
   }
 }
 
+function isCannotCloseTableUntilDeactivated(e: SendTransactionError): boolean {
+  // Lookup Tables are first deactivated and then closed. There has to be a cool-down period
+  // between the two operations. If the table is closed before it is fully deactivated, the
+  // transaction will fail. The cool-down period is ~4mins (more precisely, ~513 blocks), see
+  // https://solana.com/vi/developers/courses/program-optimization/lookup-tables#deactivate-a-lookup-table
+  return !!e.logs?.some((log) =>
+    log.includes("Program log: Table cannot be closed until it's fully deactivated in "),
+  )
+}
+
 async function doManuallyExecuteSolana(
   payer: Keypair,
   destination: AnchorProvider,
@@ -117,21 +132,54 @@ async function doManuallyExecuteSolana(
   let signature!: TransactionSignature
 
   for (const transaction of transactions) {
-    transaction.sign([payer])
+    // Refresh the blockhash for each transaction, as the blockhash is only valid for a short time
+    // and we spend a lot of time waiting for finalization of the previous transactions.
+    async function attempt() {
+      transaction.message.recentBlockhash = (
+        await destination.connection.getLatestBlockhash()
+      ).blockhash
 
-    signature = await destination.connection.sendTransaction(transaction)
-    const latestBlockhash = await destination.connection.getLatestBlockhash()
+      transaction.sign([payer])
 
-    await destination.connection.confirmTransaction(
-      {
-        signature,
-        blockhash: latestBlockhash.blockhash,
-        lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
-      },
-      'confirmed',
-    )
-    console.log(`Waiting for finalization of ${signature} ...`)
-    await waitForFinalization(destination.connection, signature)
+      signature = await destination.connection.sendTransaction(transaction)
+      const latestBlockhash = await destination.connection.getLatestBlockhash()
+
+      console.log(`Confirming ${signature} ...`)
+      await destination.connection.confirmTransaction(
+        {
+          signature,
+          blockhash: latestBlockhash.blockhash,
+          lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
+        },
+        'confirmed',
+      )
+      console.log(`Waiting for finalization of ${signature} ...`)
+      await waitForFinalization(destination.connection, signature)
+    }
+
+    async function attemptWithRetry(currentAttempt: number, maxAttempts: number) {
+      try {
+        await attempt()
+      } catch (e) {
+        if (
+          currentAttempt <= maxAttempts &&
+          e instanceof SendTransactionError &&
+          isCannotCloseTableUntilDeactivated(e)
+        ) {
+          const waitTimeSeconds = 30 // the maxAttempts * waitTimeSeconds should be greater than the cool-down period
+          console.error(
+            `Closing of lookup table failed (attempt ${currentAttempt} of ${maxAttempts}) because it has recently been deactivated and the cool-down period has not completed.\nWaiting ${waitTimeSeconds}s before retrying ...`,
+          )
+          await new Promise((resolve) => setTimeout(resolve, waitTimeSeconds * 1000))
+          await attemptWithRetry(currentAttempt + 1, maxAttempts)
+        } else {
+          console.error(`Transaction failed (attempt ${currentAttempt} of ${maxAttempts}):`, e)
+          throw e
+        }
+      }
+    }
+
+    await attemptWithRetry(1, 10)
   }
 
   const url_terminator_map: Record<string, string> = {

--- a/src/commands/manual-exec.ts
+++ b/src/commands/manual-exec.ts
@@ -56,6 +56,7 @@ export async function manualExec(
     solanaKeypair?: string
     solanaBufferAddress: string
     solanaForceBuffer: boolean
+    solanaForceLookupTable: boolean
     solanaCuLimit?: number
   },
 ) {
@@ -97,6 +98,7 @@ export async function manualExec(
       argv.solanaOfframp,
       argv.solanaBufferAddress,
       argv.solanaForceBuffer,
+      argv.solanaForceLookupTable,
       argv.solanaCuLimit,
     )
     await doManuallyExecuteSolana(keypair, anchorProvider, transactions, chainName)
@@ -128,7 +130,7 @@ async function doManuallyExecuteSolana(
       },
       'confirmed',
     )
-    console.log(`Waiting for finalization of ${signature}...`)
+    console.log(`Waiting for finalization of ${signature} ...`)
     await waitForFinalization(destination.connection, signature)
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -150,6 +150,12 @@ async function main() {
               describe: 'Forces the usage of a buffering contract for Solana manual execution.',
               default: false,
             },
+            'solana-force-lookup-table': {
+              type: 'boolean',
+              describe:
+                'Forces the creation & usage of an ad-hoc lookup table for Solana manual execution.',
+              default: false,
+            },
             'solana-cu-limit': {
               type: 'number',
               describe:

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ import { Providers } from './providers.ts'
 util.inspect.defaultOptions.depth = 6 // print down to tokenAmounts in requests
 // generate:nofail
 // `const VERSION = '${require('./package.json').version}-${require('child_process').execSync('git rev-parse --short HEAD').toString().trim()}'`
-const VERSION = '0.2.6-d4c4aa9'
+const VERSION = '0.2.6-c810a2b'
 // generate:end
 
 async function main() {

--- a/src/lib/solana/manuallyExecuteSolana.ts
+++ b/src/lib/solana/manuallyExecuteSolana.ts
@@ -1,13 +1,14 @@
 import { randomBytes } from 'crypto'
 import fs from 'fs'
 import path from 'path'
-import { type Idl, AnchorProvider, BorshCoder, Program, Wallet } from '@coral-xyz/anchor'
+import { type Idl, type web3, AnchorProvider, BorshCoder, Program, Wallet } from '@coral-xyz/anchor'
 import { BorshTypesCoder } from '@coral-xyz/anchor/dist/cjs/coder/borsh/types'
 import {
   type AccountMeta,
-  type AddressLookupTableAccount,
   type Transaction,
   type TransactionInstruction,
+  AddressLookupTableAccount,
+  AddressLookupTableProgram,
   ComputeBudgetProgram,
   Connection,
   Keypair,
@@ -60,6 +61,12 @@ class AlteredBorshCoder<A extends string = string, T extends string = string> ex
   }
 }
 
+type ManualExecAlt = {
+  addressLookupTableAccount: AddressLookupTableAccount
+  initialTxs: web3.VersionedTransaction[]
+  closeTxs: web3.VersionedTransaction[]
+}
+
 export async function buildManualExecutionTxWithSolanaDestination<
   V extends SupportedSolanaCCIPVersion,
 >(
@@ -68,6 +75,7 @@ export async function buildManualExecutionTxWithSolanaDestination<
   offrampAddress: string,
   bufferProgramAddress: string,
   forceBuffer: boolean,
+  forceLookupTable: boolean,
   computeUnitsOverride: number | undefined,
 ): Promise<VersionedTransaction[]> {
   const offrampProgram = getCcipOfframp({
@@ -93,7 +101,7 @@ export async function buildManualExecutionTxWithSolanaDestination<
     offchainTokenData: new Array(ccipRequest.message.tokenAmounts.length).fill('0x') as string[],
   })
 
-  const payerAddress = destinationProvider.wallet.publicKey.toBase58()
+  const payerAddress = destinationProvider.wallet.publicKey
 
   const { executionReport, tokenIndexes, accounts, remainingAccounts, addressLookupTableAccounts } =
     await getManuallyExecuteInputs({
@@ -101,7 +109,7 @@ export async function buildManualExecutionTxWithSolanaDestination<
       connection: destinationProvider.connection,
       offrampProgram,
       root: merkleRoot,
-      senderAddress: payerAddress,
+      senderAddress: payerAddress.toBase58(),
     })
 
   const coder = new AlteredBorshCoder(CCIP_OFFRAMP_IDL)
@@ -109,6 +117,75 @@ export async function buildManualExecutionTxWithSolanaDestination<
   const serializedTokenIndexes = Buffer.from(tokenIndexes)
 
   const { blockhash } = await destinationProvider.connection.getLatestBlockhash()
+
+  console.log('ForceLookupTable', forceLookupTable)
+
+  const alt: ManualExecAlt | undefined = !forceLookupTable
+    ? undefined
+    : await (async () => {
+        const recentSlot = await destinationProvider.connection.getSlot('finalized')
+
+        const [createIx, altAddr] = AddressLookupTableProgram.createLookupTable({
+          authority: payerAddress,
+          payer: payerAddress,
+          recentSlot,
+        })
+        console.log('Using Address Lookup Table', altAddr.toBase58())
+
+        const addresses = [...Object.values(accounts), ...remainingAccounts.map((a) => a.pubkey)]
+
+        if (addresses.length > 256) {
+          throw new Error(
+            `The number of addresses (${addresses.length}) exceeds the maximum limit imposed by Solana of 256 for Address Lookup Tables`,
+          )
+        }
+
+        // 1232 bytes is the max size of a transaction, 32 bytes used for each address.
+        // Setting a max of 30 addresses per transaction to avoid exceeding the limit.
+        // 1232 / 32 = 38.5, so we set it to 30 to be safe.
+        const maxAddressesPerTx = 30
+        const extendIxs: TransactionInstruction[] = []
+        for (let i = 0; i < addresses.length; i += maxAddressesPerTx) {
+          const end = Math.min(i + maxAddressesPerTx, addresses.length)
+          const addressesChunk = addresses.slice(i, end)
+          const extendIx = AddressLookupTableProgram.extendLookupTable({
+            payer: payerAddress,
+            authority: payerAddress,
+            lookupTable: altAddr,
+            addresses: addressesChunk,
+          })
+          extendIxs.push(extendIx)
+        }
+
+        const deactivateIx = AddressLookupTableProgram.deactivateLookupTable({
+          lookupTable: altAddr,
+          authority: payerAddress,
+        })
+
+        const closeIx = AddressLookupTableProgram.closeLookupTable({
+          authority: payerAddress,
+          lookupTable: altAddr,
+          recipient: payerAddress,
+        })
+
+        return {
+          addressLookupTableAccount: new AddressLookupTableAccount({
+            key: altAddr,
+            state: {
+              deactivationSlot: BigInt(0),
+              lastExtendedSlot: recentSlot,
+              lastExtendedSlotStartIndex: 0,
+              addresses,
+            },
+          }),
+          initialTxs: [createIx, ...extendIxs].map((ix) =>
+            toVersionedTransaction(ix, payerAddress, blockhash),
+          ),
+          closeTxs: [deactivateIx, closeIx].map((ix) =>
+            toVersionedTransaction(ix, payerAddress, blockhash),
+          ),
+        }
+      })()
 
   if (forceBuffer) {
     console.log(
@@ -124,6 +201,7 @@ export async function buildManualExecutionTxWithSolanaDestination<
       computeUnitsOverride,
       blockhash,
       addressLookupTableAccounts,
+      alt,
     )
   }
 
@@ -158,6 +236,10 @@ export async function buildManualExecutionTxWithSolanaDestination<
   })
   const messageV0 = message.compileToV0Message(addressLookupTableAccounts)
   const transaction = new VersionedTransaction(messageV0)
+
+  if (alt) {
+    return [...alt.initialTxs, transaction, ...alt.closeTxs]
+  }
 
   return [transaction]
 }
@@ -211,6 +293,7 @@ async function bufferedTransactions(
   computeUnitsOverride: number | undefined,
   blockhash: string,
   addressLookupTableAccounts: AddressLookupTableAccount[],
+  alt: ManualExecAlt | undefined,
 ): Promise<VersionedTransaction[]> {
   // Arbitrary as long as there's consistency for all translations.
   const bufferId = {
@@ -238,7 +321,7 @@ async function bufferedTransactions(
     destinationProvider,
   )
 
-  const transactions: VersionedTransaction[] = []
+  const bufferedExecTxs: VersionedTransaction[] = []
 
   const bufferingAccounts = {
     bufferedReport: bufferAddress,
@@ -249,7 +332,9 @@ async function bufferedTransactions(
     .initializeExecutionReportBuffer(bufferId)
     .accounts(bufferingAccounts)
     .transaction()
-  transactions.push(toVersionedTransaction(initTx, destinationProvider.wallet.publicKey, blockhash))
+  bufferedExecTxs.push(
+    toVersionedTransaction(initTx, destinationProvider.wallet.publicKey, blockhash),
+  )
 
   for (let i = 0; i < serializedReport.length; i += chunkSize) {
     const end = Math.min(i + chunkSize, serializedReport.length)
@@ -259,7 +344,7 @@ async function bufferedTransactions(
       .appendExecutionReportData(bufferId, chunk)
       .accounts(bufferingAccounts)
       .transaction()
-    transactions.push(
+    bufferedExecTxs.push(
       toVersionedTransaction(appendTx, destinationProvider.wallet.publicKey, blockhash),
     )
   }
@@ -291,18 +376,27 @@ async function bufferedTransactions(
     recentBlockhash: blockhash,
     instructions: finalInstructions,
   })
-  const messageV0 = message.compileToV0Message(addressLookupTableAccounts)
-  transactions.push(new VersionedTransaction(messageV0))
 
-  return transactions
+  const altAccs = [...addressLookupTableAccounts]
+  if (alt) {
+    altAccs.push(alt.addressLookupTableAccount)
+  }
+  const messageV0 = message.compileToV0Message(altAccs)
+  bufferedExecTxs.push(new VersionedTransaction(messageV0))
+
+  if (alt) {
+    return [...alt.initialTxs, ...bufferedExecTxs, ...alt.closeTxs]
+  }
+
+  return bufferedExecTxs
 }
 
 function toVersionedTransaction(
-  tx: Transaction,
+  input: Transaction | TransactionInstruction,
   payerKey: PublicKey,
   blockhash: string,
 ): VersionedTransaction {
-  const instructions = tx.instructions
+  const instructions: TransactionInstruction[] = isTransaction(input) ? input.instructions : [input]
 
   const message = new TransactionMessage({
     payerKey,
@@ -310,4 +404,8 @@ function toVersionedTransaction(
     instructions,
   })
   return new VersionedTransaction(message.compileToV0Message())
+}
+
+function isTransaction(input: Transaction | TransactionInstruction): input is Transaction {
+  return (input as Transaction).signatures !== undefined
 }

--- a/src/lib/solana/manuallyExecuteSolana.ts
+++ b/src/lib/solana/manuallyExecuteSolana.ts
@@ -1,18 +1,18 @@
-import {
-  AddressLookupTableAccount,
-  PublicKey,
-  SystemProgram,
-  Transaction,
-  TransactionInstruction,
-  type AccountMeta,
-} from '@solana/web3.js'
+import { randomBytes } from 'crypto'
 import fs from 'fs'
 import path from 'path'
-import { AnchorProvider, BorshCoder, Program, Wallet, type Idl } from '@coral-xyz/anchor'
+import { type Idl, AnchorProvider, BorshCoder, Program, Wallet } from '@coral-xyz/anchor'
+import { BorshTypesCoder } from '@coral-xyz/anchor/dist/cjs/coder/borsh/types'
 import {
+  type AccountMeta,
+  type AddressLookupTableAccount,
+  type Transaction,
+  type TransactionInstruction,
   ComputeBudgetProgram,
   Connection,
   Keypair,
+  PublicKey,
+  SystemProgram,
   TransactionMessage,
   VersionedTransaction,
 } from '@solana/web3.js'
@@ -20,15 +20,13 @@ import type { Layout } from 'buffer-layout'
 import { calculateManualExecProof } from '../execution.ts'
 import { type CCIPMessage, type CCIPRequest, type ExecutionReport, CCIPVersion } from '../types.ts'
 import { getClusterUrlByChainSelectorName } from './getClusterByChainSelectorName.ts'
-import { getManuallyExecuteInputs } from './getManuallyExecuteInputs'
+import { getManuallyExecuteInputs } from './getManuallyExecuteInputs.ts'
 import { CCIP_OFFRAMP_IDL } from './programs/1.6.0/CCIP_OFFRAMP.ts'
-import { getCcipOfframp } from './programs/getCcipOfframp'
-import type { SupportedSolanaCCIPVersion } from './programs/versioning.ts'
-import { simulateUnitsConsumed } from './simulateManuallyExecute'
-import { normalizeExecutionReportForSolana } from './utils.ts'
 import { EXECUTION_BUFFER_IDL } from './programs/1.6.0/EXECUTION_BUFFER.ts'
-import { randomBytes } from 'crypto'
-import { BorshTypesCoder } from '@coral-xyz/anchor/dist/cjs/coder/borsh/types'
+import { getCcipOfframp } from './programs/getCcipOfframp.ts'
+import type { SupportedSolanaCCIPVersion } from './programs/versioning.ts'
+import { simulateUnitsConsumed } from './simulateManuallyExecute.ts'
+import { normalizeExecutionReportForSolana } from './utils.ts'
 
 class ExtendedBorshTypesCoder<N extends string = string> extends BorshTypesCoder<N> {
   public constructor(idl: Idl) {
@@ -92,7 +90,7 @@ export async function buildManualExecutionTxWithSolanaDestination<
     message: ccipRequest.message as CCIPMessage<typeof CCIPVersion.V1_6>,
     proofs,
     // Offchain token data is unsupported for manual exec
-    offchainTokenData: new Array(ccipRequest.message.tokenAmounts.length).fill('0x'),
+    offchainTokenData: new Array(ccipRequest.message.tokenAmounts.length).fill('0x') as string[],
   })
 
   const payerAddress = destinationProvider.wallet.publicKey.toBase58()


### PR DESCRIPTION
Adds a `--solana-force-lookup-table` flag that, when set, will:
- Create a lookup table with all the accounts used for the manual exec
- Use that lookup table during the manual exec (whether it is using the intermediary buffer or not)
- Clean-up that lookup table. Note: this takes ~4 mins due to Solana's cooldown period on lookup tables

Other changes:
- Lint fixes, especially on imports
- Refresh the tx recent blockhash on each tx