### PR TITLE
Add Aptos specific input formats

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ import { Providers } from './providers.ts'
 util.inspect.defaultOptions.depth = 6 // print down to tokenAmounts in requests
 // generate:nofail
 // `const VERSION = '${require('./package.json').version}-${require('child_process').execSync('git rev-parse --short HEAD').toString().trim()}'`
-const VERSION = '0.2.7-22aade5'
+const VERSION = '0.2.7-37d8d78'
 // generate:end
 
 async function main() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ import { Providers } from './providers.ts'
 util.inspect.defaultOptions.depth = 6 // print down to tokenAmounts in requests
 // generate:nofail
 // `const VERSION = '${require('./package.json').version}-${require('child_process').execSync('git rev-parse --short HEAD').toString().trim()}'`
-const VERSION = '0.2.7-f8caa7f'
+const VERSION = '0.2.7-e678a84'
 // generate:end
 
 async function main() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ import { Providers } from './providers.ts'
 util.inspect.defaultOptions.depth = 6 // print down to tokenAmounts in requests
 // generate:nofail
 // `const VERSION = '${require('./package.json').version}-${require('child_process').execSync('git rev-parse --short HEAD').toString().trim()}'`
-const VERSION = '0.2.7-e678a84'
+const VERSION = '0.2.7-22aade5'
 // generate:end
 
 async function main() {

--- a/src/lib/execution.test.ts
+++ b/src/lib/execution.test.ts
@@ -130,6 +130,7 @@ describe('calculateManualExecProof', () => {
       messages: messages.slice(0, 1),
       proofs: ['0xf3393e4a9c575ef46c2bfd3e614cb84d994a0504fddafa609c070d0c2a8d79d8'],
       proofFlagBits: 0n,
+      merkleRoot: '0xd055c6a2bf69febaeae385fc855d732a2ed0d0fd14612d1fd45e0b83059b2876',
     })
   })
 
@@ -144,6 +145,7 @@ describe('calculateManualExecProof', () => {
       messages: batch,
       proofs: [],
       proofFlagBits: 0n,
+      merkleRoot: '0xa09a81a044318270c0fa19edae902bb43f0c60aab8567986b190eb5b2eefda1f',
     })
   })
 
@@ -260,6 +262,7 @@ describe('calculateManualExecProof', () => {
       messages: messages1_6,
       proofs: [],
       proofFlagBits: 0n,
+      merkleRoot: '0xdd90b4c5787af181896f4b8cd7ff54e875c9ae940aec6cb52a83a6c8535affa7',
     })
   })
 

