### PR TITLE
feat(sdk): add getMessagesInRange for block/slot-based CCIP message d…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- SDK: Add `getMessagesInRange()` to the abstract Chain class — range-based CCIP message discovery using `getLogs` + `decodeMessage`, returns `AsyncIterableIterator<CCIPRequest>`
+
 ## [1.6.0] - 2026-05-06
 
 - SDK: `Solana` support for `estimateReceiveExecution` method, to simulate receiver execution and `computeUnits` estimation
@@ -40,7 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SDK: add `CCIPAPIClient.searchMessages` with filters and cursor-based pagination, `searchAllMessages` async generator for automatic pagination, and `AbortSignal` support on all API methods
 - SDK: `Chain.estimateReceiveExecution` can now take a `messageId` and try to fetch messages details from API
 - SDK: `Chain.generateUnsignedExecute` and `execute` automatically try to `estimateReceiveExecution` if supported by dest chain and no `gasLimit` override is provided
-- CLI: add `--wallet hardhat:<name>` and  `--wallet foundry:<name>` keystore support for EVM
+- CLI: add `--wallet hardhat:<name>` and `--wallet foundry:<name>` keystore support for EVM
 
 ## [1.1.0] - 2026-03-06
 

--- a/ccip-sdk/src/chain.ts
+++ b/ccip-sdk/src/chain.ts
@@ -31,7 +31,7 @@ import type { EstimateMessageInput } from './gas.ts'
 import type { LeafHasher } from './hasher/common.ts'
 import { decodeMessageV1 } from './messages.ts'
 import { getOffchainTokenData } from './offchain.ts'
-import { getMessagesInTx } from './requests.ts'
+import { getMessagesInRange, getMessagesInTx } from './requests.ts'
 import { DEFAULT_GAS_LIMIT } from './shared/constants.ts'
 import type { UnsignedSolanaTx } from './solana/types.ts'
 import type { UnsignedSuiTx } from './sui/types.ts'
@@ -787,6 +787,43 @@ export abstract class Chain<F extends ChainFamily = ChainFamily> {
       }
       throw err
     }
