### PR TITLE
fix: wrap execute.estimateGas in try/catch on v2 manual-exec

### DIFF
--- a/ccip-sdk/src/evm/index.ts
+++ b/ccip-sdk/src/evm/index.ts
@@ -1470,18 +1470,25 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
         verifierResults,
         gasLimitOverride,
       )
-      // `execute()` swallows inner failures on first-exec (state=FAILURE, no revert),
-      // so `estimateGas` can measure the catch path. Floor at `message.executionGasLimit`
-      // + 20% to cover that case.
-      const estimated = await contract.execute.estimateGas(
-        input.encodedMessage,
-        ccvs,
-        verifierResults,
-        gasLimitOverride,
-      )
-      const declaredBudget = BigInt(message.executionGasLimit)
-      const bufferedFloor = (declaredBudget * 120n) / 100n
-      execTx.gasLimit = estimated > bufferedFloor ? estimated : bufferedFloor
+      // `execute()` swallows inner failures on first-exec; floor at executionGasLimit*1.2.
+      // On estimateGas failure, leave gasLimit unset and still return the tx so wallets
+      // can run their own estimation and surface the native revert reason (mirrors v1.x below).
+      try {
+        const estimated = await contract.execute.estimateGas(
+          input.encodedMessage,
+          ccvs,
+          verifierResults,
+          gasLimitOverride,
+        )
+        const declaredBudget = BigInt(message.executionGasLimit)
+        const bufferedFloor = (declaredBudget * 120n) / 100n
+        execTx.gasLimit = estimated > bufferedFloor ? estimated : bufferedFloor
+      } catch (err) {
+        this.logger.warn(
+          'Gas estimation for execute failed, returning tx without gasLimit. Error:',
+          err,
+        )
+      }
       return { family: ChainFamily.EVM, transactions: [execTx] }
     }
 


### PR DESCRIPTION
This pull request improves the robustness of gas estimation in the `EVMChain` class by handling failures during the estimation process. If gas estimation fails (for example, due to a `NoStateProgressMade` error), the code now returns the transaction without a `gasLimit`, allowing downstream tools like wallets to perform their own estimation and provide better error feedback to users.

Gas estimation error handling:

* Wrapped the gas estimation logic in a `try-catch` block in `EVMChain`, so that on estimation failure, the transaction is returned without a `gasLimit`, and a warning is logged. This mirrors the behavior of the v1.x branch and improves compatibility with external tools and wallets. [[1]](diffhunk://#diff-cae1d5fb496ff335e72129fb79782365f7f977991d0e3cdb2f7bc062f2e060ceL1475-R1479) [[2]](diffhunk://#diff-cae1d5fb496ff335e72129fb79782365f7f977991d0e3cdb2f7bc062f2e060ceR1489-R1494)