### PR TITLE
fix error data propagation viem adapter

### DIFF
--- a/ccip-sdk/src/evm/fork.test.ts
+++ b/ccip-sdk/src/evm/fork.test.ts
@@ -5,6 +5,7 @@ import { after, before, describe, it } from 'node:test'
 
 import { AbiCoder, Contract, JsonRpcProvider, Wallet, keccak256, parseUnits, toBeHex } from 'ethers'
 import { Instance } from 'prool'
+import { createPublicClient, http } from 'viem'
 
 import '../aptos/index.ts' // register Aptos chain family for cross-family message decoding
 import '../ton/index.ts' // register TON chain family for cross-family message decoding
@@ -16,6 +17,7 @@ import { type ExecutionInput, ExecutionState, MessageStatus, NetworkType } from 
 import { interfaces } from './const.ts'
 import { FUJI_TO_SEPOLIA, SEPOLIA_TO_FUJI, TON_TO_SEPOLIA } from './fork.test.data.ts'
 import { EVMChain } from './index.ts'
+import { ViemTransportProvider } from './viem/client-adapter.ts'
 
 // ── Chain constants ──
 
@@ -1502,6 +1504,146 @@ describe('EVM Fork Tests', { skip, timeout: 180_000 }, () => {
       assert.equal(execution.receipt.state, ExecutionState.Success)
 
       sepoliaWithApi.destroy?.()
+    })
+  })
+
+  describe('ViemTransportProvider — revert data forwarding', () => {
+    // Triggers a real pool-capacity revert through the viem adapter and asserts the
+    // SDK's error-decoding machinery recovers the custom error name + args.
+    // Pre-fix (before Patch B): `ViemTransportProvider._send` drops viem's error.data;
+    // `EVMChain.parse(err)` only sees the calldata selector and returns `method: "ccipSend"`
+    // with no `revert` key.
+    // Post-fix: the walk preserves error.data; `parseWithFragment` matches the selector
+    // against the pool ABI and returns `TokenMaxCapacityExceeded` with decoded args.
+    // BigInt-safe JSON stringifier — `parsed` contains decoded revert args as bigints.
+    const stringifyParsed = (v: unknown): string =>
+      JSON.stringify(v, (_, val) => (typeof val === 'bigint' ? val.toString() : val))
+
+    // Reads the pool's current outbound capacity through the SDK and returns 10× it, so
+    // the post-fee amount still exceeds capacity regardless of the pool's transfer-fee
+    // config. The pool deducts a percentage fee BEFORE the rate-limit check, so sending
+    // exactly `capacity + 1` underflows capacity after the fee and is accepted. Keeps
+    // the test dynamic across rate-limit reconfigs on the upstream pool.
+    const overCapacityAmount = async (): Promise<bigint> => {
+      assert.ok(sepoliaChain, 'sepolia chain should be initialized for capacity probe')
+      const features = await sepoliaChain.getLaneFeatures({
+        router: SEPOLIA_V2_0_ROUTER,
+        destChainSelector: FUJI_SELECTOR,
+        token: FTF_TOKEN_SEPOLIA,
+      })
+      const rateLimits = features[LaneFeature.RATE_LIMITS]
+      assert.ok(rateLimits?.capacity, 'pool must have rate-limit capacity configured')
+      return rateLimits.capacity * 10n + 1n
+    }
+
+    // Each test in this block submits real txs through a dedicated `EVMChain` instance
+    // so nonce caches start empty and re-fetch from the fork. The shared `sepoliaChain`
+    // used elsewhere in the suite holds cached nonces from prior tests, which become
+    // stale once other chains on the same fork consume nonces for this wallet.
+
+    it('decodes TokenMaxCapacityExceeded custom error on pool-capacity revert', async () => {
+      assert.ok(sepoliaInstance, 'sepolia anvil should be running')
+      const anvilUrl = `http://${sepoliaInstance.host}:${sepoliaInstance.port}`
+      const walletAddress = await wallet.getAddress()
+
+      // Amount = 10× pool's outbound capacity (see overCapacityAmount). Dynamic so the
+      // test survives rate-limit reconfig upstream. `sendMessage` handles approve internally.
+      const oversizedAmount = await overCapacityAmount()
+      const ethersProvider = wallet.provider as JsonRpcProvider
+      await setERC20Balance(ethersProvider, FTF_TOKEN_SEPOLIA, walletAddress, oversizedAmount)
+
+      // Build a viem PublicClient pointed at the same Anvil fork, wrap with
+      // ViemTransportProvider, and bind a Wallet to it. Every RPC call
+      // (estimateGas, eth_call, eth_sendTransaction) now flows through the adapter.
+      const viemClient = createPublicClient({
+        chain: { id: SEPOLIA_CHAIN_ID, name: 'Sepolia Fork' } as never,
+        transport: http(anvilUrl),
+      })
+      const viemProvider = new ViemTransportProvider(viemClient as never)
+      const viemWallet = new Wallet(ANVIL_PRIVATE_KEY, viemProvider)
+      const viemChain = await EVMChain.fromProvider(viemProvider, {
+        apiClient: null,
+        logger: testLogger,
+      })
+
+      let caught: unknown
+      try {
+        await viemChain.sendMessage({
+          router: SEPOLIA_V2_0_ROUTER,
+          destChainSelector: FUJI_SELECTOR,
+          message: {
+            receiver: walletAddress,
+            tokenAmounts: [{ token: FTF_TOKEN_SEPOLIA, amount: oversizedAmount }],
+            extraArgs: { gasLimit: 0n },
+          },
+          wallet: viemWallet,
+        })
+      } catch (err) {
+        caught = err
+      }
+
+      assert.ok(caught, 'sendMessage should throw on over-capacity amount')
+
+      const parsed = EVMChain.parse(caught)
+      assert.ok(parsed, 'EVMChain.parse should return a decoded envelope')
+
+      const flat = stringifyParsed(parsed)
+      assert.match(
+        flat,
+        /TokenMaxCapacityExceeded/,
+        `viem-adapter path should surface the decoded custom error name. Parsed: ${flat}`,
+      )
+
+      viemChain.destroy?.()
+    })
+
+    // Cross-check: same over-capacity send via the ethers-direct chain (sepoliaChain)
+    // must produce an equivalent decoded output. Proves the viem adapter achieves
+    // functional parity with the ethers-direct baseline.
+    it('produces equivalent decoded output on ethers-direct path', async () => {
+      assert.ok(sepoliaInstance, 'sepolia anvil should be running')
+      const anvilUrl = `http://${sepoliaInstance.host}:${sepoliaInstance.port}`
+      const walletAddress = await wallet.getAddress()
+
+      const oversizedAmount = await overCapacityAmount()
+      const ethersProvider = wallet.provider as JsonRpcProvider
+      await setERC20Balance(ethersProvider, FTF_TOKEN_SEPOLIA, walletAddress, oversizedAmount)
+
+      // Dedicated EVMChain for this test (see describe-block preamble).
+      const ethersChainLocal = await EVMChain.fromProvider(new JsonRpcProvider(anvilUrl), {
+        apiClient: null,
+        logger: testLogger,
+      })
+      const ethersWalletLocal = new Wallet(ANVIL_PRIVATE_KEY, ethersChainLocal.provider)
+
+      let caught: unknown
+      try {
+        await ethersChainLocal.sendMessage({
+          router: SEPOLIA_V2_0_ROUTER,
+          destChainSelector: FUJI_SELECTOR,
+          message: {
+            receiver: walletAddress,
+            tokenAmounts: [{ token: FTF_TOKEN_SEPOLIA, amount: oversizedAmount }],
+            extraArgs: { gasLimit: 0n },
+          },
+          wallet: ethersWalletLocal,
+        })
+      } catch (err) {
+        caught = err
+      }
+
+      assert.ok(caught, 'sendMessage should throw on oversized amount (ethers-direct)')
+      const parsed = EVMChain.parse(caught)
+      assert.ok(parsed, 'EVMChain.parse should decode the revert on ethers-direct path')
+
+      const flat = stringifyParsed(parsed)
+      assert.match(
+        flat,
+        /TokenMaxCapacityExceeded/,
+        `ethers-direct path should surface the decoded custom error name. Parsed: ${flat}`,
+      )
+
+      ethersChainLocal.destroy?.()
     })
   })
 })