+  }
+
+  /**
+   * Discover and decode CCIP messages within a block/slot/checkpoint range.
+   *
+   * @remarks
+   * This is the range-scanning equivalent of {@link getMessagesInTx}. Results are
+   * yielded in native log order (block number + log index for EVM, slot order for Solana).
+   * Non-CCIP logs in the range are silently skipped.
+   *
+   * On Solana, the `address` parameter is required (router program address).
+   * On EVM, it is optional but recommended for public RPCs that require address filtering.
+   *
+   * @param opts - {@link LogFilter} options (startBlock, endBlock, address, topics, page)
+   * @returns Async iterator of {@link CCIPRequest} objects in native log order
+   * @throws {@link CCIPChainFamilyUnsupportedError} if a pre-v1.6 message is found on a non-EVM chain
+   * @throws {@link CCIPLogsAddressRequiredError} on Solana if `address` is not provided (thrown by underlying {@link Chain.getLogs})
+   *
+   * @see {@link getMessagesInBatch} - Batch discovery by sequence number range
+   *
+   * @example Scan a block range on EVM
+   * ```typescript
+   * for await (const request of chain.getMessagesInRange({
+   *   startBlock: 1000000,
+   *   endBlock: 1001000,
+   *   address: '0xOnRampAddress...', // optional on EVM
+   * })) {
+   *   console.log(`seqNr=${request.message.sequenceNumber} dest=${request.lane.destChainSelector}`)
+   * }
+   * ```
+   *
+   * @see {@link getMessagesInTx} - Per-transaction message discovery
+   */
+  async *getMessagesInRange(
+    opts: Parameters<Chain['getLogs']>[0],
+  ): AsyncIterableIterator<CCIPRequest> {
+    yield* getMessagesInRange(this, opts)
   }
 
   /**

--- a/ccip-sdk/src/evm/errors.ts
+++ b/ccip-sdk/src/evm/errors.ts
@@ -140,7 +140,7 @@ export function recursiveParseError(
     try {
       const obj = data.toObject()
       const keys = Object.keys(obj)
-      // eslint-disable-next-line no-restricted-syntax
+
       if (keys.length > 0 && keys.every((k) => k.startsWith('_'))) throw new Error('not an obj')
       kv = Object.entries(obj).map(([k, v]) => [j(key, k), v])
     } catch {

--- a/ccip-sdk/src/evm/errors.ts
+++ b/ccip-sdk/src/evm/errors.ts
@@ -140,9 +140,11 @@ export function recursiveParseError(
     try {
       const obj = data.toObject()
       const keys = Object.keys(obj)
-
-      if (keys.length > 0 && keys.every((k) => k.startsWith('_'))) throw new Error('not an obj')
-      kv = Object.entries(obj).map(([k, v]) => [j(key, k), v])
+      if (keys.length > 0 && keys.every((k) => k.startsWith('_'))) {
+        kv = data.toArray().map((v, i) => [j(key, `[${i}]`), v])
+      } else {
+        kv = Object.entries(obj).map(([k, v]) => [j(key, k), v])
+      }
     } catch {
       kv = data.toArray().map((v, i) => [j(key, `[${i}]`), v])
     }

--- a/ccip-sdk/src/index.ts
+++ b/ccip-sdk/src/index.ts
@@ -63,7 +63,7 @@ export {
 } from './extra-args.ts'
 export { estimateReceiveExecution } from './gas.ts'
 export { CCTP_FINALITY_FAST, CCTP_FINALITY_STANDARD, getOffchainTokenData } from './offchain.ts'
-export { decodeMessage, sourceToDestTokenAddresses } from './requests.ts'
+export { decodeMessage, getMessagesInRange, sourceToDestTokenAddresses } from './requests.ts'
 export {
   type CCIPExecution,
   type CCIPMessage,

--- a/ccip-sdk/src/requests.test.ts
+++ b/ccip-sdk/src/requests.test.ts
@@ -14,6 +14,7 @@ import {
   decodeMessage,
   getMessageById,
   getMessagesInBatch,
+  getMessagesInRange,
   getMessagesInTx,
 } from './requests.ts'
 import { SolanaChain } from './solana/index.ts'
@@ -509,6 +510,223 @@ describe('getMessagesInBatch', () => {
     assert.equal(calls[1]!.startTime, 0)
     assert.equal(calls[1]!.startBlock, undefined)
     assert.equal(calls[1]!.endBefore, undefined)
+  })
+})
+
+describe('getMessagesInRange', () => {
+  it('should yield CCIP requests from logs', async () => {
+    // Use a fresh local mock chain to avoid state issues from other test suites
+    const localChain = new MockChain()
+    localChain.getLogs.mock.mockImplementation((_opts: LogFilter) =>
+      (async function* () {
+        yield {
+          address: rampAddress,
+          index: 1,
+          topics: [topic0],
+          data: mockedMessage(1),
+          blockNumber: 12000,
+          transactionHash: '0x111',
+          tx: {
+            hash: '0x111',
+            logs: [],
+            blockNumber: 12000,
+            timestamp: 1234567890,
+            from: '0x0000000000000000000000000000000000000001',
+          },
+        } as ChainLog
+        yield {
+          address: rampAddress,
+          index: 2,
+          topics: [topic0],
+          data: { notAMessage: true }, // non-CCIP log
+          blockNumber: 12000,
+          transactionHash: '0x222',
+        } as unknown as ChainLog
+        yield {
+          address: rampAddress,
+          index: 3,
+          topics: [topic0],
+          data: mockedMessage(2),
+          blockNumber: 12001,
+          transactionHash: '0x333',
+          tx: {
+            hash: '0x333',
+            logs: [],
+            blockNumber: 12001,
+            timestamp: 1234567891,
+            from: '0x0000000000000000000000000000000000000002',
+          },
+        } as ChainLog
+      })(),
+    )
+
+    const results: CCIPRequest[] = []
+    for await (const request of getMessagesInRange(localChain as unknown as Chain, {
+      startBlock: 12000,
+      endBlock: 12001,
+      address: rampAddress,
+    })) {
+      results.push(request)
+    }
+
+    // Should yield 2 messages (non-CCIP log skipped)
+    assert.equal(results.length, 2)
+    assert.equal(results[0]!.message.sequenceNumber, 1n)
+    assert.equal(results[1]!.message.sequenceNumber, 2n)
+    // Lane should be constructed
+    assert.equal(results[0]!.lane.onRamp, rampAddress)
+    assert.equal(results[0]!.lane.version, CCIPVersion.V1_2)
+    // getLaneForOnRamp should be called (no destChainSelector in mocked messages)
+    assert.equal(localChain.getLaneForOnRamp.mock.calls.length, 2)
+  })
+
+  it('should resolve lane via typeAndVersion for v1.6+ messages with destChainSelector', async () => {
+    const localChain = new MockChain()
+    localChain.typeAndVersion.mock.mockImplementation(() =>
+      Promise.resolve(['OnRamp', CCIPVersion.V1_6, `OnRamp ${CCIPVersion.V1_6}`]),
+    )
+    // Override decodeMessage to return a message with destChainSelector (v1.6+)
+    MockChain.decodeMessage.mock.mockImplementation(
+      (log: { topics: readonly string[]; data: unknown }): CCIPMessage | undefined => {
+        if (typeof log.data === 'object' && log.data && 'messageId' in log.data) {
+          const d = log.data as Record<string, unknown>
+          return {
+            messageId: d.messageId,
+            sourceChainSelector:
+              d.sourceChainSelector != null
+                ? (d.sourceChainSelector as bigint)
+                : 16015286601757825753n,
+            destChainSelector: d.destChainSelector as bigint, // v1.6+ field
+            sequenceNumber: d.sequenceNumber != null ? (d.sequenceNumber as bigint) : 1n,
+            nonce: 0n,
+            sender: '0x0000000000000000000000000000000000000045',
+            receiver: toBeHex(456, 32),
+            data: '0x',
+            tokenAmounts: [],
+            sourceTokenData: [],
+            gasLimit: 100n,
+            strict: false,
+            feeToken: '0x0000000000000000000000000000000000008916',
+            feeTokenAmount: 0n,
+          } as CCIPMessage
+        }
+        return undefined
+      },
+    )
+    const v16Message = {
+      ...mockedMessage(1),
+      destChainSelector: 4949039107694359620n, // v1.6+ includes destChainSelector
+    }
+    localChain.getLogs.mock.mockImplementation((_opts: LogFilter) =>
+      (async function* () {
+        yield {
+          address: rampAddress,
+          index: 1,
+          topics: [topic0],
+          data: v16Message,
+          blockNumber: 15000,
+          transactionHash: '0xV16Tx',
+          tx: {
+            hash: '0xV16Tx',
+            logs: [],
+            blockNumber: 15000,
+            timestamp: 1234567890,
+            from: '0x0000000000000000000000000000000000000001',
+          },
+        } as ChainLog
+      })(),
+    )
+
+    const results: CCIPRequest[] = []
+    for await (const request of getMessagesInRange(localChain as unknown as Chain, {
+      startBlock: 15000,
+      endBlock: 15000,
+    })) {
+      results.push(request)
+    }
+
+    assert.equal(results.length, 1)
+    // Lane should use typeAndVersion path (not getLaneForOnRamp)
+    assert.equal(localChain.typeAndVersion.mock.calls.length, 1)
+    assert.equal(localChain.getLaneForOnRamp.mock.calls.length, 0)
+    // Lane should have destChainSelector from the message
+    assert.equal(results[0]!.lane.destChainSelector, 4949039107694359620n)
+    assert.equal(results[0]!.lane.version, CCIPVersion.V1_6)
+    assert.equal(results[0]!.lane.onRamp, rampAddress)
+  })
+
+  it('should yield nothing for range with no CCIP messages', async () => {
+    mockedChain.getLogs.mock.mockImplementation((_opts: LogFilter) =>
+      (async function* () {
+        // empty
+      })(),
+    )
+
+    const results: CCIPRequest[] = []
+    for await (const request of getMessagesInRange(mockedChain as unknown as Chain, {
+      startBlock: 12000,
+      endBlock: 12001,
+    })) {
+      results.push(request)
+    }
+
+    assert.equal(results.length, 0)
+  })
+
+  it('should pass default topics and address to getLogs', async () => {
+    mockedChain.getLogs.mock.mockImplementation((_opts: LogFilter) =>
+      (async function* () {
+        // empty
+      })(),
+    )
+
+    for await (const _ of getMessagesInRange(mockedChain as unknown as Chain, {
+      startBlock: 100,
+      endBlock: 200,
+      address: '0xMyOnRamp',
+    })) {
+      // consume
+    }
+
+    assert.equal(mockedChain.getLogs.mock.calls.length, 1)
+    const callArgs = (mockedChain.getLogs.mock.calls[0] as unknown as { arguments: [LogFilter] })
+      .arguments[0]
+    assert.equal(callArgs.startBlock, 100)
+    assert.equal(callArgs.endBlock, 200)
+    assert.equal(callArgs.address, '0xMyOnRamp')
+    assert.deepEqual(callArgs.topics, ['CCIPSendRequested', 'CCIPMessageSent'])
+  })
+
+  it('should fetch transaction when log.tx is not available', async () => {
+    const localChain = new MockChain()
+    localChain.getLogs.mock.mockImplementation((_opts: LogFilter) =>
+      (async function* () {
+        yield {
+          address: rampAddress,
+          index: 1,
+          topics: [topic0],
+          data: mockedMessage(1),
+          blockNumber: 12000,
+          transactionHash: '0xNoTxLog',
+          // no tx field
+        } as ChainLog
+      })(),
+    )
+
+    const results: CCIPRequest[] = []
+    for await (const request of getMessagesInRange(localChain as unknown as Chain, {
+      startBlock: 12000,
+      endBlock: 12000,
+    })) {
+      results.push(request)
+    }
+
+    assert.equal(results.length, 1)
+    // getTransaction should have been called as fallback
+    assert.equal(localChain.getTransaction.mock.calls.length, 1)
+    const txHash = (localChain.getTransaction.mock.calls[0] as unknown as { arguments: [string] })
+      .arguments[0]
+    assert.equal(txHash, '0xNoTxLog')
   })
 })
 

--- a/ccip-sdk/src/requests.ts
+++ b/ccip-sdk/src/requests.ts
@@ -489,7 +489,10 @@ export async function* getMessagesInRange(
 ): AsyncIterableIterator<CCIPRequest> {
   for await (const log of source.getLogs({
     ...opts,
-    topics: opts.topics ?? [...(source.network.family === ChainFamily.EVM ? ['CCIPSendRequested'] : []), 'CCIPMessageSent'],
+    topics: opts.topics ?? [
+      ...(source.network.family === ChainFamily.EVM ? ['CCIPSendRequested'] : []),
+      'CCIPMessageSent',
+    ],
   })) {
     const message = (source.constructor as ChainStatic).decodeMessage(log)
     if (!message) continue

--- a/ccip-sdk/src/requests.ts
+++ b/ccip-sdk/src/requests.ts
@@ -23,6 +23,7 @@ import {
   type CCIPVersion,
   type ChainLog,
   type ChainTransaction,
+  type Lane,
   type MessageInput,
   ChainFamily,
 } from './types.ts'
@@ -209,6 +210,30 @@ export function buildMessageForDest(message: MessageInput, dest: ChainFamily): A
 }
 
 /**
+ * Resolve the lane for a decoded CCIP message.
+ *
+ * Shared helper used by {@link getMessagesInTx}, {@link getMessageById}, and
+ * {@link getMessagesInRange} to build the {@link Lane} from a decoded message and log.
+ *
+ * @internal
+ */
+async function resolveLane(source: Chain, message: CCIPMessage, log: ChainLog): Promise<Lane> {
+  if ('destChainSelector' in message) {
+    const [_, version] = await source.typeAndVersion(log.address)
+    return {
+      sourceChainSelector: message.sourceChainSelector,
+      destChainSelector: message.destChainSelector,
+      onRamp: log.address,
+      version: version as CCIPVersion,
+    }
+  } else if (source.network.family !== ChainFamily.EVM) {
+    throw new CCIPChainFamilyUnsupportedError(source.network.family)
+  } else {
+    return await (source as EVMChain).getLaneForOnRamp(log.address)
+  }
+}
+
+/**
  * Fetch all CCIP messages in a transaction.
  * @param source - Source chain instance
  * @param tx - ChainTransaction to search in
@@ -219,25 +244,11 @@ export function buildMessageForDest(message: MessageInput, dest: ChainFamily): A
  * @see {@link getMessageById} - Search by messageId when tx hash unknown
  */
 export async function getMessagesInTx(source: Chain, tx: ChainTransaction): Promise<CCIPRequest[]> {
-  // RPC fallback
   const requests: CCIPRequest[] = []
   for (const log of tx.logs) {
-    let lane
     const message = (source.constructor as ChainStatic).decodeMessage(log)
     if (!message) continue
-    if ('destChainSelector' in message) {
-      const [_, version] = await source.typeAndVersion(log.address)
-      lane = {
-        sourceChainSelector: message.sourceChainSelector,
-        destChainSelector: message.destChainSelector,
-        onRamp: log.address,
-        version: version as CCIPVersion,
-      }
-    } else if (source.network.family !== ChainFamily.EVM) {
-      throw new CCIPChainFamilyUnsupportedError(source.network.family)
-    } else {
-      lane = await (source as EVMChain).getLaneForOnRamp(log.address)
-    }
+    const lane = await resolveLane(source, message, log)
     requests.push({ lane, message, log, tx })
   }
   if (!requests.length)
@@ -287,25 +298,9 @@ export async function getMessageById(
   })) {
     const message = (source.constructor as ChainStatic).decodeMessage(log)
     if (message?.messageId !== messageId) continue
-    let destChainSelector, version
-    if ('destChainSelector' in message) {
-      destChainSelector = message.destChainSelector
-      ;[, version] = await source.typeAndVersion(log.address)
-    } else {
-      ;({ destChainSelector, version } = await (source as EVMChain).getLaneForOnRamp(log.address))
-    }
+    const lane = await resolveLane(source, message, log)
     const tx = log.tx ?? (await source.getTransaction(log.transactionHash))
-    return {
-      lane: {
-        sourceChainSelector: message.sourceChainSelector,
-        destChainSelector,
-        onRamp: log.address,
-        version: version as CCIPVersion,
-      },
-      message,
-      log,
-      tx,
-    }
+    return { lane, message, log, tx }
   }
   throw new CCIPMessageIdNotFoundError(messageId)
 }
