### PR TITLE
nit: accept empty string for feeToken in evm

### DIFF
--- a/ccip-sdk/src/evm/index.ts
+++ b/ccip-sdk/src/evm/index.ts
@@ -1051,7 +1051,7 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
       receiver: encodeAddressToEvm(populatedMessage.receiver),
       data: hexlify(populatedMessage.data ?? '0x'),
       tokenAmounts: populatedMessage.tokenAmounts ?? [],
-      feeToken: populatedMessage.feeToken ?? ZeroAddress,
+      feeToken: populatedMessage.feeToken || ZeroAddress,
       extraArgs: hexlify(
         (this.constructor as typeof EVMChain).encodeExtraArgs(populatedMessage.extraArgs),
       ),
@@ -1334,7 +1334,7 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
       fee: opts.message.fee ?? (await this.getFee({ ...opts, message: populatedMessage })),
     }
 
-    const feeToken = message.feeToken ?? ZeroAddress
+    const feeToken = message.feeToken || ZeroAddress
     const receiver = encodeAddressToEvm(message.receiver)
     const data = hexlify(message.data ?? '0x')
     const extraArgs = hexlify(


### PR DESCRIPTION
## Summary

  Align `EVMChain.feeToken` handling with the rest of the SDK's chain families (Solana/Aptos/TON) by replacing `??` with `||` in the two EVM sites that default `feeToken` to `ZeroAddress`.

  **Why:** `??` fires only on `null | undefined`, so `feeToken: ''` reached ethers unchanged — where `checkAddress('')` interpreted it as an ENS name and reverted with `UNCONFIGURED_NAME`. Every other chain family in the SDK already uses a
  falsy-check (truthy-ternary on Solana/TON, `||` on Aptos), so an adapter passing `feeToken: ''` as a "native" sentinel worked on 4 of 5 chains and failed only on EVM with a confusing error.

  `||` makes EVM treat the empty string the same as `undefined` → use `ZeroAddress` (native), matching the rest of the SDK.

  ## Changes

  Two one-character edits in `ccip-sdk/src/evm/index.ts`:

  - `:1054` — inside `getFee(...)`, building the `Router.getFee` call.
  - `:1337` — inside `generateUnsignedSendMessage`, driving approve + send logic.

  ```diff
  - feeToken: populatedMessage.feeToken ?? ZeroAddress,
  + feeToken: populatedMessage.feeToken || ZeroAddress,
  - const feeToken = message.feeToken ?? ZeroAddress
  + const feeToken = message.feeToken || ZeroAddress

  Behavior change

  Exactly one input changes: feeToken === ''.

  ┌─────────────────────┬─────────────────────────────────────┬──────────────────────┐
  │        Input        │               Before                │        After         │
  ├─────────────────────┼─────────────────────────────────────┼──────────────────────┤
  │ undefined / omitted │ ZeroAddress (native)                │ ZeroAddress (native) │
  ├─────────────────────┼─────────────────────────────────────┼──────────────────────┤
  │ '0xabc…'            │ '0xabc…'                            │ '0xabc…'             │
  ├─────────────────────┼─────────────────────────────────────┼──────────────────────┤
  │ ''                  │ '' → ethers UNCONFIGURED_NAME error │ ZeroAddress (native) │
  └─────────────────────┴─────────────────────────────────────┴──────────────────────┘

  No other falsy strings exist in JS (only ''), so no other inputs are affected.