### PR TITLE
fix: manualExec --sender-queue for large queues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- fix: `manualExec --sender-queue` for large queues (#51)
 
 ## [0.2.8] - 2025-07-16
 - fix: aptos messages decoding format (#43)

--- a/src/commands/manual-exec.ts
+++ b/src/commands/manual-exec.ts
@@ -43,6 +43,10 @@ import {
   withDateTimestamp,
 } from './utils.ts'
 
+const MAX_QUEUE = 1000
+const MAX_EXECS_IN_BATCH = 1
+const MAX_PENDING_TXS = 25
+
 export async function manualExec(
   providers: Providers,
   txHash: string,
@@ -381,6 +385,7 @@ export async function manualExecSenderQueue(
   const requests: Omit<CCIPRequest, 'timestamp' | 'tx'>[] = []
   for await (const request of fetchRequestsForSender(source, firstRequest)) {
     requests.push(request)
+    if (requests.length >= MAX_QUEUE) break
   }
   console.info('Found', requests.length, `requests for "${firstRequest.message.sender}"`)
 
@@ -406,48 +411,51 @@ export async function manualExecSenderQueue(
   console.info(requestsPending.length, `requests eligible for manualExec`)
   if (!requestsPending.length) return
 
-  const maxExecsInBatch = 1
-  const batches: (readonly [
-    CCIPCommit,
-    Omit<CCIPRequest<CCIPVersion>, 'tx' | 'timestamp'>[],
-    string[],
-  ])[] = []
-  let startBlock = destFromBlock
-  for (const request of requestsPending) {
-    if (
-      batches.length > 0 &&
-      request.message.header.sequenceNumber <= batches[batches.length - 1][0].report.maxSeqNr
-    ) {
-      if (batches[batches.length - 1][2].length >= maxExecsInBatch) {
-        batches.push([batches[batches.length - 1][0], batches[batches.length - 1][1], []])
-      }
-      batches[batches.length - 1][2].push(request.message.header.messageId)
-      continue
-    }
-    const commit = await fetchCommitReport(dest, request, { startBlock, page: argv.page })
-    startBlock = commit.log.blockNumber + 1
-
-    const batch = await fetchAllMessagesInBatch(
-      source,
-      request.lane.destChainSelector,
-      request.log,
-      commit.report,
-      { page: argv.page },
-    )
-    const msgIdsToExec = [request.message.header.messageId]
-    batches.push([commit, batch, msgIdsToExec] as const)
-  }
-  console.info('Got', batches.length, 'batches to execute')
-
   const wallet = (await getWallet(argv)).connect(dest)
-
   const offRampContract = await discoverOffRamp(wallet, firstRequest.lane, {
     fromBlock: destFromBlock,
     page: argv.page,
   })
-
   let nonce = await wallet.getNonce()
-  for (const [i, [commit, batch, msgIdsToExec]] of batches.entries()) {
+
+  let startBlock = destFromBlock
+  let lastBatch:
+    | readonly [CCIPCommit, Omit<CCIPRequest<CCIPVersion>, 'tx' | 'timestamp'>[]]
+    | undefined
+  const txsPending = []
+  for (let i = 0; i < requestsPending.length; ) {
+    let commit, batch
+    if (
+      !lastBatch ||
+      requestsPending[i].message.header.sequenceNumber > lastBatch[0].report.maxSeqNr
+    ) {
+      commit = await fetchCommitReport(dest, requestsPending[i], {
+        startBlock,
+        page: argv.page,
+      })
+      startBlock = commit.log.blockNumber + 1
+
+      batch = await fetchAllMessagesInBatch(
+        source,
+        requestsPending[i].lane.destChainSelector,
+        requestsPending[i].log,
+        commit.report,
+        { page: argv.page },
+      )
+      lastBatch = [commit, batch]
+    } else {
+      ;[commit, batch] = lastBatch
+    }
+
+    const msgIdsToExec = [] as string[]
+    while (
+      i < requestsPending.length &&
+      requestsPending[i].message.header.sequenceNumber <= commit.report.maxSeqNr &&
+      msgIdsToExec.length < MAX_EXECS_IN_BATCH
+    ) {
+      msgIdsToExec.push(requestsPending[i++].message.header.messageId)
+    }
+
     const manualExecReport = calculateManualExecProof(
       batch.map(({ message }) => message),
       firstRequest.lane,
@@ -527,8 +535,15 @@ export async function manualExecSenderQueue(
       )
     }
 
+    const toExec = requestsPending[i - 1] // log only request data for last msg in msgIdsToExec
     console.log(
-      `[${i + 1} of ${batches.length}, ${batch.length} msgs]`,
+      `🚀 [${i}/${requestsPending.length}, ${batch.length} batch, ${msgIdsToExec.length} to exec]`,
+      'source tx =',
+      toExec.log.transactionHash,
+      'msgId =',
+      toExec.message.header.messageId,
+      'nonce =',
+      toExec.message.header.nonce,
       'manualExec tx =',
       manualExecTx.hash,
       'to =',
@@ -536,5 +551,16 @@ export async function manualExecSenderQueue(
       'gasLimit =',
       manualExecTx.gasLimit,
     )
+    txsPending.push(manualExecTx)
+    if (txsPending.length >= MAX_PENDING_TXS) {
+      console.debug(
+        'awaiting',
+        txsPending.length,
+        'txs:',
+        txsPending.map((tx) => tx.hash),
+      )
+      await txsPending[txsPending.length - 1].wait()
+      txsPending.length = 0
+    }
   }
 }


### PR DESCRIPTION
`manualExec --sender-queue` should be used with `--gas-limit`, due to being hard/impossible to predict gas precisely for pending state