--- a/ccip-sdk/src/evm/viem/client-adapter.ts
+++ b/ccip-sdk/src/evm/viem/client-adapter.ts
@@ -5,7 +5,7 @@ import {
   JsonRpcApiProvider,
   Network,
 } from 'ethers'
-import type { Chain, PublicClient, Transport } from 'viem'
+import { type Chain, type PublicClient, type Transport, BaseError } from 'viem'
 
 import type { ChainContext } from '../../chain.ts'
 import { CCIPViemAdapterError } from '../../errors/index.ts'
@@ -52,9 +52,48 @@ export class ViemTransportProvider extends JsonRpcApiProvider {
           })
           return { id: p.id, result }
         } catch (error) {
+          // Preserve revert data through the viem→ethers bridge. viem throws a `BaseError`
+          // tree where one of the nodes carries the revert payload (`ContractFunctionRevertedError.raw`,
+          // `RpcRequestError.data`, `CallExecutionError.cause.data`). Stringifying via
+          // `String(error)` discards it; ethers' downstream `getErrorData`/`parseData` then
+          // can't decode the custom error. We walk the chain for the first node with a
+          // `data` field (same pattern viem's own `getContractError` uses) and forward its
+          // hex payload in the JSON-RPC error envelope.
+          let data: `0x${string}` | undefined
+          let message = String(error)
+
+          if (error instanceof BaseError) {
+            const node = error.walk((e) => e !== null && typeof e === 'object' && 'data' in e) as {
+              raw?: unknown
+              data?: unknown
+            } | null
+
+            // Prefer `.raw` (ContractFunctionRevertedError's raw revert bytes) over `.data`,
+            // because `.data` on that class is structured (decoded) while on RpcRequestError
+            // it's the raw hex we want.
+            const candidate = typeof node?.raw === 'string' ? node.raw : node?.data
+            if (
+              typeof candidate === 'string' &&
+              candidate.startsWith('0x') &&
+              candidate.length > 2
+            ) {
+              data = candidate as `0x${string}`
+            }
+
+            message = error.shortMessage
+          }
+
           return {
             id: p.id,
-            error: { code: -32000, message: String(error) },
+            error: {
+              // Use EIP-1474 execution-reverted code when we successfully extracted revert
+              // bytes — matches viem's own `EXECUTION_REVERTED_ERROR_CODE = 3` convention
+              // and satisfies ethers' `spelunkData` heuristic for `/revert/i`-containing
+              // messages paired with hex data.
+              code: data ? 3 : -32000,
+              message,
+              ...(data ? { data } : {}),
+            },
           }
         }
       }),


