### PR TITLE
fix get-supported-tokens when given a PriceRegistry

### DIFF
--- a/ccip-cli/src/commands/supported-tokens.ts
+++ b/ccip-cli/src/commands/supported-tokens.ts
@@ -124,7 +124,11 @@ async function getSupportedTokens(ctx: Ctx, argv: Parameters<typeof handler>[0])
   let jsonFeeTokens: unknown
 
   // Handle --fee-tokens flag
-  if (argv.feeTokens === true || argv.onlyFeeTokens || (argv.feeTokens == null && registry)) {
+  if (
+    argv.feeTokens === true ||
+    argv.onlyFeeTokens ||
+    (argv.feeTokens == null && registry && !argv.token)
+  ) {
     const feeTokens: Record<string, TokenInfo & { price?: number }> = await source.getFeeTokens(
       argv.address,
     )

--- a/ccip-sdk/src/evm/const.ts
+++ b/ccip-sdk/src/evm/const.ts
@@ -35,6 +35,7 @@ const customErrors = [
   'error InvalidAdapter()',
   'error BlacklistableBlacklistedAccount(address)',
   'error WrongAsset(address expected, address received)',
+  'error FailedInnerCall()',
 ] as const
 
 export const VersionedContractABI = parseAbi(['function typeAndVersion() view returns (string)'])

--- a/ccip-sdk/src/evm/index.ts
+++ b/ccip-sdk/src/evm/index.ts
@@ -1,6 +1,5 @@
 import {
   type BytesLike,
-  type Interface,
   type JsonRpcApiProvider,
   type Log,
   type Result,
@@ -1966,49 +1965,40 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
    * @throws {@link CCIPVersionUnsupportedError} if OnRamp version is not supported
    */
   async getFeeTokens(address: string) {
-    const onRamp = await this._getSomeOnRampFor(address)
-    const [_, version] = await this.typeAndVersion(onRamp)
     let tokens
-    let onRampIface: Interface | undefined
-    switch (version) {
-      case CCIPVersion.V1_2:
-        onRampIface = interfaces.EVM2EVMOnRamp_v1_2
-      // falls through
-      case CCIPVersion.V1_5: {
-        onRampIface ??= interfaces.EVM2EVMOnRamp_v1_5
-        const fragment = onRampIface.getEvent('FeeConfigSet')!
-        const tokens_ = new Set()
-        for await (const log of this.getLogs({
-          address: onRamp,
-          topics: [fragment.topicHash],
-          startBlock: 1,
-          onlyFallback: true,
-        })) {
-          ;(
-            onRampIface.decodeEventLog(fragment, log.data, log.topics) as unknown as {
-              feeConfig: { token: string; enabled: boolean }[]
-            }
-          ).feeConfig.forEach(({ token, enabled }) =>
-            enabled ? tokens_.add(token) : tokens_.delete(token),
-          )
+    const [type, version] = await this.typeAndVersion(address)
+
+    if (type.endsWith('OnRamp') && version < CCIPVersion.V1_6) {
+      // TODO: cleanup this branch once CCIP v1.5 is deprecated
+      const onRampIface =
+        version === CCIPVersion.V1_2 ? interfaces.EVM2EVMOnRamp_v1_2 : interfaces.EVM2EVMOnRamp_v1_5
+      const fragment = onRampIface.getEvent('FeeConfigSet')!
+      const tokens_ = new Set()
+      for await (const log of this.getLogs({
+        address,
+        topics: [fragment.topicHash],
+        startBlock: 1,
+        onlyFallback: true,
+      })) {
+        const decoded = onRampIface.decodeEventLog(fragment, log.data, log.topics) as unknown as {
+          feeConfig: { token: string; enabled: boolean }[]
+        } | null
+        for (const { token, enabled } of decoded?.feeConfig ?? []) {
+          if (enabled) tokens_.add(token)
+          else tokens_.delete(token)
         }
-        tokens = Array.from(tokens_)
-        break
       }
-      case CCIPVersion.V1_6:
-      case CCIPVersion.V2_0: {
-        const feeQuoter = await this.getFeeQuoterFor(onRamp)
-        const contract = new Contract(
-          feeQuoter,
-          interfaces.FeeQuoter,
-          this.provider,
-        ) as unknown as TypedContract<typeof FeeQuoter_ABI>
-        tokens = await contract.getFeeTokens()
-        break
-      }
-      default:
-        throw new CCIPVersionUnsupportedError(version)
+      tokens = Array.from(tokens_)
+    } else {
+      const feeQuoter = await this.getFeeQuoterFor(address)
+      const contract = new Contract(
+        feeQuoter,
+        interfaces.FeeQuoter,
+        this.provider,
+      ) as unknown as TypedContract<typeof FeeQuoter_ABI>
+      tokens = await contract.getFeeTokens()
     }
+
     return Object.fromEntries(
       await Promise.all(
         tokens.map(

--- a/ccip-sdk/src/evm/index.ts
+++ b/ccip-sdk/src/evm/index.ts
@@ -375,7 +375,7 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
 
   /** {@inheritDoc Chain.getLogs} */
   async *getLogs(
-    filter: SetFieldType<LogFilter, 'endBlock', EVMEndBlockTag> & { onlyFallback?: boolean },
+    filter: SetFieldType<LogFilter, 'endBlock', EVMEndBlockTag>,
   ): AsyncIterableIterator<Log> {
     if (filter.watch instanceof Promise)
       filter = { ...filter, watch: Promise.race([filter.watch, this.destroy$]) }
@@ -1965,39 +1965,13 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
    * @throws {@link CCIPVersionUnsupportedError} if OnRamp version is not supported
    */
   async getFeeTokens(address: string) {
-    let tokens
-    const [type, version] = await this.typeAndVersion(address)
-
-    if (type.endsWith('OnRamp') && version < CCIPVersion.V1_6) {
-      // TODO: cleanup this branch once CCIP v1.5 is deprecated
-      const onRampIface =
-        version === CCIPVersion.V1_2 ? interfaces.EVM2EVMOnRamp_v1_2 : interfaces.EVM2EVMOnRamp_v1_5
-      const fragment = onRampIface.getEvent('FeeConfigSet')!
-      const tokens_ = new Set()
-      for await (const log of this.getLogs({
-        address,
-        topics: [fragment.topicHash],
-        startBlock: 1,
-        onlyFallback: true,
-      })) {
-        const decoded = onRampIface.decodeEventLog(fragment, log.data, log.topics) as unknown as {
-          feeConfig: { token: string; enabled: boolean }[]
-        } | null
-        for (const { token, enabled } of decoded?.feeConfig ?? []) {
-          if (enabled) tokens_.add(token)
-          else tokens_.delete(token)
-        }
-      }
-      tokens = Array.from(tokens_)
-    } else {
-      const feeQuoter = await this.getFeeQuoterFor(address)
-      const contract = new Contract(
-        feeQuoter,
-        interfaces.FeeQuoter,
-        this.provider,
-      ) as unknown as TypedContract<typeof FeeQuoter_ABI>
-      tokens = await contract.getFeeTokens()
-    }
+    const feeQuoter = await this.getFeeQuoterFor(address)
+    const contract = new Contract(
+      feeQuoter,
+      interfaces.FeeQuoter,
+      this.provider,
+    ) as unknown as TypedContract<typeof FeeQuoter_ABI>
+    const tokens = await contract.getFeeTokens()
 
     return Object.fromEntries(
       await Promise.all(
@@ -2083,7 +2057,6 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
           null,
           messageId ?? null,
         ],
-        // onlyFallback: false,
       }
     } else /* >= V1.6 */ {
       const topicHash =
@@ -2098,7 +2071,6 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
           null,
           messageId ?? null,
         ],
-        // onlyFallback: false,
       }
     }
     yield* super.getExecutionReceipts(opts_)

--- a/ccip-sdk/src/evm/logs.ts
+++ b/ccip-sdk/src/evm/logs.ts
@@ -1,197 +1,29 @@
-import {
-  type JsonRpcApiProvider,
-  type Log,
-  FetchRequest,
-  JsonRpcProvider,
-  isHexString,
-} from 'ethers'
-import { memoize } from 'micro-memoize'
+import { type JsonRpcApiProvider, type Log, isHexString } from 'ethers'
 import type { SetFieldType } from 'type-fest'
 
 import type { LogFilter } from '../chain.ts'
 import {
   CCIPLogTopicsNotFoundError,
-  CCIPLogsAddressRequiredError,
-  CCIPLogsNotFoundError,
   CCIPLogsRequiresStartError,
   CCIPLogsWatchRequiresFinalityError,
-  CCIPRpcNotFoundError,
 } from '../errors/index.ts'
 import type { FinalityRequested } from '../extra-args.ts'
 import { blockRangeGenerator, getSomeBlockNumberBefore } from '../utils.ts'
 import { getAllFragmentsMatchingEvents } from './const.ts'
 import type { WithLogger } from '../types.ts'
 
-const MAX_PARALLEL_JOBS = 24
-const PER_REQUEST_TIMEOUT = 5000
 /** Tags or values which can be used as `endBlock` in {@link EVMChain.getLogs} filter */
 export type EVMEndBlockTag = FinalityRequested | 'latest'
-
-const getFallbackRpcsList = memoize(
-  async () => {
-    const response = await fetch('https://chainlist.org/rpcs.json')
-    const data = await response.json()
-    return data as {
-      chainId: number
-      rpc: { url: string }[]
-      explorers: { url: string }[]
-    }[]
-  },
-  { async: true },
-)
-
-// like Promise.any, but receives Promise factories and spawn a maximum number of them in parallel
-function anyPromiseMax<T>(
-  promises: readonly (() => Promise<T>)[],
-  maxParallelJobs: number,
-  cancel?: Promise<unknown>,
-): Promise<T> {
-  return new Promise((resolve, reject) => {
-    const errors: unknown[] = new Array(promises.length)
-    let index = 0
-    let inFlight = 0
-    let completed = 0
-
-    if (promises.length === 0) {
-      reject(new AggregateError([], 'All promises were rejected'))
-      return
-    }
-    let cancelled = false
-    void cancel?.finally(() => {
-      cancelled = true
-    })
-
-    const startNext = () => {
-      while (!cancelled && inFlight < maxParallelJobs && index < promises.length) {
-        const currentIndex = index++
-        inFlight++
-
-        void promises[currentIndex]!()
-          .then(resolve)
-          .catch((error) => {
-            errors[currentIndex] = error
-            completed++
-            inFlight--
-
-            if (completed === promises.length) {
-              reject(new AggregateError(errors, 'All promises were rejected'))
-            } else {
-              startNext()
-            }
-          })
-      }
-    }
-
-    startNext()
-  })
-}
-
-// cache
-const archiveRpcs: Record<number, Promise<JsonRpcApiProvider>> = {}
-
-/**
- * Like provider.getLogs, but from a public list of archive nodes and wide range, races the first to reply
- * @param chainId - The chain ID of the network to query
- * @param filter - Log filter options
- * @param destroy$ - An optional promise that, when resolved, cancels the requests
- * @returns Array of Logs
- */
-async function getFallbackArchiveLogs(
-  chainId: number,
-  filter: {
-    address: string
-    topics: (string | string[] | null)[]
-    startBlock: number
-    endBlock?: EVMEndBlockTag
-  },
-  { logger = console, destroy$ }: { destroy$?: Promise<unknown> } & WithLogger = {},
-) {
-  const provider = archiveRpcs[chainId]
-  if (provider != null) {
-    return (await provider).getLogs({
-      ...filter,
-      fromBlock: filter.startBlock,
-      toBlock: filter.endBlock || 'latest',
-    })
-  }
-  let cancel!: (_?: unknown) => void
-  let cancel$ = new Promise<unknown>((resolve) => (cancel = resolve))
-  if (destroy$) cancel$ = Promise.race([destroy$, cancel$])
-
-  let winner: string | undefined
-  const providerLogs$ = getFallbackRpcsList()
-    .then((rpcs) => {
-      const rpc = rpcs.find(({ chainId: id }) => id === chainId)
-      if (!rpc) throw new CCIPRpcNotFoundError(chainId)
-      return Array.from(
-        new Set(rpc.rpc.map(({ url }) => url).filter((url) => url.match(/^https?:\/\//))),
-      )
-    })
-    .then((urls) =>
-      anyPromiseMax(
-        urls.map((url) => async () => {
-          const fetchReq = new FetchRequest(url)
-          fetchReq.timeout = PER_REQUEST_TIMEOUT
-          const provider = new JsonRpcProvider(fetchReq, chainId)
-          void cancel$.finally(() => {
-            if (url === winner) return
-            provider.destroy()
-            try {
-              fetchReq.cancel()
-            } catch (_) {
-              // ignore
-            }
-          })
-          return [
-            provider,
-            await provider
-              .getLogs({
-                ...filter,
-                fromBlock: filter.startBlock,
-                toBlock: filter.endBlock || 'latest',
-              })
-              .then((logs) => {
-                if (!logs.length) throw new CCIPLogsNotFoundError(filter)
-                logger.debug(
-                  'getFallbackArchiveLogs raced',
-                  url,
-                  'from',
-                  urls.length,
-                  'urls, got',
-                  logs.length,
-                  'logs for',
-                  filter,
-                )
-                winner ??= url
-                cancel()
-                return logs
-              }),
-          ] as const // return both winner provider and logs
-        }),
-        MAX_PARALLEL_JOBS,
-        cancel$,
-      ),
-    )
-    .finally(cancel)
-  archiveRpcs[chainId] = providerLogs$.then(([provider]) => provider) // cache provider
-  archiveRpcs[chainId].catch(() => {
-    delete archiveRpcs[chainId]
-  })
-  return providerLogs$.then(([, logs]) => logs) // return logs
-}
 
 /**
  * Implements Chain.getLogs for EVM.
  * Walks logs forward from `startBlock` or `startTime`; if neither is provided, throws.
- * @param filter - Chain LogFilter. The `onlyFallback` option controls pagination behavior:
- *   - If undefined (default): paginate main provider only by filter.page
- *   - If false: first try whole range with main provider, then fallback to archive provider
- *   - If true: don't paginate (throw if can't fetch wide range from either provider)
+ * @param filter - Chain LogFilter
  * @param ctx - Context object containing provider, logger and destroy$ notify promise
  * @returns Async iterator of logs.
  */
 export async function* getEvmLogs(
-  filter: SetFieldType<LogFilter, 'endBlock', EVMEndBlockTag> & { onlyFallback?: boolean },
+  filter: SetFieldType<LogFilter, 'endBlock', EVMEndBlockTag>,
   ctx: { provider: JsonRpcApiProvider; destroy$?: Promise<unknown> } & WithLogger,
 ): AsyncIterableIterator<Log> {
   const { provider, logger = console } = ctx
@@ -226,42 +58,12 @@ export async function* getEvmLogs(
       ctx,
     )
   }
-  filter.startBlock = Math.max(0, filter.startBlock!)
-  const startBlock = filter.startBlock
-  if (filter.onlyFallback != null) {
-    if (!filter.address || !filter.topics?.length) throw new CCIPLogsAddressRequiredError()
-    let logs
-    try {
-      logs = await provider.getLogs({
-        ...filter,
-        fromBlock: startBlock,
-        toBlock: endBlock,
-      })
-    } catch (_) {
-      try {
-        logs = await getFallbackArchiveLogs(
-          Number((await provider.getNetwork()).chainId),
-          {
-            address: filter.address,
-            topics: filter.topics,
-            startBlock,
-            endBlock,
-          },
-          ctx,
-        )
-      } catch (err) {
-        if (filter.onlyFallback === true) throw err
-      }
-    }
-    if (logs) {
-      yield* logs
-      return
-    }
-  }
-
-  let latestLogBlockNumber = startBlock
-  // paginate only if filter.onlyFallback isn't true
-  for (const blockRange of blockRangeGenerator({ ...filter, startBlock, endBlock })) {
+  let latestLogBlockNumber = filter.startBlock!
+  for (const blockRange of blockRangeGenerator({
+    ...filter,
+    startBlock: filter.startBlock!,
+    endBlock,
+  })) {
     const filter_ = {
       ...blockRange,
       ...(filter.address ? { address: filter.address } : {}),


### PR DESCRIPTION
- use PriceRegistry v1.2 `getFeeTokens` for v1.5 OnRamps fetching
- Allows passing PriceRegistry address to `get-supported-tokens` command
- cleanup bunch of fallback RPCs and code from EVM which were needed only for v1.5 `getFeeTokens`