### PR TITLE
fix: graceful fallback when dest RPC is unavailable in show command

### DIFF
--- a/ccip-cli/src/commands/show.ts
+++ b/ccip-cli/src/commands/show.ts
@@ -214,7 +214,19 @@ export async function showRequests(ctx: Ctx, argv: Parameters<typeof handler>[0]
       output.write('Commit (dest):')
   })()
 
-  const dest = await getChain(request.lane.destChainSelector)
+  let dest: Chain | undefined
+  try {
+    dest = await getChain(request.lane.destChainSelector)
+  } catch (err) {
+    logger.debug(
+      'No dest RPC available for',
+      request.lane.destChainSelector,
+      '— emitting partial result:',
+      err,
+    )
+    emitJsonEnvelope()
+    return
+  }
 
   let execs$, cancelWaitVerifications: (() => void) | undefined, verifications$
   if (request.metadata?.receiptTransactionHash) {

--- a/ccip-cli/src/index.ts
+++ b/ccip-cli/src/index.ts
@@ -25,7 +25,7 @@ import { Format } from './commands/index.ts'
 util.inspect.defaultOptions.depth = 6 // print down to tokenAmounts in requests
 // generate:nofail
 // `const VERSION = '${require('./package.json').version}-${require('child_process').execSync('git rev-parse --short HEAD').toString().trim()}'`
-const VERSION = '1.4.2-f874d03'
+const VERSION = '1.4.2-81f6baf'
 // generate:end
 
 const require = createRequire(import.meta.url)

--- a/ccip-cli/src/providers/index.ts
+++ b/ccip-cli/src/providers/index.ts
@@ -164,9 +164,11 @@ export function fetchChainsFromRpcs(
     const c = (chains[network.name] = new Promise((resolve, reject) => {
       chainsCbs[network.name] = [resolve, reject]
     }))
-    void c.finally(() => {
-      delete chainsCbs[network.name] // when chain is settled, delete the callbacks
-    })
+    void c
+      .finally(() => {
+        delete chainsCbs[network.name] // when chain is settled, delete the callbacks
+      })
+      .catch(() => {}) // rejection already handled by chainGetter caller
     void loadChainFamily(network.family)
     return c
   }

--- a/ccip-sdk/src/api/index.ts
+++ b/ccip-sdk/src/api/index.ts
@@ -60,7 +60,7 @@ export const DEFAULT_TIMEOUT_MS = 30000
 /** SDK version string for telemetry header */
 // generate:nofail
 // `export const SDK_VERSION = '${require('./package.json').version}-${require('child_process').execSync('git rev-parse --short HEAD').toString().trim()}'`
-export const SDK_VERSION = '1.4.2-f874d03'
+export const SDK_VERSION = '1.4.2-81f6baf'
 // generate:end
 
 /** SDK telemetry header name */

--- a/package-lock.json
+++ b/package-lock.json
@@ -18923,20 +18923,6 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "license": "MIT"
     },
-    "node_modules/jayson/node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "extraneous": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
-    },
     "node_modules/jayson/node_modules/uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -29794,20 +29780,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10"
-      }
-    },
-    "node_modules/webpack-bundle-analyzer/node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "extraneous": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
       }
     },
     "node_modules/webpack-bundle-analyzer/node_modules/ws": {


### PR DESCRIPTION
This pull request focuses on improving error handling and robustness in the chain-fetching logic, as well as updating version strings across the CLI and SDK. The most significant change is the addition of a try/catch block to handle missing destination RPCs gracefully in the `showRequests` command, ensuring the CLI emits a partial result instead of failing. There are also minor improvements to promise rejection handling and version string updates.

Error handling and robustness improvements:

* Added a try/catch block around the destination chain fetch in `showRequests` to handle cases where the destination RPC is unavailable, logging the issue and emitting a partial result instead of crashing.
* Added a `.catch(() => {})` after a promise's `.finally()` in `fetchChainsFromRpcs` to suppress unhandled promise rejection warnings, since errors are already handled by the caller.

Version updates:

* Updated the CLI version string to `1.4.2-81f6baf` in `ccip-cli/src/index.ts`.
* Updated the SDK version string to `1.4.2-81f6baf` in `ccip-sdk/src/api/index.ts`.