@@ -436,6 +431,72 @@ export async function getMessagesInBatch<
     )
   }
   return entries.map((e) => e.message)
+}
+
+/**
+ * Discover and decode CCIP messages within a block/slot/checkpoint range.
+ *
+ * This is the range-scanning equivalent of {@link getMessagesInTx}. It composes
+ * {@link Chain.getLogs} and {@link ChainStatic.decodeMessage} to yield CCIP requests
+ * in discovery order without requiring transaction hashes upfront.
+ *
+ * Results are yielded in native log order: (blockNumber, logIndex) ascending for EVM,
+ * slot order for Solana. Non-CCIP logs in the range are silently skipped.
+ *
+ * @param source - Source chain to scan logs from
+ * @param opts - {@link LogFilter} options. Key fields:
+ *   - `startBlock` / `endBlock` — block/slot range (endBlock supports `'finalized'` and `'latest'`)
+ *   - `address` — onRamp/router address (optional on EVM, required on Solana)
+ *   - `topics` — defaults to both CCIP message event names
+ *   - `page` — batch size for log pagination
+ * @returns Async iterator of {@link CCIPRequest} objects in native log order
+ *
+ * @throws {@link CCIPChainFamilyUnsupportedError} if a pre-v1.6 message is found on a non-EVM chain
+ * @throws {@link CCIPLogsAddressRequiredError} on Solana if `address` is not provided
+ *
+ * @example EVM — scan a block range for all CCIP messages
+ *
+ * ```typescript
+ * const chain = await EVMChain.fromUrl('https://rpc.sepolia.org')
+ * for await (const request of getMessagesInRange(chain, {
+ *   startBlock: 1000000,
+ *   endBlock: 1001000,
+ *   address: '0xOnRampAddress...', // optional on EVM, but recommended for public RPCs
+ * })) {
+ *   console.log(`seqNr=${request.message.sequenceNumber} dest=${request.lane.destChainSelector}`)
+ * }
+ * ```
+ *
+ * @example Solana — scan a slot range (address required)
+ *
+ * ```typescript
+ * const chain = await SolanaChain.fromUrl('https://api.devnet.solana.com')
+ * for await (const request of getMessagesInRange(chain, {
+ *   startBlock: 450000000,
+ *   endBlock: 450100000,
+ *   address: 'Ccip842gzYHh...', // router program address (required on Solana)
+ * })) {
+ *   console.log(`seqNr=${request.message.sequenceNumber}`)
+ * }
+ * ```
+ *
+ * @see {@link getMessagesInTx} - Per-transaction message discovery
+ * @see {@link getMessagesInBatch} - Batch discovery by sequence number range
+ */
+export async function* getMessagesInRange(
+  source: Chain,
+  opts: LogFilter,
+): AsyncIterableIterator<CCIPRequest> {
+  for await (const log of source.getLogs({
+    ...opts,
+    topics: opts.topics ?? ['CCIPSendRequested', 'CCIPMessageSent'],
+  })) {
+    const message = (source.constructor as ChainStatic).decodeMessage(log)
+    if (!message) continue
+    const lane = await resolveLane(source, message, log)
+    const tx = log.tx ?? (await source.getTransaction(log.transactionHash))
+    yield { lane, message, log, tx }
+  }
 }
 
 /**

--- a/ccip-sdk/src/requests.ts
+++ b/ccip-sdk/src/requests.ts
@@ -489,7 +489,7 @@ export async function* getMessagesInRange(
 ): AsyncIterableIterator<CCIPRequest> {
   for await (const log of source.getLogs({
     ...opts,
-    topics: opts.topics ?? ['CCIPSendRequested', 'CCIPMessageSent'],
+    topics: opts.topics ?? [...(source.network.family === ChainFamily.EVM ? ['CCIPSendRequested'] : []), 'CCIPMessageSent'],
   })) {
     const message = (source.constructor as ChainStatic).decodeMessage(log)
     if (!message) continue


### PR DESCRIPTION
This pull request introduces a new feature for range-based discovery of CCIP messages in the SDK, along with related updates to the CLI and tests. The main addition is the `getMessagesInRange()` method, which enables efficient scanning and decoding of CCIP messages across block/slot ranges. The implementation includes robust test coverage and code refactoring to share lane resolution logic. Additionally, two new Creditcoin networks are added to the chain selectors.

### CCIP Message Discovery Enhancements

* Added the `getMessagesInRange()` method to the abstract `Chain` class and exported it from the SDK, enabling range-based CCIP message discovery using `getLogs` and `decodeMessage`. This returns an `AsyncIterableIterator<CCIPRequest>` and is documented for both EVM and Solana chains. (`ccip-sdk/src/chain.ts`, `ccip-sdk/src/requests.ts`, `ccip-sdk/src/index.ts`, `CHANGELOG.md`) [[1]](diffhunk://#diff-807a4ca9474665a0a92dd38d0c7b802fa323550a99ef0c98a2ae754be2cd8838R718-R754) [[2]](diffhunk://#diff-b81ef54d709010c60e65f5bef6259dd146094d6f2c05ecaac273c1742f96e767R391-R456) [[3]](diffhunk://#diff-3d28b72ab4b737c2170709dc1a546750455bb7c3e9147e1b23b21158999d6efaL60-R60) [[4]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR11)
* Introduced a shared `resolveLane` helper to unify lane resolution logic for decoded messages, reducing code duplication in message discovery functions. (`ccip-sdk/src/requests.ts`) [[1]](diffhunk://#diff-b81ef54d709010c60e65f5bef6259dd146094d6f2c05ecaac273c1742f96e767R204-R227) [[2]](diffhunk://#diff-b81ef54d709010c60e65f5bef6259dd146094d6f2c05ecaac273c1742f96e767L214-R243) [[3]](diffhunk://#diff-b81ef54d709010c60e65f5bef6259dd146094d6f2c05ecaac273c1742f96e767L279-R292)

### Testing Improvements

* Added comprehensive tests for `getMessagesInRange`, covering correct message extraction, lane resolution for different CCIP versions, log filtering, transaction fallback, and empty results. (`ccip-sdk/src/requests.test.ts`)

### Chain Selector Updates

* Added Creditcoin mainnet and testnet to the chain selectors. (`ccip-sdk/src/selectors.ts`)

### Minor/Other Changes

* Updated SDK and CLI version strings to reflect the new build. (`ccip-sdk/src/api/index.ts`, `ccip-cli/src/index.ts`) [[1]](diffhunk://#diff-5f48bbf823c493f0440756f358944ddb3701689533062df8cc5f540175d7db9aL63-R63) [[2]](diffhunk://#diff-d031752a3dc854d38b0b2f7ba015c3d626d241205c336dfe5e0821d4656bff05L14-R14)
* Minor code style and import adjustments for maintainability. (`ccip-sdk/src/evm/errors.ts`, `ccip-sdk/src/requests.ts`) [[1]](diffhunk://#diff-0d03cad19a7111895ec1b19a47d2d242dc179cc8171ec45d6b0a649c72ef1282L143-R143) [[2]](diffhunk://#diff-b81ef54d709010c60e65f5bef6259dd146094d6f2c05ecaac273c1742f96e767L4-R4) [[3]](diffhunk://#diff-b81ef54d709010c60e65f5bef6259dd146094d6f2c05ecaac273c1742f96e767R24)

These changes collectively improve the SDK's ability to discover and process CCIP messages across block ranges, making it easier to build tools that require historical or batch message analysis.