### PR DESCRIPTION
This pull request enhances the error-handling path for EVM chain interactions in the SDK, particularly when using the Viem transport provider. The main focus is to ensure that revert data from failed contract calls is preserved and correctly decoded, achieving parity between the Viem-based and ethers.js-based providers. It also adds comprehensive tests to verify this behavior.

**Error handling and data preservation improvements:**

* Updated `ViemTransportProvider` in `client-adapter.ts` to walk the Viem error chain and extract revert data, forwarding it in the JSON-RPC error envelope. This enables downstream decoding of custom errors, such as `TokenMaxCapacityExceeded`, by the SDK.
* Improved error message handling by preferring `.raw` revert bytes when available, and using the EIP-1474 execution-reverted error code when revert data is present.

**Testing and validation:**

* Added a new test suite in `fork.test.ts` that sends over-capacity transactions through both the Viem and ethers.js providers, asserting that the SDK decodes and surfaces custom errors identically in both cases. This ensures functional parity and robustness of the error decoding logic.
* Imported Viem client and transport provider in `fork.test.ts` to support the new test cases. [[1]](diffhunk://#diff-951371c0af67892627ef98d0745d3bf7260c57d65d83d22a84b666e13a1bb913R8) [[2]](diffhunk://#diff-951371c0af67892627ef98d0745d3bf7260c57d65d83d22a84b666e13a1bb913R20)
* Included Viem's `BaseError` in the adapter for improved error introspection.