--- a/src/lib/requests.test.ts
+++ b/src/lib/requests.test.ts
@@ -349,21 +349,21 @@ describe('fetchRequestsForSender', () => {
 describe('decodeMessage', () => {
   it('should decode 1.5 message with tokenAmounts', () => {
     const msgInfoString =
-      '{"data": "0x0000000000000000000000002cac89abf06dbe5d3a059517053b7144074e1ce50000000000000000000000002cac89abf06dbe5d3a059517053b7144074e1ce500000000000000000000000000000000000000000000000048810ec3e431431f0000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000493e0", "nonce": 3, "sender": "0xac82b70d55dcf33d8c3d62cc9469d4b1797def66", "strict": false, "feeToken": "0x779877a7b0d9e8603169ddbd7836e478b4624789", "gasLimit": 300000, "receiver": "0xc1ca35997dd2c981c7ade0c73bd8628079fd0a4e", "messageId": "0x6c8899267b18796eb04f563d6966ed36772f44480924a4b0035f4b8253cdd6a8", "tokenAmounts": [{"token": "0x1c7d4b196cb0c7b01d743fbc6116a902379c7238", "amount": 1}], "feeTokenAmount": 43716430206517156, "sequenceNumber": 2662, "sourceTokenData": ["0x000000000000000000000000000000000000000000000000000000000003fc650000000000000000000000000000000000000000000000000000000000000000"], "sourceChainSelector": 16015286601757825753}'
+      '{"data": "0x", "nonce": 10, "sender": "0xc70070c9c8fe7866449edbf4ba3918c5936fe639", "strict": false, "feeToken": "0xd00ae08403b9bbb9124bb305c09058e32c39a48c", "gasLimit": 0, "receiver": "0xc70070c9c8fe7866449edbf4ba3918c5936fe639", "messageId": "0xe9d9d03588f0b3fca80bc43b2194d314aec8ebbea67f6390ef63b095b11e6f80", "tokenAmounts": [{"token": "0xd21341536c5cf5eb1bcb58f6723ce26e8d8e90e4", "amount": 100000000000000000}], "feeTokenAmount": 31933333333333333, "sequenceNumber": 40944, "sourceTokenData": ["0x"], "sourceChainSelector": 14767482510784806043}'
 
     expect(() => decodeMessage(msgInfoString)).not.toThrow()
 
     const msg = decodeMessage(msgInfoString)
-
     expect(msg.tokenAmounts.length).toBe(1)
     const tokenAmount = msg.tokenAmounts[0]
 
     expect('token' in msg.tokenAmounts[0]).toBe(true)
-    expect(msg.feeTokenAmount).toBe(43716430206517156n)
+    expect(msg.feeTokenAmount).toBe(31933333333333333n)
+
     if ('token' in tokenAmount) {
-      expect(tokenAmount.token).toBe('0x1c7d4b196cb0c7b01d743fbc6116a902379c7238')
+      expect(tokenAmount.token).toBe('0xd21341536c5cf5eb1bcb58f6723ce26e8d8e90e4')
+      expect(tokenAmount.amount).toBe(100000000000000000n)
     }
-    expect(tokenAmount.amount).toBe(1n)
   })
 
   it('should decode 1.6 message from Aptos with snake case formats', () => {

--- a/src/lib/requests.ts
+++ b/src/lib/requests.ts
@@ -28,8 +28,10 @@ import {
   defaultAbiCoder,
 } from './types.ts'
 import {
+  bigIntReplacer,
   blockRangeGenerator,
   chainNameFromSelector,
+  convertKeysToCamelCase,
   decodeAddress,
   getDataBytes,
   lazyCached,
@@ -107,6 +109,8 @@ const ccipMessagesTopicHashes = new Set(ccipMessagesFragments.map((fragment) => 
 export function decodeMessage(data: string | Uint8Array | Record<string, unknown>): CCIPMessage {
   if (typeof data === 'string' && data.startsWith('{')) {
     data = yaml.parse(data, { intAsBigInt: true }) as Record<string, unknown>
+    // Convert snake_case keys to camelCase after YAML parsing
+    data = convertKeysToCamelCase(data) as Record<string, unknown>
   }
   if (isBytesLike(data)) {
     let result: Result | undefined
@@ -126,7 +130,7 @@ export function decodeMessage(data: string | Uint8Array | Record<string, unknown
     data = resultsToMessage(result)
   }
   if (typeof data !== 'object' || typeof data?.sender !== 'string')
-    throw new Error('unknown message format: ' + JSON.stringify(data))
+    throw new Error('unknown message format: ' + JSON.stringify(data, bigIntReplacer))
 
   if (!data.header) {
     data.header = {
@@ -162,14 +166,19 @@ export function decodeMessage(data: string | Uint8Array | Record<string, unknown
       if (typeof tokenAmount.destExecData === 'string' && tokenAmount.destGasAmount == null) {
         tokenAmount.destGasAmount = getUint(hexlify(getDataBytes(tokenAmount.destExecData)))
       }
-      tokenAmount.sourcePoolAddress = decodeAddress(
-        tokenAmount.sourcePoolAddress as string,
-        sourceFamily,
-      )
-      tokenAmount.destTokenAddress = decodeAddress(
-        tokenAmount.destTokenAddress as string,
-        destFamily,
-      )
+      // Can be undefined if the message is from before v1.5 and failed to parse sourceTokenData
+      if (tokenAmount.sourcePoolAddress) {
+        tokenAmount.sourcePoolAddress = decodeAddress(
+          tokenAmount.sourcePoolAddress as string,
+          sourceFamily,
+        )
+      }
+      if (tokenAmount.destTokenAddress) {
+        tokenAmount.destTokenAddress = decodeAddress(
+          tokenAmount.destTokenAddress as string,
+          destFamily,
+        )
+      }
       return tokenAmount
     },
   )

--- a/src/lib/selectors.ts
+++ b/src/lib/selectors.ts
@@ -118,6 +118,7 @@ const selectors: Selectors = {
   '592': { selector: 6422105447186081193n, name: 'polkadot-mainnet-astar' },
   '678': { selector: 9107126442626377432n, name: 'janction-mainnet' },
   '679': { selector: 5059197667603797935n, name: 'janction-testnet-sepolia' },
+  '682': { selector: 6260932437388305511n, name: 'private-testnet-obsidian' },
   '919': {
     selector: 829525985033418733n,
     name: 'ethereum-testnet-sepolia-mode-1',


### PR DESCRIPTION
## Why
Aptos message events have some different formats

## What
`networkInfo`: 
- Add support for chain selectors coming as strings.
- Unit Tests

`decodeMessage`:
- Add support for decoding messages with snake_case format. It converts every key in the message to camelCase
- Unit tests

Other fixes:
- Failing tests in Solana 