### PR TITLE
refactor: replace destroy promises with AbortSignal

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-min-release-age=10
+min-release-age=12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- SDK: `Solana` support for `estimateReceiveExecution`
+## [1.6.0] - 2026-05-06
+
+- SDK: `Solana` support for `estimateReceiveExecution` method, to simulate receiver execution and `computeUnits` estimation
 - CLI: Solana-dest support for `<send|manual-exec> --estimate-gas=<%margin> [--only-estimate]`
+- SDK: Chains `ctx` construction parameter may receive `abort: AbortSignal` for disconnect and cancellation of inflight requests; `Chain.abort` property exposes a signal connected to it, and is aborted when `destroy()` is called
 
 ## [1.5.0] - 2026-04-22
 

--- a/ccip-cli/package.json
+++ b/ccip-cli/package.json
@@ -53,7 +53,7 @@
     "@chainlink/ccip-sdk": "^1.6.0",
     "@coral-xyz/anchor": "^0.29.0",
     "@ethers-ext/signer-ledger": "^6.0.0-beta.1",
-    "@inquirer/prompts": "8.4.1",
+    "@inquirer/prompts": "8.4.2",
     "@ledgerhq/hw-app-aptos": "6.37.0",
     "@ledgerhq/hw-app-solana": "7.9.0",
     "@ledgerhq/hw-transport-node-hid": "6.32.0",

--- a/ccip-cli/src/commands/getCtx.test.ts
+++ b/ccip-cli/src/commands/getCtx.test.ts
@@ -108,7 +108,7 @@ describe('getCtx', () => {
     it('returns a working destroy function', async () => {
       const [ctx, destroy] = getCtx({})
       let resolved = false
-      ctx.destroy$.then(() => {
+      ctx.abort.addEventListener('abort', () => {
         resolved = true
       })
       destroy()

--- a/ccip-cli/src/commands/lane-latency.test.ts
+++ b/ccip-cli/src/commands/lane-latency.test.ts
@@ -47,7 +47,7 @@ describe('lane-latency command', () => {
   }
 
   const createCtx = (): Ctx => ({
-    destroy$: Promise.resolve(),
+    abort: new AbortController().signal,
     output: mockOutput,
     logger: mockLogger,
   })

--- a/ccip-cli/src/commands/search/messages.test.ts
+++ b/ccip-cli/src/commands/search/messages.test.ts
@@ -60,7 +60,7 @@ describe('search messages command', () => {
   }
 
   const createCtx = (): Ctx => ({
-    destroy$: Promise.resolve(),
+    abort: new AbortController().signal,
     output: mockOutput,
     logger: mockLogger,
   })

--- a/ccip-cli/src/commands/search/messages.ts
+++ b/ccip-cli/src/commands/search/messages.ts
@@ -129,9 +129,8 @@ export async function searchMessages(ctx: Ctx, argv: Parameters<typeof handler>[
   }
   const limit = requestedLimit === 0 ? Infinity : requestedLimit
 
-  // Wire abort signal from destroy$ for cancellation
   const ac = new AbortController()
-  ctx.destroy$.then(() => ac.abort()).catch(() => {})
+  ctx.abort.addEventListener('abort', () => ac.abort(), { once: true })
 
   let warned = false
   const results: MessageSearchResult[] = []

--- a/ccip-cli/src/commands/show.ts
+++ b/ccip-cli/src/commands/show.ts
@@ -209,9 +209,11 @@ export async function showRequests(ctx: Ctx, argv: Parameters<typeof handler>[0]
   const finalized$ = (async () => {
     if (argv.wait) {
       logger.info(`[${MessageStatus.Sent}] Waiting for source chain finalization...`)
+      const finalizedAc = new AbortController()
+      cancelWaitFinalized = finalizedAc.abort.bind(finalizedAc)
       await source.waitFinalized({
         request,
-        cancel$: new Promise<void>((resolve) => (cancelWaitFinalized = resolve)),
+        abort: finalizedAc.signal,
       })
       logger.info(`[${MessageStatus.SourceFinalized}] Source chain finalized`)
     }
@@ -238,7 +240,11 @@ export async function showRequests(ctx: Ctx, argv: Parameters<typeof handler>[0]
 
     if (argv.wait)
       logger.info(`[${MessageStatus.SourceFinalized}] Waiting for commit on destination chain...`)
-    else if (!request.metadata?.receiptTransactionHash && argv.format !== Format.json)
+    else if (
+      !request.metadata?.receiptTransactionHash &&
+      argv.format !== Format.json &&
+      !ctx.abort.aborted
+    )
       output.write('Commit (dest):')
   })()
 
@@ -253,7 +259,7 @@ export async function showRequests(ctx: Ctx, argv: Parameters<typeof handler>[0]
       err,
     )
     emitJsonEnvelope()
-    return
+    throw err
   }
 
   let execs$, cancelWaitVerifications: (() => void) | undefined, verifications$
@@ -275,12 +281,18 @@ export async function showRequests(ctx: Ctx, argv: Parameters<typeof handler>[0]
   } else {
     offRamp ??= await discoverOffRamp(source, dest, request.lane.onRamp, source)
 
+    let watch
+    if (argv.wait) {
+      const ac = new AbortController()
+      watch = ac.signal
+      cancelWaitVerifications = ac.abort.bind(ac)
+    }
     verifications$ = (async () => {
       const verifications = await dest.getVerifications({
         offRamp,
         request,
         ...argv,
-        watch: argv.wait && new Promise<void>((resolve) => (cancelWaitVerifications = resolve)),
+        watch,
       })
       cancelWaitFinalized?.()
       await finalized$
@@ -312,7 +324,7 @@ export async function showRequests(ctx: Ctx, argv: Parameters<typeof handler>[0]
       sourceChainSelector: request.message.sourceChainSelector,
       startTime: request.tx.timestamp,
       verifications: !argv.wait ? await verifications$ : undefined,
-      watch: argv.wait && ctx.destroy$,
+      watch: argv.wait && ctx.abort,
     })
   }
 

--- a/ccip-cli/src/commands/types.ts
+++ b/ccip-cli/src/commands/types.ts
@@ -17,7 +17,7 @@ export type Format = (typeof Format)[keyof typeof Format]
  * - `logger` writes to stderr — used for status, progress, warnings, errors, debug.
  */
 export type Ctx = {
-  destroy$: Promise<unknown>
+  abort: AbortSignal
   /** Write data to stdout. */
   output: {
     /** Console.log to stdout — supports multiple args with util.inspect formatting. */

--- a/ccip-cli/src/commands/utils.test.ts
+++ b/ccip-cli/src/commands/utils.test.ts
@@ -7,7 +7,7 @@ import {
   CCIPUsdcAttestationError,
 } from '@chainlink/ccip-sdk/src/index.ts'
 
-import { formatCCIPError } from './utils.ts'
+import { formatCCIPError, yieldResolved } from './utils.ts'
 
 describe('formatCCIPError', () => {
   it('should return null for non-CCIPError instances', () => {
@@ -87,5 +87,23 @@ describe('formatCCIPError', () => {
 
     assert.ok(formatted)
     assert.doesNotMatch(formatted, /Stack trace:/)
+  })
+})
+
+describe('yieldResolved', () => {
+  it('throws if a promise rejects while the generator is paused after a yield', async () => {
+    const err = new Error('late failure')
+    let rejectLater!: (err: Error) => void
+    const lateReject = new Promise<number>((_, reject) => {
+      rejectLater = reject
+    })
+
+    const gen = yieldResolved([Promise.resolve(1), lateReject])
+    assert.deepEqual(await gen.next(), { value: 1, done: false })
+
+    rejectLater(err)
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    await assert.rejects(gen.next(), err)
   })
 })

--- a/ccip-cli/src/commands/utils.ts
+++ b/ccip-cli/src/commands/utils.ts
@@ -631,15 +631,53 @@ export async function parseTokenAmounts(source: Chain, transferTokens: readonly 
  * Yield resolved promises (like Promise.all), but as they resolve.
  * Throws as soon as any promise rejects.
  *
- * @param promises - Promises to resolve
+ * @param promises - Promises to resolve (can be an array or a generator)
  * @returns Resolved values as they resolve
  **/
-export async function* yieldResolved<T>(promises: readonly Promise<T>[]): AsyncGenerator<T> {
-  const map = new Map(promises.map((p) => [p, p.then((res) => [p, res] as const)] as const))
-  while (map.size > 0) {
-    const [p, res] = await Promise.race(map.values())
-    map.delete(p)
-    yield res
+export async function* yieldResolved<T>(promises: Iterable<Promise<T>>): AsyncGenerator<T> {
+  const queue: T[] = []
+  let resolve: (() => void) | null = null
+  let reject: ((err: unknown) => void) | null = null
+  let remaining = 0
+  let done = false
+
+  try {
+    for (const p of promises) {
+      remaining++
+      p.then(
+        (value) => {
+          if (done) return
+          queue.push(value)
+          resolve?.()
+          resolve = null
+        },
+        (err) => {
+          if (done) return
+          reject?.(err)
+          reject = null
+        },
+      )
+    }
+
+    while (remaining > 0) {
+      if (queue.length === 0) {
+        await new Promise<void>((res, rej) => {
+          resolve = res
+          reject = rej
+        })
+        resolve = null
+        reject = null
+      }
+      while (queue.length > 0) {
+        remaining--
+        yield queue.shift()!
+      }
+    }
+  } finally {
+    done = true
+    resolve = null
+    reject = null
+    queue.length = 0
   }
 }
 
@@ -651,11 +689,12 @@ export async function* yieldResolved<T>(promises: readonly Promise<T>[]): AsyncG
  * - `logger.info/warn/error/debug` → stderr (status/diagnostics)
  *
  * @param argv - yargs argv containing verbose flag
- * @returns context object with destroy$ signal, output, and logger
+ * @returns context object with abort signal, output, and logger
  */
-export function getCtx(argv: { verbose?: boolean }): [ctx: Ctx, destroy: () => void] {
-  let destroy
-  const destroy$ = new Promise<void>((resolve) => (destroy = resolve))
+export function getCtx(argv: {
+  verbose?: boolean
+}): [ctx: Ctx, destroy: (reason?: unknown) => void] {
+  const ac = new AbortController()
 
   // Logger: always stderr
   const stderrConsole = new Console(process.stderr, process.stderr, true)
@@ -675,5 +714,5 @@ export function getCtx(argv: { verbose?: boolean }): [ctx: Ctx, destroy: () => v
 
   if (argv.verbose) logger.debug('Verbose mode enabled')
 
-  return [{ destroy$, output, logger, verbose: argv.verbose }, destroy!]
+  return [{ abort: ac.signal, output, logger, verbose: argv.verbose }, ac.abort.bind(ac)]
 }

--- a/ccip-cli/src/commands/utils.ts
+++ b/ccip-cli/src/commands/utils.ts
@@ -635,9 +635,8 @@ export async function parseTokenAmounts(source: Chain, transferTokens: readonly 
  * @returns Resolved values as they resolve
  **/
 export async function* yieldResolved<T>(promises: Iterable<Promise<T>>): AsyncGenerator<T> {
-  const queue: T[] = []
+  const queue: ({ ok: true; value: T } | { ok: false; err: unknown })[] = []
   let resolve: (() => void) | null = null
-  let reject: ((err: unknown) => void) | null = null
   let remaining = 0
   let done = false
 
@@ -647,36 +646,36 @@ export async function* yieldResolved<T>(promises: Iterable<Promise<T>>): AsyncGe
       p.then(
         (value) => {
           if (done) return
-          queue.push(value)
+          queue.push({ ok: true, value })
           resolve?.()
           resolve = null
         },
         (err) => {
           if (done) return
-          reject?.(err)
-          reject = null
+          queue.push({ ok: false, err })
+          resolve?.()
+          resolve = null
         },
       )
     }
 
     while (remaining > 0) {
       if (queue.length === 0) {
-        await new Promise<void>((res, rej) => {
+        await new Promise<void>((res) => {
           resolve = res
-          reject = rej
         })
         resolve = null
-        reject = null
       }
       while (queue.length > 0) {
+        const result = queue.shift()!
         remaining--
-        yield queue.shift()!
+        if (!result.ok) throw result.err
+        yield result.value
       }
     }
   } finally {
     done = true
     resolve = null
-    reject = null
     queue.length = 0
   }
 }

--- a/ccip-cli/src/index.ts
+++ b/ccip-cli/src/index.ts
@@ -26,7 +26,7 @@ import { Format } from './commands/index.ts'
 util.inspect.defaultOptions.depth = 6 // print down to tokenAmounts in requests
 // generate:nofail
 // `const VERSION = '${require('./package.json').version}-${require('child_process').execSync('git rev-parse --short HEAD').toString().trim()}'`
-const VERSION = '1.6.0-8f8d5b94'
+const VERSION = '1.6.0-faa7467f'
 // generate:end
 
 const require = createRequire(import.meta.url)

--- a/ccip-cli/src/index.ts
+++ b/ccip-cli/src/index.ts
@@ -13,6 +13,7 @@ console.info = stderrConsole.info.bind(stderrConsole)
 
 import { realpathSync } from 'fs'
 import { createRequire } from 'module'
+import https from 'node:https'
 import util from 'node:util'
 import { pathToFileURL } from 'url'
 
@@ -159,8 +160,9 @@ if (import.meta.main || wasCalledAsScript()) {
     })
     .finally(() => {
       clearTimeout(later)
+      https.globalAgent.destroy() // cleanup kept-alive sockets
       setTimeout(() => {
-        util.inspect.defaultOptions.depth = 2
+        util.inspect.defaultOptions.depth = 3
         console.debug(
           'Pending handles after main completion:',
           (process as any)._getActiveHandles().length, // eslint-disable-line

--- a/ccip-cli/src/providers/index.test.ts
+++ b/ccip-cli/src/providers/index.test.ts
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import {
+  type ChainTransaction,
+  CCIPTransactionNotFoundError,
+  ChainFamily,
+  networkInfo,
+  supportedChains,
+} from '@chainlink/ccip-sdk/src/index.ts'
+
+import { fetchChainsFromRpcs } from './index.ts'
+import type { Ctx } from '../commands/index.ts'
+
+describe('fetchChainsFromRpcs', () => {
+  it('lets duplicate tx-hash race endpoints query before aborting losers', async () => {
+    const originalEvm = supportedChains[ChainFamily.EVM]
+    const attempts: string[] = []
+    const aborts: string[] = []
+    const txHash = '0x'.padEnd(66, '1')
+
+    class FakeEvmChain {
+      static family = ChainFamily.EVM
+      static isTxHash = () => true
+
+      network = networkInfo('ethereum-testnet-sepolia')
+      url = ''
+
+      constructor(url: string) {
+        this.url = url
+      }
+
+      static async fromUrl(url: string, ctx?: { abort?: AbortSignal }) {
+        ctx?.abort?.addEventListener('abort', () => aborts.push(url), { once: true })
+        await new Promise((resolve) => setTimeout(resolve, url.includes('first') ? 0 : 10))
+        return new FakeEvmChain(url)
+      }
+
+      async getTransaction(hash: string): Promise<ChainTransaction> {
+        attempts.push(this.url)
+        if (!this.url.includes('second')) throw new CCIPTransactionNotFoundError(hash)
+        return {
+          hash,
+          logs: [],
+          blockNumber: 1,
+          timestamp: 1,
+          from: '0x0000000000000000000000000000000000000000',
+        }
+      }
+    }
+
+    const ac = new AbortController()
+    const ctx: Ctx = {
+      abort: ac.signal,
+      output: { write: () => {}, table: () => {} },
+      logger: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} },
+    }
+
+    try {
+      supportedChains[ChainFamily.EVM] = FakeEvmChain as never
+
+      const [, tx$] = fetchChainsFromRpcs(
+        ctx,
+        { rpcs: ['http://first.example', 'http://second.example'], rpcsFile: '', api: false },
+        txHash,
+      )
+
+      const [chain, tx] = await tx$
+      assert.equal((chain as unknown as FakeEvmChain).url, 'http://second.example')
+      assert.equal(tx.hash, txHash)
+      assert.deepEqual(attempts, ['http://first.example', 'http://second.example'])
+    } finally {
+      supportedChains[ChainFamily.EVM] = originalEvm
+      ac.abort()
+    }
+
+    assert.ok(aborts.includes('http://first.example'))
+  })
+})

--- a/ccip-cli/src/providers/index.test.ts
+++ b/ccip-cli/src/providers/index.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from 'node:test'
 
 import {
   type ChainTransaction,
+  CCIPRpcNotFoundError,
   CCIPTransactionNotFoundError,
   ChainFamily,
   networkInfo,
@@ -12,9 +13,137 @@ import {
 import { fetchChainsFromRpcs } from './index.ts'
 import type { Ctx } from '../commands/index.ts'
 
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+const delay = (ms: number) => new Promise<void>((r) => setTimeout(r, ms))
+
+const TX_HASH = '0x' + '1'.repeat(64)
+const FAKE_TX: ChainTransaction = {
+  hash: TX_HASH,
+  logs: [],
+  blockNumber: 1,
+  timestamp: 1,
+  from: '0x' + '0'.repeat(40),
+}
+
+/**
+ * Temporarily replaces the entire supportedChains registry with the provided
+ * fakes and returns a restore callback for use in finally blocks.
+ *
+ * Without this, Object.values(supportedChains).filter(C =\> C.isTxHash(...))
+ * inside fetchChainsFromRpcs picks up every real family whose isTxHash matches
+ * (APTOS, CANTON, SUI, TON all claim EVM-format hashes), causing their real
+ * fromUrl implementations to race against our fakes with live network I/O.
+ */
+function setupSupportedChains(fakes: Record<string, unknown>): () => void {
+  const sc = supportedChains as Record<string, unknown>
+  const saved = Object.fromEntries(Object.entries(sc))
+  for (const key of Object.keys(saved)) delete sc[key]
+  Object.assign(sc, fakes)
+  return () => {
+    for (const key of Object.keys(sc)) delete sc[key]
+    Object.assign(sc, saved)
+  }
+}
+
+function makeCtx(): [Ctx, AbortController] {
+  const ac = new AbortController()
+  return [
+    {
+      abort: ac.signal,
+      output: { write: () => {}, table: () => {} },
+      logger: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} },
+    },
+    ac,
+  ]
+}
+
+/**
+ * Builds a configurable fake chain class whose per-URL behaviour is
+ * controlled by callback parameters, and returns it alongside a stats
+ * object that records connections, destructions and getTransaction calls.
+ *
+ * The returned `FakeChain` must be assigned to `supportedChains[family]`
+ * (cast `as never`) inside a try/finally that restores the original.
+ */
+function makeChainClass({
+  family,
+  networkName,
+  connectDelay = () => 0,
+  connectReject = () => false,
+  getTx = () => 'notfound' as 'found' | 'notfound',
+  txDelay = () => 0,
+}: {
+  family: ChainFamily
+  networkName: string
+  /** Milliseconds before fromUrl resolves for a given url. */
+  connectDelay?: (url: string) => number
+  /** If true for a url, fromUrl rejects instead of resolving. */
+  connectReject?: (url: string) => boolean
+  /** Whether getTransaction succeeds ('found') or throws ('notfound'). */
+  getTx?: (url: string) => 'found' | 'notfound'
+  /** Extra delay (ms) before getTransaction settles. */
+  txDelay?: (url: string) => number
+}) {
+  const stats = {
+    connected: [] as string[],
+    /** Urls whose destroy() was called (deduplicated to first call). */
+    destroyed: [] as string[],
+    txAttempted: [] as string[],
+  }
+
+  class FakeChain {
+    static family = family
+    static isTxHash = () => true
+
+    network = networkInfo(networkName)
+    url: string
+    private _ac = new AbortController()
+    abort = this._ac.signal
+    destroy: () => void
+
+    constructor(url: string) {
+      this.url = url
+      this.destroy = () => {
+        if (!this._ac.signal.aborted) stats.destroyed.push(url)
+        this._ac.abort()
+      }
+    }
+
+    static async fromUrl(url: string, opts?: { abort?: AbortSignal }) {
+      const ms = connectDelay(url)
+      if (ms > 0) await delay(ms)
+      if (connectReject(url)) throw new Error(`connection refused: ${url}`)
+      const chain = new FakeChain(url)
+      opts?.abort?.addEventListener('abort', () => chain.destroy(), { once: true })
+      stats.connected.push(url)
+      return chain
+    }
+
+    async getTransaction(hash: string): Promise<ChainTransaction> {
+      stats.txAttempted.push(this.url)
+      const ms = txDelay(this.url)
+      if (ms > 0) await delay(ms)
+      if (getTx(this.url) === 'notfound') throw new CCIPTransactionNotFoundError(hash)
+      return FAKE_TX
+    }
+  }
+
+  return { FakeChain: FakeChain as never, stats }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
 describe('fetchChainsFromRpcs', () => {
+  // -------------------------------------------------------------------------
+  // Existing regression test (kept verbatim aside from the abort/destroy fix)
+  // -------------------------------------------------------------------------
+
   it('lets duplicate tx-hash race endpoints query before aborting losers', async () => {
-    const originalEvm = supportedChains[ChainFamily.EVM]
     const attempts: string[] = []
     const aborts: string[] = []
     const txHash = '0x'.padEnd(66, '1')
@@ -25,6 +154,9 @@ describe('fetchChainsFromRpcs', () => {
 
       network = networkInfo('ethereum-testnet-sepolia')
       url = ''
+      private _ac = new AbortController()
+      abort = this._ac.signal
+      destroy = () => this._ac.abort()
 
       constructor(url: string) {
         this.url = url
@@ -33,7 +165,9 @@ describe('fetchChainsFromRpcs', () => {
       static async fromUrl(url: string, ctx?: { abort?: AbortSignal }) {
         ctx?.abort?.addEventListener('abort', () => aborts.push(url), { once: true })
         await new Promise((resolve) => setTimeout(resolve, url.includes('first') ? 0 : 10))
-        return new FakeEvmChain(url)
+        const chain = new FakeEvmChain(url)
+        ctx?.abort?.addEventListener('abort', () => chain.destroy(), { once: true })
+        return chain
       }
 
       async getTransaction(hash: string): Promise<ChainTransaction> {
@@ -55,10 +189,8 @@ describe('fetchChainsFromRpcs', () => {
       output: { write: () => {}, table: () => {} },
       logger: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} },
     }
-
+    const restore = setupSupportedChains({ [ChainFamily.EVM]: FakeEvmChain as never })
     try {
-      supportedChains[ChainFamily.EVM] = FakeEvmChain as never
-
       const [, tx$] = fetchChainsFromRpcs(
         ctx,
         { rpcs: ['http://first.example', 'http://second.example'], rpcsFile: '', api: false },
@@ -70,10 +202,337 @@ describe('fetchChainsFromRpcs', () => {
       assert.equal(tx.hash, txHash)
       assert.deepEqual(attempts, ['http://first.example', 'http://second.example'])
     } finally {
-      supportedChains[ChainFamily.EVM] = originalEvm
+      restore()
       ac.abort()
     }
 
     assert.ok(aborts.includes('http://first.example'))
+  })
+
+  // -------------------------------------------------------------------------
+  // chainGetter — no txHash
+  // -------------------------------------------------------------------------
+
+  it('chainGetter: returns chain from first winning endpoint and destroys late arrivals', async () => {
+    // fast.example wins the network race (Branch 1); slow.example arrives
+    // afterwards and gets chain.destroy() via the !txHash branch.
+    const { FakeChain, stats } = makeChainClass({
+      family: ChainFamily.EVM,
+      networkName: 'ethereum-testnet-sepolia',
+      connectDelay: (url) => (url.includes('slow') ? 30 : 0),
+    })
+    const restore = setupSupportedChains({ [ChainFamily.EVM]: FakeChain })
+    const [ctx, ac] = makeCtx()
+    try {
+      const chainGetter = fetchChainsFromRpcs(ctx, {
+        rpcs: ['http://fast.example', 'http://slow.example'],
+        rpcsFile: '',
+        api: false,
+      })
+      const chain = await chainGetter('ethereum-testnet-sepolia')
+      assert.equal(chain.network.name, 'ethereum-testnet-sepolia')
+      assert.equal((chain as unknown as { url: string }).url, 'http://fast.example')
+      // Give slow.example time to connect and be discarded
+      await delay(50)
+      assert.ok(
+        stats.destroyed.includes('http://slow.example'),
+        'loser is eagerly destroyed via !txHash branch',
+      )
+    } finally {
+      restore()
+      ac.abort()
+    }
+  })
+
+  it('chainGetter: resolves a pending request once the endpoint connects (Branch 2)', async () => {
+    // chainGetter is called before any chain has connected, creating a pending
+    // entry in pendingChainsCbs. The chain resolves it via Branch 2.
+    const { FakeChain, stats } = makeChainClass({
+      family: ChainFamily.EVM,
+      networkName: 'ethereum-testnet-sepolia',
+      connectDelay: () => 20,
+    })
+    const restore = setupSupportedChains({ [ChainFamily.EVM]: FakeChain })
+    const [ctx, ac] = makeCtx()
+    try {
+      const chainGetter = fetchChainsFromRpcs(ctx, {
+        rpcs: ['http://rpc.example'],
+        rpcsFile: '',
+        api: false,
+      })
+      // Called synchronously — no chain has connected yet
+      const chainPromise = chainGetter('ethereum-testnet-sepolia')
+      assert.equal(stats.connected.length, 0, 'not connected at call time')
+      const chain = await chainPromise
+      assert.equal(stats.connected.length, 1, 'connected after await')
+      assert.equal(chain.network.name, 'ethereum-testnet-sepolia')
+    } finally {
+      restore()
+      ac.abort()
+    }
+  })
+
+  it('chainGetter: rejects with CCIPRpcNotFoundError when all endpoints fail to connect', async () => {
+    const { FakeChain } = makeChainClass({
+      family: ChainFamily.EVM,
+      networkName: 'ethereum-testnet-sepolia',
+      connectReject: () => true,
+    })
+    const restore = setupSupportedChains({ [ChainFamily.EVM]: FakeChain })
+    const [ctx, ac] = makeCtx()
+    try {
+      const chainGetter = fetchChainsFromRpcs(ctx, {
+        rpcs: ['http://bad1.example', 'http://bad2.example'],
+        rpcsFile: '',
+        api: false,
+      })
+      await assert.rejects(chainGetter('ethereum-testnet-sepolia'), CCIPRpcNotFoundError)
+    } finally {
+      restore()
+      ac.abort()
+    }
+  })
+
+  it('chainGetter: rejects immediately with CCIPRpcNotFoundError once family is already exhausted', async () => {
+    // After the first call exhausts the endpoint set and sets finished[F]=true,
+    // a second call should hit the fast-path without making any new connections.
+    const { FakeChain, stats } = makeChainClass({
+      family: ChainFamily.EVM,
+      networkName: 'ethereum-testnet-sepolia',
+      connectReject: () => true,
+    })
+    const restore = setupSupportedChains({ [ChainFamily.EVM]: FakeChain })
+    const [ctx, ac] = makeCtx()
+    try {
+      const chainGetter = fetchChainsFromRpcs(ctx, {
+        rpcs: ['http://bad.example'],
+        rpcsFile: '',
+        api: false,
+      })
+      // First call drains the family
+      await assert.rejects(chainGetter('ethereum-testnet-sepolia'), CCIPRpcNotFoundError)
+      // Second call must use the finished[F] fast-path — no new connections
+      const connectedBefore = stats.connected.length
+      await assert.rejects(chainGetter('ethereum-testnet-sepolia'), CCIPRpcNotFoundError)
+      assert.equal(stats.connected.length, connectedBefore, 'no new endpoints tried on second call')
+    } finally {
+      restore()
+      ac.abort()
+    }
+  })
+
+  // -------------------------------------------------------------------------
+  // txHash search
+  // -------------------------------------------------------------------------
+
+  it('txHash: rejects with CCIPTransactionNotFoundError when tx not on any chain', async () => {
+    const { FakeChain } = makeChainClass({
+      family: ChainFamily.EVM,
+      networkName: 'ethereum-testnet-sepolia',
+      // getTx defaults to 'notfound' for all urls
+    })
+    const restore = setupSupportedChains({ [ChainFamily.EVM]: FakeChain })
+    const [ctx, ac] = makeCtx()
+    try {
+      const [, txResult] = fetchChainsFromRpcs(
+        ctx,
+        { rpcs: ['http://rpc1.example', 'http://rpc2.example'], rpcsFile: '', api: false },
+        TX_HASH,
+      )
+      await assert.rejects(txResult, CCIPTransactionNotFoundError)
+    } finally {
+      restore()
+      ac.abort()
+    }
+  })
+
+  it('txHash: Branch-4 (txOnlyRacer) is destroyed via catch when it loses the tx race', async () => {
+    // a.example connects first → Branch 1 (network winner, finds tx after 10 ms).
+    // b.example connects at 5 ms → Branch 4 (txOnlyRacers); its getTransaction
+    // throws immediately, so the catch block destroys it before txResult resolves.
+    const { FakeChain, stats } = makeChainClass({
+      family: ChainFamily.EVM,
+      networkName: 'ethereum-testnet-sepolia',
+      connectDelay: (url) => (url.includes('b.') ? 5 : 0),
+      getTx: (url) => (url.includes('a.') ? 'found' : 'notfound'),
+      txDelay: (url) => (url.includes('a.') ? 10 : 0),
+    })
+    const restore = setupSupportedChains({ [ChainFamily.EVM]: FakeChain })
+    const [ctx, ac] = makeCtx()
+    try {
+      const [, txResult] = fetchChainsFromRpcs(
+        ctx,
+        { rpcs: ['http://a.example', 'http://b.example'], rpcsFile: '', api: false },
+        TX_HASH,
+      )
+      const [chain, tx] = await txResult
+      assert.equal((chain as unknown as { url: string }).url, 'http://a.example')
+      assert.equal(tx.hash, TX_HASH)
+      // b.example's getTransaction failed → catch → destroy
+      assert.ok(stats.destroyed.includes('http://b.example'), 'txOnlyRacer is eagerly destroyed')
+      // b.example did attempt getTransaction (it connected before txFoundIn was set)
+      assert.ok(
+        stats.txAttempted.includes('http://b.example'),
+        'txOnlyRacer did attempt getTransaction',
+      )
+    } finally {
+      restore()
+      ac.abort()
+    }
+  })
+
+  it('txHash: chain connecting after txFoundIn is set is immediately destroyed without calling getTransaction', async () => {
+    // a.example connects at T=0 and finds tx after 3 ms (txFoundIn set at ~T=3 ms).
+    // b.example connects at T=15 ms → chain$.then sees txFoundIn set → Branch 3
+    // destroy. chain.abort.throwIfAborted() then fires in the txs$ fn so
+    // getTransaction is never reached.
+    const { FakeChain, stats } = makeChainClass({
+      family: ChainFamily.EVM,
+      networkName: 'ethereum-testnet-sepolia',
+      connectDelay: (url) => (url.includes('b.') ? 15 : 0),
+      getTx: (url) => (url.includes('a.') ? 'found' : 'notfound'),
+      txDelay: () => 3,
+    })
+    const restore = setupSupportedChains({ [ChainFamily.EVM]: FakeChain })
+    const [ctx, ac] = makeCtx()
+    try {
+      const [, txResult] = fetchChainsFromRpcs(
+        ctx,
+        { rpcs: ['http://a.example', 'http://b.example'], rpcsFile: '', api: false },
+        TX_HASH,
+      )
+      const [chain, tx] = await txResult
+      assert.equal((chain as unknown as { url: string }).url, 'http://a.example')
+      assert.equal(tx.hash, TX_HASH)
+      // Wait for b.example to connect and be processed
+      await delay(20)
+      assert.ok(
+        stats.destroyed.includes('http://b.example'),
+        'late-arriving chain is immediately destroyed',
+      )
+      assert.ok(
+        !stats.txAttempted.includes('http://b.example'),
+        'late-arriving chain never calls getTransaction',
+      )
+    } finally {
+      restore()
+      ac.abort()
+    }
+  })
+
+  it('txHash: Branch-2 chain given to a pending chainGetter is NOT destroyed when it cannot find the tx', async () => {
+    // chainGetter(N) is called before any chain connects → pendingChainsCbs entry.
+    // The single endpoint connects → Branch 2 (resolves the pending promise).
+    // The same chain's getTransaction fails → catch: txOnlyRacers.has(chain) is
+    // false (Branch 2 was never added), so destroy() must NOT be called.
+    const { FakeChain, stats } = makeChainClass({
+      family: ChainFamily.EVM,
+      networkName: 'ethereum-testnet-sepolia',
+      connectDelay: () => 10,
+      getTx: () => 'notfound',
+    })
+    const restore = setupSupportedChains({ [ChainFamily.EVM]: FakeChain })
+    const [ctx, ac] = makeCtx()
+    try {
+      const [chainGetter, txResult] = fetchChainsFromRpcs(
+        ctx,
+        { rpcs: ['http://rpc.example'], rpcsFile: '', api: false },
+        TX_HASH,
+      )
+      // Call before chain connects → Branch 2 pending
+      const chainPromise = chainGetter('ethereum-testnet-sepolia')
+      // txResult will fail (tx not on this chain); chainPromise will succeed
+      const [chain] = await Promise.all([
+        chainPromise,
+        txResult.catch((err) => {
+          assert.ok(err instanceof CCIPTransactionNotFoundError)
+          return null
+        }),
+      ])
+      // Flush any remaining microtasks from the catch handler
+      await delay(0)
+      assert.equal(chain.network.name, 'ethereum-testnet-sepolia')
+      assert.equal(
+        stats.destroyed.length,
+        0,
+        'Branch-2 chain must not be destroyed before ctx.abort',
+      )
+    } finally {
+      restore()
+      ac.abort()
+      await delay(0) // let ctx.abort propagate
+      assert.equal(stats.destroyed.length, 1, 'chain is cleaned up after ctx.abort')
+    }
+  })
+
+  it('txFoundIn shared across families: SVM txOnlyRacer is destroyed after EVM wins', async () => {
+    // Both families search for the tx (isTxHash = true for both).
+    // All three URLs are tried by both family factories (shared endpoints set).
+    //
+    // EVM factory:
+    //   evm.example → connects fast, finds tx after 3 ms → txFoundIn set
+    //   s1/s2       → connect at 50 ms (after txFoundIn) → Branch 3 immediate destroy
+    //
+    // SVM factory:
+    //   s1.example  → connects fast → Branch 1 for solana-devnet
+    //   s2.example  → connects at 20 ms → Branch 4 (txOnlyRacer)
+    //                 txFoundIn is already set → early-exit → catch → destroy
+    //   evm.example → connects at 50 ms (irrelevant, after everything settles)
+    //
+    // Key assertions: after EVM sets txFoundIn, s2's txs$ candidate sees it
+    // immediately and destroys s2 without ever calling getTransaction.
+    const { FakeChain: FakeEvmChain } = makeChainClass({
+      family: ChainFamily.EVM,
+      networkName: 'ethereum-testnet-sepolia',
+      connectDelay: (url) => (url.includes('evm') ? 0 : 50),
+      getTx: (url) => (url.includes('evm') ? 'found' : 'notfound'),
+      txDelay: () => 3,
+    })
+    const { FakeChain: FakeSvmChain, stats: svmStats } = makeChainClass({
+      family: ChainFamily.Solana,
+      networkName: 'solana-devnet',
+      connectDelay: (url) => (url.includes('s2') ? 20 : url.includes('evm') ? 50 : 0),
+      getTx: () => 'notfound',
+    })
+
+    const restore = setupSupportedChains({
+      [ChainFamily.EVM]: FakeEvmChain,
+      [ChainFamily.Solana]: FakeSvmChain,
+    })
+    const [ctx, ac] = makeCtx()
+    try {
+      const [, txResult] = fetchChainsFromRpcs(
+        ctx,
+        {
+          rpcs: ['http://evm.example', 'http://s1.example', 'http://s2.example'],
+          rpcsFile: '',
+          api: false,
+        },
+        TX_HASH,
+      )
+
+      const [chain, tx] = await txResult
+      assert.equal((chain as unknown as { url: string }).url, 'http://evm.example')
+      assert.equal(tx.hash, TX_HASH)
+
+      // Wait for s2 to connect at T=20 ms and be processed
+      await delay(30)
+
+      assert.ok(
+        svmStats.destroyed.includes('http://s2.example'),
+        'SVM txOnlyRacer is destroyed after EVM sets txFoundIn',
+      )
+      assert.ok(
+        !svmStats.txAttempted.includes('http://s2.example'),
+        'SVM txOnlyRacer never wastefully calls getTransaction',
+      )
+      assert.ok(
+        !svmStats.destroyed.includes('http://s1.example'),
+        'Branch-1 SVM chain (still useful) is not prematurely destroyed',
+      )
+    } finally {
+      restore()
+      ac.abort()
+    }
   })
 })

--- a/ccip-cli/src/providers/index.ts
+++ b/ccip-cli/src/providers/index.ts
@@ -14,6 +14,7 @@ import {
   ChainFamily,
   NetworkType,
   networkInfo,
+  signalToPromise,
   supportedChains,
 } from '@chainlink/ccip-sdk/src/index.ts'
 
@@ -68,7 +69,7 @@ export function fetchChainsFromRpcs(
  * Receives a list of rpcs and/or rpcs file, and loads them concurrently for each chain family
  * If txHash is provided, fetches matching families first and returns [chainGetter, txPromise];
  * Otherwise, spawns racing URLs for each family asked by `getChain` getter
- * @param ctx - Context object containing destroy$ promise and logger properties
+ * @param ctx - Context object containing abort signal and logger properties
  * @param argv - Options containing rpcs (list), rpcs file and noApi flag
  * @param txHash - Optional txHash to fetch concurrently; causes the function to return a [ChainGetter, Promise<ChainTransaction>]
  * @returns a ChainGetter (if txHash was provided), or a tuple of [ChainGetter, Promise<ChainTransaction>]
@@ -103,8 +104,11 @@ export function fetchChainsFromRpcs(
       const txs$: Promise<unknown>[] = []
       let txFound = false
       for (const url of endpoints) {
+        ctx.abort.throwIfAborted()
+        const raceAc = new AbortController()
         const chain$ = C.fromUrl(url, {
           ...ctx,
+          abort: AbortSignal.any([ctx.abort, raceAc.signal]),
           apiClient:
             argv.api === false ? null : typeof argv.api === 'string' ? argv.api : undefined,
         })
@@ -114,10 +118,11 @@ export function fetchChainsFromRpcs(
           (chain) => {
             endpoints.delete(url) // when resolved, remove from set so it isn't tried for future families
             // on chain detected for url
-            if (chain.network.name in chains && !(chain.network.name in chainsCbs))
-              return chain.destroy?.() // but lost race, cleanup right away
-            // keep and schedule cleanup on shutdown
-            if (chain.destroy) void ctx.destroy$.finally(chain.destroy.bind(chain))
+            if (chain.network.name in chains && !(chain.network.name in chainsCbs)) {
+              raceAc.abort() // lost race, abort immediately (destroys provider via signal listener)
+              return
+            }
+            // winner: provider cleanup is handled automatically by ctx.abort signal
             if (!(chain.network.name in chains)) {
               // chain won for this network, but was not "asked" by getChain (yet?): save
               chains[chain.network.name] = Promise.resolve(chain)
@@ -134,6 +139,7 @@ export function fetchChainsFromRpcs(
         if (txHash) {
           txs$.push(
             chain$.then(async (chain) => {
+              raceAc.signal.throwIfAborted() // if chain lost the race, skip tx fetch
               const tx = await chain.getTransaction(txHash)
               if (!txFound) {
                 txFound = true
@@ -147,13 +153,19 @@ export function fetchChainsFromRpcs(
         }
       }
 
-      void Promise.race([Promise.allSettled(chains$), ctx.destroy$]).finally(() => {
-        if (finished[F]) return
-        finished[F] = true
-        Object.entries(chainsCbs)
-          .filter(([name]) => networkInfo(name).family === F)
-          .forEach(([name, [_, reject]]) => reject(new CCIPRpcNotFoundError(name)))
-      })
+      Promise.race([Promise.allSettled(chains$), signalToPromise(ctx.abort)])
+        .finally(() => {
+          if (finished[F]) return
+          finished[F] = true
+          Object.entries(chainsCbs)
+            .filter(([name]) => networkInfo(name).family === F)
+            .forEach(([name, [_, reject]]) => reject(new CCIPRpcNotFoundError(name)))
+        })
+        .catch(() => {
+          // signalToPromise(ctx.abort) rejects with DOMException when the parent
+          // context aborts before all race URLs settle; swallow it here so the
+          // void-discarded chain doesn't surface as an unhandled rejection.
+        })
       return Promise.any(txHash ? txs$ : chains$)
     }))
 

--- a/ccip-cli/src/providers/index.ts
+++ b/ccip-cli/src/providers/index.ts
@@ -80,35 +80,28 @@ export function fetchChainsFromRpcs(
   txHash?: string,
 ) {
   const chains: Record<string, Promise<Chain>> = {}
-  const chainsCbs: Record<
+  const pendingChainsCbs: Record<
     string,
     readonly [resolve: (value: Chain) => void, reject: (reason?: unknown) => void]
   > = {}
-  const finished: Partial<Record<ChainFamily, boolean>> = {}
+  const finished: Partial<Record<ChainFamily, true>> = {}
   const initFamily$: Partial<Record<ChainFamily, Promise<unknown>>> = {}
   let endpoints$: Promise<Set<string>> | undefined
-
-  let txResolve: (value: [Chain, ChainTransaction]) => void, txReject: (reason?: unknown) => void
-  const txResult = new Promise<[Chain, ChainTransaction]>((resolve, reject) => {
-    txResolve = resolve
-    txReject = reject
-  })
+  let txFoundIn: string | undefined
 
   const loadChainFamily = (F: ChainFamily, txHash?: string) =>
     (initFamily$[F] ??= (endpoints$ ??= collectEndpoints.call(ctx, argv)).then((endpoints) => {
       const C = supportedChains[F]
       if (!C) throw new CCIPChainFamilyUnsupportedError(F)
+      ctx.abort.throwIfAborted()
       ctx.logger.debug('Racing', endpoints.size, 'RPC endpoints for', F)
 
       const chains$: Promise<Chain>[] = []
-      const txs$: Promise<unknown>[] = []
-      let txFound = false
+      const txOnlyRacers = new WeakSet<Chain>()
       for (const url of endpoints) {
-        ctx.abort.throwIfAborted()
-        const raceAc = new AbortController()
         const chain$ = C.fromUrl(url, {
           ...ctx,
-          abort: AbortSignal.any([ctx.abort, raceAc.signal]),
+          abort: ctx.abort,
           apiClient:
             argv.api === false ? null : typeof argv.api === 'string' ? argv.api : undefined,
         })
@@ -117,47 +110,53 @@ export function fetchChainsFromRpcs(
         void chain$.then(
           (chain) => {
             endpoints.delete(url) // when resolved, remove from set so it isn't tried for future families
-            // on chain detected for url
-            if (chain.network.name in chains && !(chain.network.name in chainsCbs)) {
-              raceAc.abort() // lost race, abort immediately (destroys provider via signal listener)
-              return
-            }
             // winner: provider cleanup is handled automatically by ctx.abort signal
             if (!(chain.network.name in chains)) {
               // chain won for this network, but was not "asked" by getChain (yet?): save
-              chains[chain.network.name] = Promise.resolve(chain)
-            } else if (chain.network.name in chainsCbs) {
+              chains[chain.network.name] = chain$
+            } else if (chain.network.name in pendingChainsCbs) {
               // chain detected, and there's a "pending request" by getChain: resolve
-              const [resolve] = chainsCbs[chain.network.name]!
+              const [resolve] = pendingChainsCbs[chain.network.name]!
               resolve(chain)
+            } else if (!txHash || txFoundIn) {
+              chain.destroy() // lost race (either network's or tx's)
+            } else {
+              txOnlyRacers.add(chain) // lost race, but may still find tx before winner and take its place
             }
-            return chain
           },
           () => {},
         )
-
-        if (txHash) {
-          txs$.push(
-            chain$.then(async (chain) => {
-              raceAc.signal.throwIfAborted() // if chain lost the race, skip tx fetch
+      }
+      let txs$
+      if (txHash) {
+        txs$ = Promise.any(
+          chains$.map(async (chain$) => {
+            const chain = await chain$
+            chain.abort.throwIfAborted()
+            try {
+              if (txFoundIn) throw new Error('tx already raced')
               const tx = await chain.getTransaction(txHash)
-              if (!txFound) {
-                txFound = true
-                // in case tx is first found, prefer it over any previously found chain for this network
-                chains[chain.network.name] = chain$
-                delete chainsCbs[chain.network.name]
+              if (txFoundIn) {
+                if (txFoundIn === chain.network.name) chain.destroy()
+                throw new Error('tx already raced')
               }
-              txResolve([chain, tx])
-            }),
-          )
-        }
+              txFoundIn = chain.network.name
+              // in case tx is first found, prefer it over any previously found chain for this network
+              chains[chain.network.name] = chain$
+              return [chain, tx] as const
+            } catch (err) {
+              if (txOnlyRacers.has(chain)) chain.destroy()
+              throw err
+            }
+          }),
+        )
       }
 
       Promise.race([Promise.allSettled(chains$), signalToPromise(ctx.abort)])
         .finally(() => {
           if (finished[F]) return
           finished[F] = true
-          Object.entries(chainsCbs)
+          Object.entries(pendingChainsCbs)
             .filter(([name]) => networkInfo(name).family === F)
             .forEach(([name, [_, reject]]) => reject(new CCIPRpcNotFoundError(name)))
         })
@@ -166,32 +165,37 @@ export function fetchChainsFromRpcs(
           // context aborts before all race URLs settle; swallow it here so the
           // void-discarded chain doesn't surface as an unhandled rejection.
         })
-      return Promise.any(txHash ? txs$ : chains$)
+      return txs$
     }))
 
   const chainGetter = async (idOrSelectorOrName: number | string | bigint): Promise<Chain> => {
     const network = networkInfo(idOrSelectorOrName)
     if (network.name in chains) return chains[network.name]!
     if (finished[network.family]) throw new CCIPRpcNotFoundError(network.name)
-    const c = (chains[network.name] = new Promise((resolve, reject) => {
-      chainsCbs[network.name] = [resolve, reject]
-    }))
-    void c
+
+    const { promise, resolve, reject } = Promise.withResolvers<Chain>()
+    chains[network.name] = promise
+    pendingChainsCbs[network.name] = [resolve, reject]
+
+    void promise
       .finally(() => {
-        delete chainsCbs[network.name] // when chain is settled, delete the callbacks
+        delete pendingChainsCbs[network.name] // when chain is settled, delete the callbacks
       })
       .catch(() => {}) // rejection already handled by chainGetter caller
     void loadChainFamily(network.family)
-    return c
+    return promise
   }
 
   if (!txHash) return chainGetter
 
-  void Promise.allSettled(
+  // truty txHash means txs$ return branch of loadChainFamily
+  const txResult = Promise.any(
     Object.values(supportedChains)
       .filter((C) => C.isTxHash(txHash))
-      .map((C) => loadChainFamily(C.family, txHash)),
-  ).finally(() => txReject(new CCIPTransactionNotFoundError(txHash))) // noop if txResolved
+      .map((C) => loadChainFamily(C.family, txHash) as Promise<[Chain, ChainTransaction]>),
+  ).catch((err) =>
+    Promise.reject(new CCIPTransactionNotFoundError(txHash, { context: { aggregateErr: err } })),
+  )
   return [chainGetter, txResult]
 }
 

--- a/ccip-sdk/package.json
+++ b/ccip-sdk/package.json
@@ -75,7 +75,7 @@
     "viem": "^2.48.1"
   },
   "dependencies": {
-    "axios": "1.15.0",
+    "axios": "1.15.2",
     "@aptos-labs/ts-sdk": "^6.3.1",
     "@coral-xyz/anchor": "^0.29.0",
     "@mysten/bcs": "^2.0.3",
@@ -85,7 +85,7 @@
     "@ton/core": "0.63.1",
     "@ton/crypto": "^3.3.0",
     "@ton/ton": "^16.2.4",
-    "abitype": "1.2.3",
+    "abitype": "1.2.4",
     "bn.js": "^5.2.3",
     "borsh": "^2.0.0",
     "bs58": "^6.0.0",

--- a/ccip-sdk/src/api/index.ts
+++ b/ccip-sdk/src/api/index.ts
@@ -60,7 +60,7 @@ export const DEFAULT_TIMEOUT_MS = 30000
 /** SDK version string for telemetry header */
 // generate:nofail
 // `export const SDK_VERSION = '${require('./package.json').version}-${require('child_process').execSync('git rev-parse --short HEAD').toString().trim()}'`
-export const SDK_VERSION = '1.6.0-8f8d5b94'
+export const SDK_VERSION = '1.6.0-faa7467f'
 // generate:end
 
 /** SDK telemetry header name */

--- a/ccip-sdk/src/aptos/index.ts
+++ b/ccip-sdk/src/aptos/index.ts
@@ -236,7 +236,7 @@ export class AptosChain extends Chain<typeof ChainFamily.Aptos> {
 
   /** {@inheritDoc Chain.getLogs} */
   async *getLogs(opts: LogFilter & { versionAsHash?: boolean }): AsyncIterableIterator<ChainLog> {
-    if (opts.watch && this.abort) {
+    if (opts.watch) {
       opts = {
         ...opts,
         watch:

--- a/ccip-sdk/src/aptos/index.ts
+++ b/ccip-sdk/src/aptos/index.ts
@@ -94,7 +94,6 @@ export class AptosChain extends Chain<typeof ChainFamily.Aptos> {
   /** Native token decimals (8 for APT). */
   static readonly decimals = 8
 
-  readonly destroy$: Promise<void>
   /** The Aptos SDK provider for blockchain interactions. */
   provider: Aptos
 
@@ -111,7 +110,6 @@ export class AptosChain extends Chain<typeof ChainFamily.Aptos> {
   constructor(provider: Aptos, network: NetworkInfo, ctx?: ChainContext) {
     super(network, ctx)
 
-    this.destroy$ = new Promise<void>((resolve) => (this.destroy = resolve))
     this.provider = provider
 
     this.typeAndVersion = memoize(this.typeAndVersion.bind(this), {
@@ -238,6 +236,15 @@ export class AptosChain extends Chain<typeof ChainFamily.Aptos> {
 
   /** {@inheritDoc Chain.getLogs} */
   async *getLogs(opts: LogFilter & { versionAsHash?: boolean }): AsyncIterableIterator<ChainLog> {
+    if (opts.watch && this.abort) {
+      opts = {
+        ...opts,
+        watch:
+          opts.watch instanceof AbortSignal
+            ? AbortSignal.any([opts.watch, this.abort])
+            : this.abort,
+      }
+    }
     yield* streamAptosLogs(this, opts)
   }
 

--- a/ccip-sdk/src/aptos/logs.ts
+++ b/ccip-sdk/src/aptos/logs.ts
@@ -16,7 +16,7 @@ import {
   CCIPTopicsInvalidError,
 } from '../errors/index.ts'
 import type { ChainLog } from '../types.ts'
-import { sleep } from '../utils.ts'
+import { signalToPromise } from '../utils.ts'
 
 const DEFAULT_POLL_INTERVAL = 5e3
 
@@ -156,7 +156,10 @@ async function* fetchEventsForward(
 
   let first = true,
     catchedUp = false
-  while (opts.watch || !catchedUp) {
+  while (
+    (opts.watch && (!(opts.watch instanceof AbortSignal) || !opts.watch.aborted)) ||
+    !catchedUp
+  ) {
     const lastReq = performance.now()
     const data = await fetchBatch(start)
     if (
@@ -193,12 +196,14 @@ async function* fetchEventsForward(
     }
     catchedUp ||= start >= end
     if (opts.watch && catchedUp) {
-      let break$ = sleep(
+      let delay$ = AbortSignal.timeout(
         Math.max((opts.pollInterval || DEFAULT_POLL_INTERVAL) - (performance.now() - lastReq), 1),
-      ).then(() => false)
-      if (opts.watch instanceof Promise)
-        break$ = Promise.race([break$, opts.watch.then(() => true)])
-      if (await break$) break
+      )
+      if (opts.watch instanceof AbortSignal) {
+        if (opts.watch.aborted) break
+        delay$ = AbortSignal.any([opts.watch, delay$])
+      }
+      await signalToPromise(delay$).catch(() => false)
     }
   }
 }

--- a/ccip-sdk/src/aptos/logs.ts
+++ b/ccip-sdk/src/aptos/logs.ts
@@ -197,7 +197,10 @@ async function* fetchEventsForward(
     catchedUp ||= start >= end
     if (opts.watch && catchedUp) {
       let delay$ = AbortSignal.timeout(
-        Math.max((opts.pollInterval || DEFAULT_POLL_INTERVAL) - (performance.now() - lastReq), 1),
+        Math.max(
+          Math.ceil((opts.pollInterval || DEFAULT_POLL_INTERVAL) - (performance.now() - lastReq)),
+          1,
+        ),
       )
       if (opts.watch instanceof AbortSignal) {
         if (opts.watch.aborted) break

--- a/ccip-sdk/src/chain.ts
+++ b/ccip-sdk/src/chain.ts
@@ -570,7 +570,7 @@ export abstract class Chain<F extends ChainFamily = ChainFamily> {
   /** Retry configuration for API fallback operations (null if API client is disabled) */
   readonly apiRetryConfig: Required<ApiRetryConfig> | null
   /** Abort signal from ChainContext; fires when the chain should tear down. */
-  readonly abort?: AbortSignal
+  readonly abort: AbortSignal
 
   /**
    * Base constructor for Chain class.
@@ -589,7 +589,11 @@ export abstract class Chain<F extends ChainFamily = ChainFamily> {
       )
     this.network = network as NetworkInfo<F>
     this.logger = logger
-    this.abort = abort
+
+    const ac = new AbortController()
+    this.abort = ac.signal
+    this.destroy = ac.abort.bind(ac)
+    abort?.addEventListener('abort', (r?: unknown) => this.destroy(r), { once: true })
 
     // API client initialization: default enabled, null = explicit opt-out
     if (apiClient === null) {
@@ -603,6 +607,9 @@ export abstract class Chain<F extends ChainFamily = ChainFamily> {
       this.apiRetryConfig = { ...DEFAULT_API_RETRY_CONFIG, ...apiRetryConfig }
     }
   }
+
+  /** Cleanup method to release resources (e.g., close connections). */
+  destroy: (reason?: unknown) => void;
 
   /** Custom inspector for Node.js util.inspect. */
   [util.inspect.custom]() {

--- a/ccip-sdk/src/chain.ts
+++ b/ccip-sdk/src/chain.ts
@@ -135,6 +135,12 @@ export type ChainContext = WithLogger & {
    * Default: DEFAULT_API_RETRY_CONFIG
    */
   apiRetryConfig?: ApiRetryConfig
+
+  /**
+   * Abort signal for cancelling in-flight requests and watch loops on this chain.
+   * When the signal fires, the provider is destroyed and all active getLogs watch loops exit.
+   */
+  abort?: AbortSignal
 } & WithCantonConfig
 
 /**
@@ -208,9 +214,9 @@ export type LogFilter = {
   /** Cursor hint for the exclusive upper end of iteration on chains that support it. */
   endBefore?: string
   /** watch mode: polls for new logs after fetching since start (required), until endBlock finality tag
-   *  (e.g. endBlock=finalized polls only finalized logs); can be a promise to cancel loop
+   *  (e.g. endBlock=finalized polls only finalized logs); can be an AbortSignal to cancel loop
    */
-  watch?: boolean | Promise<unknown>
+  watch?: boolean | AbortSignal
   /** Contract address to filter logs by. */
   address?: string
   /** Topics to filter logs by. */
@@ -563,6 +569,8 @@ export abstract class Chain<F extends ChainFamily = ChainFamily> {
   readonly apiClient: CCIPAPIClient | null
   /** Retry configuration for API fallback operations (null if API client is disabled) */
   readonly apiRetryConfig: Required<ApiRetryConfig> | null
+  /** Abort signal from ChainContext; fires when the chain should tear down. */
+  readonly abort?: AbortSignal
 
   /**
    * Base constructor for Chain class.
@@ -571,7 +579,7 @@ export abstract class Chain<F extends ChainFamily = ChainFamily> {
    * @throws {@link CCIPChainFamilyMismatchError} if network family doesn't match the Chain subclass
    */
   constructor(network: NetworkInfo, ctx?: ChainContext) {
-    const { logger = console, apiClient, apiRetryConfig } = ctx ?? {}
+    const { logger = console, apiClient, apiRetryConfig, abort } = ctx ?? {}
 
     if (network.family !== (this.constructor as ChainStatic).family)
       throw new CCIPChainFamilyMismatchError(
@@ -581,6 +589,7 @@ export abstract class Chain<F extends ChainFamily = ChainFamily> {
       )
     this.network = network as NetworkInfo<F>
     this.logger = logger
+    this.abort = abort
 
     // API client initialization: default enabled, null = explicit opt-out
     if (apiClient === null) {
@@ -594,9 +603,6 @@ export abstract class Chain<F extends ChainFamily = ChainFamily> {
       this.apiRetryConfig = { ...DEFAULT_API_RETRY_CONFIG, ...apiRetryConfig }
     }
   }
-
-  /** Cleanup method to release resources (e.g., close connections). */
-  destroy?(): void | Promise<void>
 
   /** Custom inspector for Node.js util.inspect. */
   [util.inspect.custom]() {
@@ -665,7 +671,7 @@ export abstract class Chain<F extends ChainFamily = ChainFamily> {
   async waitFinalized({
     request: { log, tx },
     finality = 'finalized',
-    cancel$,
+    abort,
   }: {
     request: SetOptional<
       PickDeep<
@@ -676,7 +682,7 @@ export abstract class Chain<F extends ChainFamily = ChainFamily> {
       'tx'
     >
     finality?: number | 'finalized'
-    cancel$?: Promise<unknown>
+    abort?: AbortSignal
   }): Promise<true> {
     const timestamp = log.tx?.timestamp ?? tx?.timestamp
     if (!timestamp || Date.now() / 1e3 - timestamp > 60) {
@@ -687,12 +693,14 @@ export abstract class Chain<F extends ChainFamily = ChainFamily> {
       ])
       if (trans.timestamp <= finalizedTs) return true
     }
+    const signals = [this.abort, abort].filter(Boolean) as AbortSignal[]
+    const watch = signals.length ? AbortSignal.any(signals) : true
     for await (const l of this.getLogs({
       address: log.address,
       startBlock: log.blockNumber,
       endBlock: finality,
       topics: [log.topics[0]!],
-      watch: cancel$ ?? true,
+      watch,
     })) {
       if (l.transactionHash === log.transactionHash) {
         return true

--- a/ccip-sdk/src/errors/specialized.ts
+++ b/ccip-sdk/src/errors/specialized.ts
@@ -1449,11 +1449,11 @@ export class CCIPNetworkFamilyUnsupportedError extends CCIPError {
 export class CCIPRpcNotFoundError extends CCIPError {
   override readonly name = 'CCIPRpcNotFoundError'
   /** Creates an RPC not found error. */
-  constructor(chainId: string | number, options?: CCIPErrorOptions) {
-    super(CCIPErrorCode.RPC_NOT_FOUND, `No RPC found for chainId=${chainId}`, {
+  constructor(chain: string | number, options?: CCIPErrorOptions) {
+    super(CCIPErrorCode.RPC_NOT_FOUND, `No RPC found for chain=${chain}`, {
       ...options,
       isTransient: false,
-      context: { ...options?.context, chainId },
+      context: { ...options?.context, chain },
     })
   }
 }

--- a/ccip-sdk/src/evm/fork.test.ts
+++ b/ccip-sdk/src/evm/fork.test.ts
@@ -182,9 +182,9 @@ describe('EVM Fork Tests', { skip, timeout: 180_000 }, () => {
   })
 
   after(async () => {
-    sepoliaChain?.destroy?.()
-    fujiChain?.destroy?.()
-    arbSepChain?.destroy?.()
+    sepoliaChain?.provider.destroy()
+    fujiChain?.provider.destroy()
+    arbSepChain?.provider.destroy()
     await Promise.all([sepoliaInstance?.stop(), fujiInstance?.stop(), arbSepInstance?.stop()])
   })
 
@@ -1408,7 +1408,7 @@ describe('EVM Fork Tests', { skip, timeout: 180_000 }, () => {
       assert.ok(execution.timestamp > 0, 'should have timestamp')
       assert.equal(execution.receipt.state, ExecutionState.Success)
 
-      fujiWithApi.destroy?.()
+      fujiWithApi.provider.destroy()
     })
 
     it('should execute a v1.5 message via API-driven path (Sepolia -> Fuji)', async () => {
@@ -1438,7 +1438,7 @@ describe('EVM Fork Tests', { skip, timeout: 180_000 }, () => {
       assert.ok(execution.timestamp > 0, 'should have timestamp')
       assert.equal(execution.receipt.state, ExecutionState.Success)
 
-      fujiWithApi.destroy?.()
+      fujiWithApi.provider.destroy()
     })
 
     // TON-source messages were historically problematic due to data quality issues
@@ -1473,7 +1473,7 @@ describe('EVM Fork Tests', { skip, timeout: 180_000 }, () => {
       assert.ok(execution.timestamp > 0, 'should have timestamp')
       assert.equal(execution.receipt.state, ExecutionState.Success)
 
-      sepoliaWithApi.destroy?.()
+      sepoliaWithApi.provider.destroy()
     })
 
     // Another problematic TON-source message with gasLimit=1 and data payload.
@@ -1507,7 +1507,7 @@ describe('EVM Fork Tests', { skip, timeout: 180_000 }, () => {
       assert.ok(execution.timestamp > 0, 'should have timestamp')
       assert.equal(execution.receipt.state, ExecutionState.Success)
 
-      sepoliaWithApi.destroy?.()
+      sepoliaWithApi.provider.destroy()
     })
   })
 
@@ -1598,7 +1598,7 @@ describe('EVM Fork Tests', { skip, timeout: 180_000 }, () => {
         `viem-adapter path should surface the decoded custom error name. Parsed: ${flat}`,
       )
 
-      viemChain.destroy?.()
+      viemChain.provider.destroy()
     })
 
     // Cross-check: same over-capacity send via the ethers-direct chain (sepoliaChain)
@@ -1647,7 +1647,7 @@ describe('EVM Fork Tests', { skip, timeout: 180_000 }, () => {
         `ethers-direct path should surface the decoded custom error name. Parsed: ${flat}`,
       )
 
-      ethersChainLocal.destroy?.()
+      ethersChainLocal.provider.destroy()
     })
   })
 })

--- a/ccip-sdk/src/evm/index.ts
+++ b/ccip-sdk/src/evm/index.ts
@@ -65,7 +65,9 @@ import {
   encodeFinality,
 } from '../extra-args.ts'
 import type { LeafHasher } from '../hasher/common.ts'
+import { decodeMessageV1 } from '../messages.ts'
 import { CCTP_FINALITY_FAST, getUsdcBurnFees } from '../offchain.ts'
+import { buildMessageForDest, decodeMessage, getMessagesInBatch } from '../requests.ts'
 import { supportedChains } from '../supported-chains.ts'
 import {
   type CCIPExecution,
@@ -130,9 +132,7 @@ import { getV12LeafHasher, getV16LeafHasher } from './hasher.ts'
 import { type EVMEndBlockTag, getEvmLogs } from './logs.ts'
 import type { CCIPMessage_V1_6_EVM, CCIPMessage_V2_0, CleanAddressable } from './messages.ts'
 import { encodeEVMOffchainTokenData } from './offchain.ts'
-import { buildMessageForDest, decodeMessage, getMessagesInBatch } from '../requests.ts'
 import { type UnsignedEVMTx, resultToObject } from './types.ts'
-import { decodeMessageV1 } from '../messages.ts'
 export type { UnsignedEVMTx }
 
 /** Raw on-chain TokenBucket struct returned by TokenPool rate limiter queries. */
@@ -209,7 +209,6 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
   static readonly decimals = 18
 
   provider: JsonRpcApiProvider
-  readonly destroy$: Promise<void>
   private noncesPromises: Record<string, Promise<unknown>>
   /**
    * Cache of current nonces per wallet address.
@@ -230,8 +229,7 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
     this.nonces = {}
 
     this.provider = provider
-    this.destroy$ = new Promise<void>((resolve) => (this.destroy = resolve))
-    void this.destroy$.finally(() => provider.destroy())
+    ctx?.abort?.addEventListener('abort', () => provider.destroy(), { once: true })
 
     this.typeAndVersion = memoize(this.typeAndVersion.bind(this))
 
@@ -295,10 +293,11 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
    * @param url - WebSocket (wss://) or HTTP (https://) endpoint URL.
    * @returns A ready JSON-RPC provider.
    */
-  static async _getProvider(url: string): Promise<JsonRpcApiProvider> {
+  static async _getProvider(url: string, abort?: AbortSignal): Promise<JsonRpcApiProvider> {
     let providerReady: Promise<JsonRpcApiProvider>
     if (url.startsWith('ws')) {
       const provider = new WebSocketProvider(url)
+      abort?.addEventListener('abort', () => void provider.destroy(), { once: true })
       providerReady = new Promise((resolve, reject) => {
         provider.websocket.onerror = reject
         provider
@@ -308,6 +307,7 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
       })
     } else if (url.startsWith('http')) {
       const provider = new JsonRpcProvider(url)
+      abort?.addEventListener('abort', () => provider.destroy(), { once: true })
       providerReady = Promise.resolve(provider)
     } else {
       throw new CCIPDataFormatUnsupportedError(url)
@@ -348,7 +348,7 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
    * ```
    */
   static async fromUrl(url: string, ctx?: ChainContext): Promise<EVMChain> {
-    return this.fromProvider(await this._getProvider(url), ctx)
+    return this.fromProvider(await this._getProvider(url, ctx?.abort), ctx)
   }
 
   /** {@inheritDoc Chain.getBlockTimestamp} */
@@ -377,8 +377,15 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
   async *getLogs(
     filter: SetFieldType<LogFilter, 'endBlock', EVMEndBlockTag>,
   ): AsyncIterableIterator<Log> {
-    if (filter.watch instanceof Promise)
-      filter = { ...filter, watch: Promise.race([filter.watch, this.destroy$]) }
+    if (filter.watch && this.abort) {
+      filter = {
+        ...filter,
+        watch:
+          filter.watch instanceof AbortSignal
+            ? AbortSignal.any([filter.watch, this.abort])
+            : this.abort,
+      }
+    }
     yield* getEvmLogs(filter, this)
   }
 

--- a/ccip-sdk/src/evm/index.ts
+++ b/ccip-sdk/src/evm/index.ts
@@ -229,7 +229,7 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
     this.nonces = {}
 
     this.provider = provider
-    ctx?.abort?.addEventListener('abort', () => provider.destroy(), { once: true })
+    this.abort.addEventListener('abort', () => this.provider.destroy(), { once: true })
 
     this.typeAndVersion = memoize(this.typeAndVersion.bind(this))
 

--- a/ccip-sdk/src/evm/index.ts
+++ b/ccip-sdk/src/evm/index.ts
@@ -377,7 +377,7 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
   async *getLogs(
     filter: SetFieldType<LogFilter, 'endBlock', EVMEndBlockTag>,
   ): AsyncIterableIterator<Log> {
-    if (filter.watch && this.abort) {
+    if (filter.watch) {
       filter = {
         ...filter,
         watch:

--- a/ccip-sdk/src/evm/logs.ts
+++ b/ccip-sdk/src/evm/logs.ts
@@ -92,16 +92,20 @@ export async function* getEvmLogs(
 
     const contAc = new AbortController()
     let contSignal = contAc.signal
-    void provider.once(
+    const contEvent =
       !filter.endBlock || typeof filter.endBlock === 'number' || filter.endBlock == 'latest'
         ? 'block'
-        : filter.endBlock, // finalized | safe
-      contAc.abort.bind(contAc),
-    )
+        : filter.endBlock // finalized | safe
+    const contListener = () => contAc.abort()
+    void provider.once(contEvent, contListener)
     if (filter.watch instanceof AbortSignal) {
       if (filter.watch.aborted) break
       contSignal = AbortSignal.any([filter.watch, contSignal])
     }
-    await signalToPromise(contSignal).catch(() => false)
+    try {
+      await signalToPromise(contSignal).catch(() => false)
+    } finally {
+      void provider.off(contEvent, contListener)
+    }
   }
 }

--- a/ccip-sdk/src/evm/logs.ts
+++ b/ccip-sdk/src/evm/logs.ts
@@ -8,7 +8,7 @@ import {
   CCIPLogsWatchRequiresFinalityError,
 } from '../errors/index.ts'
 import type { FinalityRequested } from '../extra-args.ts'
-import { blockRangeGenerator, getSomeBlockNumberBefore } from '../utils.ts'
+import { blockRangeGenerator, getSomeBlockNumberBefore, signalToPromise } from '../utils.ts'
 import { getAllFragmentsMatchingEvents } from './const.ts'
 import type { WithLogger } from '../types.ts'
 
@@ -19,12 +19,12 @@ export type EVMEndBlockTag = FinalityRequested | 'latest'
  * Implements Chain.getLogs for EVM.
  * Walks logs forward from `startBlock` or `startTime`; if neither is provided, throws.
  * @param filter - Chain LogFilter
- * @param ctx - Context object containing provider, logger and destroy$ notify promise
+ * @param ctx - Context object containing provider, logger and optional abort signal
  * @returns Async iterator of logs.
  */
 export async function* getEvmLogs(
   filter: SetFieldType<LogFilter, 'endBlock', EVMEndBlockTag>,
-  ctx: { provider: JsonRpcApiProvider; destroy$?: Promise<unknown> } & WithLogger,
+  ctx: { provider: JsonRpcApiProvider; abort?: AbortSignal } & WithLogger,
 ): AsyncIterableIterator<Log> {
   const { provider, logger = console } = ctx
 
@@ -77,20 +77,7 @@ export async function* getEvmLogs(
   }
 
   // watch mode, otherwise return
-  while (filter.watch) {
-    let cont$ = new Promise<number | false>(
-      (resolve) =>
-        void provider.once(
-          !filter.endBlock || typeof filter.endBlock === 'number' || filter.endBlock == 'latest'
-            ? 'block'
-            : filter.endBlock, // finalized | safe
-          resolve,
-        ),
-    )
-    if (filter.watch instanceof Promise)
-      cont$ = Promise.race([filter.watch.then(() => false as const), cont$])
-    if ((await cont$) === false) break
-
+  while (filter.watch && (!(filter.watch instanceof AbortSignal) || !filter.watch.aborted)) {
     const filter_ = {
       fromBlock: Math.max(latestLogBlockNumber, endBlock - (filter.page ?? 10e3)) + 1,
       toBlock: filter.endBlock || 'latest',
@@ -102,5 +89,19 @@ export async function* getEvmLogs(
     if (logs.length)
       latestLogBlockNumber = Math.max(latestLogBlockNumber, logs[logs.length - 1]!.blockNumber)
     yield* logs
+
+    const contAc = new AbortController()
+    let contSignal = contAc.signal
+    void provider.once(
+      !filter.endBlock || typeof filter.endBlock === 'number' || filter.endBlock == 'latest'
+        ? 'block'
+        : filter.endBlock, // finalized | safe
+      contAc.abort.bind(contAc),
+    )
+    if (filter.watch instanceof AbortSignal) {
+      if (filter.watch.aborted) break
+      contSignal = AbortSignal.any([filter.watch, contSignal])
+    }
+    await signalToPromise(contSignal).catch(() => false)
   }
 }

--- a/ccip-sdk/src/index.ts
+++ b/ccip-sdk/src/index.ts
@@ -94,6 +94,7 @@ export {
   getDataBytes,
   isSupportedTxHash,
   networkInfo,
+  signalToPromise,
   withRetry,
 } from './utils.ts'
 export {

--- a/ccip-sdk/src/solana/__tests__/integration.test.ts
+++ b/ccip-sdk/src/solana/__tests__/integration.test.ts
@@ -260,9 +260,7 @@ describe('Solana Devnet estimateReceiveExecution Tests', { skip }, () => {
     })
   })
 
-  after(async () => {
-    chain?.destroy?.()
-  })
+  after(async () => {})
 
   it('should estimate receiver execution for a failed Fuji -> Solana devnet message', async () => {
     assert.ok(chain, 'Solana devnet chain should be initialized')
@@ -270,7 +268,7 @@ describe('Solana Devnet estimateReceiveExecution Tests', { skip }, () => {
     await using disposer = new AsyncDisposableStack()
     const source = disposer.adopt(
       await EVMChain.fromUrl(FUJI_RPC, { apiClient: null, logger: testLogger }),
-      (source) => source.destroy?.(),
+      (source) => source.provider.destroy(),
     )
 
     const tx = await source.getTransaction(ESTIMATE_MSG.txHash)

--- a/ccip-sdk/src/solana/fork.test.ts
+++ b/ccip-sdk/src/solana/fork.test.ts
@@ -160,7 +160,6 @@ describe('Solana Fork Tests', { skip, timeout: 180_000 }, () => {
   })
 
   after(async () => {
-    solanaChain?.destroy?.()
     await surfpoolInstance?.stop()
   })
 
@@ -267,8 +266,6 @@ describe('Solana Fork Tests', { skip, timeout: 180_000 }, () => {
         .find((r) => r?.messageId === EXEC_MSG.messageId)
       assert.ok(receipt, 'should find ExecutionStateChanged in offRamp logs')
       assert.equal(receipt.state, ExecutionState.Success, 'offRamp log should confirm Success')
-
-      solanaWithApi.destroy?.()
     })
   })
 })

--- a/ccip-sdk/src/solana/gas.ts
+++ b/ccip-sdk/src/solana/gas.ts
@@ -171,37 +171,19 @@ export async function estimateExecComputeUnits({
     return []
   })
 
-  if (setupIxs.length) {
-    try {
-      const [setupResult, fullResult] = await Promise.all([
-        simulateTransaction(
-          { connection, logger },
-          {
-            payerKey: SIMULATION_PAYER,
-            instructions: setupIxs,
-          },
-        ),
-        simulateTransaction(
-          { connection, logger },
-          {
-            payerKey: SIMULATION_PAYER,
-            instructions: [...setupIxs, receiveIx],
-          },
-        ),
-      ])
-      return Math.max(0, (fullResult.unitsConsumed ?? 0) - (setupResult.unitsConsumed ?? 0))
-    } catch (err) {
-      logger.debug('Failed to simulate Solana token setup; simulating receiver only:', err)
-    }
-  }
-
   const simResult = await simulateTransaction(
     { connection, logger },
-    {
-      payerKey: SIMULATION_PAYER,
-      instructions: [receiveIx],
-    },
+    { payerKey: SIMULATION_PAYER, instructions: [...setupIxs, receiveIx] },
   )
+
+  let re
+  for (const log of (simResult.logs ?? []).toReversed()) {
+    re ??= new RegExp(`^Program ${message.receiver} consumed (\\d+)\\b`)
+    const match = log.match(re)
+    if (match && Number(match[1]) > 0) {
+      return Number(match[1])
+    }
+  }
 
   return simResult.unitsConsumed ?? 0
 }

--- a/ccip-sdk/src/solana/index.ts
+++ b/ccip-sdk/src/solana/index.ts
@@ -948,7 +948,7 @@ export class SolanaChain extends Chain<typeof ChainFamily.Solana> {
         onRampAddress,
         minSeqNr: BigInt(merkleRoot.minSeqNr.toString()),
         maxSeqNr: BigInt(merkleRoot.maxSeqNr.toString()),
-        merkleRoot: hexlify(getDataBytes(merkleRoot.merkleRoot)),
+        merkleRoot: hexlify(getDataBytes(merkleRoot.merkleRoot)) as `0x${string}`,
       },
     ]
   }

--- a/ccip-sdk/src/solana/index.ts
+++ b/ccip-sdk/src/solana/index.ts
@@ -212,7 +212,6 @@ export class SolanaChain extends Chain<typeof ChainFamily.Solana> {
 
   connection: Connection
   commitment: Commitment = 'confirmed'
-  readonly destroy$: Promise<void>
 
   /**
    * Creates a new SolanaChain instance.
@@ -223,7 +222,6 @@ export class SolanaChain extends Chain<typeof ChainFamily.Solana> {
     super(network, ctx)
 
     this.connection = connection
-    this.destroy$ = new Promise<void>((resolve) => (this.destroy = resolve))
 
     // Memoize expensive operations
     this.typeAndVersion = memoize(this.typeAndVersion.bind(this), {
@@ -407,8 +405,15 @@ export class SolanaChain extends Chain<typeof ChainFamily.Solana> {
   async *getTransactionsForAddress(
     opts: Omit<LogFilter, 'topics'>,
   ): AsyncGenerator<SolanaTransaction> {
-    if (opts.watch instanceof Promise)
-      opts = { ...opts, watch: Promise.race([opts.watch, this.destroy$]) }
+    if (opts.watch && this.abort) {
+      opts = {
+        ...opts,
+        watch:
+          opts.watch instanceof AbortSignal
+            ? AbortSignal.any([opts.watch, this.abort])
+            : this.abort,
+      }
+    }
     yield* getTransactionsForAddress(opts, this)
   }
 

--- a/ccip-sdk/src/solana/index.ts
+++ b/ccip-sdk/src/solana/index.ts
@@ -405,7 +405,7 @@ export class SolanaChain extends Chain<typeof ChainFamily.Solana> {
   async *getTransactionsForAddress(
     opts: Omit<LogFilter, 'topics'>,
   ): AsyncGenerator<SolanaTransaction> {
-    if (opts.watch && this.abort) {
+    if (opts.watch) {
       opts = {
         ...opts,
         watch:

--- a/ccip-sdk/src/solana/logs.ts
+++ b/ccip-sdk/src/solana/logs.ts
@@ -81,7 +81,10 @@ async function* fetchSigsForward(
     }
 
     let delay$ = AbortSignal.timeout(
-      Math.max((opts.pollInterval || DEFAULT_POLL_INTERVAL) - (performance.now() - lastReq), 1),
+      Math.max(
+        Math.ceil((opts.pollInterval || DEFAULT_POLL_INTERVAL) - (performance.now() - lastReq)),
+        1,
+      ),
     )
     if (opts.watch instanceof AbortSignal) {
       if (opts.watch.aborted) break

--- a/ccip-sdk/src/solana/logs.ts
+++ b/ccip-sdk/src/solana/logs.ts
@@ -7,7 +7,7 @@ import {
   CCIPLogsRequiresStartError,
   CCIPLogsWatchRequiresFinalityError,
 } from '../errors/index.ts'
-import { sleep } from '../utils.ts'
+import { signalToPromise } from '../utils.ts'
 
 const DEFAULT_POLL_INTERVAL = 5e3
 
@@ -56,16 +56,9 @@ async function* fetchSigsForward(
   yield* allSigs // all past logs
 
   if (allSigs.length) until = allSigs[allSigs.length - 1]!.signature
-  let lastReq = performance.now()
   // if not watch mode, returns
-  while (opts.watch) {
-    let break$ = sleep(
-      Math.max((opts.pollInterval || DEFAULT_POLL_INTERVAL) - (performance.now() - lastReq), 1),
-    ).then(() => false)
-    if (opts.watch instanceof Promise) break$ = Promise.race([break$, opts.watch.then(() => true)])
-    if (await break$) break
-
-    lastReq = performance.now()
+  while (opts.watch && (!(opts.watch instanceof AbortSignal) || !opts.watch.aborted)) {
+    const lastReq = performance.now()
     batch = await connection.getSignaturesForAddress(
       new PublicKey(opts.address!),
       { limit, until },
@@ -86,6 +79,15 @@ async function* fetchSigsForward(
       until = sig.signature
       yield sig
     }
+
+    let delay$ = AbortSignal.timeout(
+      Math.max((opts.pollInterval || DEFAULT_POLL_INTERVAL) - (performance.now() - lastReq), 1),
+    )
+    if (opts.watch instanceof AbortSignal) {
+      if (opts.watch.aborted) break
+      delay$ = AbortSignal.any([opts.watch, delay$])
+    }
+    await signalToPromise(delay$).catch(() => false)
   }
 }
 

--- a/ccip-sdk/src/solana/utils.ts
+++ b/ccip-sdk/src/solana/utils.ts
@@ -345,13 +345,13 @@ export async function simulateTransaction(
 
   const result = await connection.simulateTransaction(tx, config)
 
+  logger.debug('Simulation results:', {
+    logs: result.value.logs,
+    unitsConsumed: result.value.unitsConsumed,
+    returnData: result.value.returnData,
+    err: result.value.err,
+  })
   if (result.value.err) {
-    logger.debug('Simulation results:', {
-      logs: result.value.logs,
-      unitsConsumed: result.value.unitsConsumed,
-      returnData: result.value.returnData,
-      err: result.value.err,
-    })
     // same error sendTransaction sends, to be catched up
     throw new SendTransactionError({
       action: 'simulate',

--- a/ccip-sdk/src/sui/events.ts
+++ b/ccip-sdk/src/sui/events.ts
@@ -8,7 +8,7 @@ import {
   CCIPLogsWatchRequiresFinalityError,
   CCIPTopicsInvalidError,
 } from '../errors/index.ts'
-import { sleep } from '../utils.ts'
+import { signalToPromise } from '../utils.ts'
 
 type MerkleRoot = {
   max_seq_nr: string
@@ -154,7 +154,10 @@ async function* fetchEventsForward<T>(
   let currentCheckpoint = startCheckpoint
   let catchedUp = false
 
-  while (opts.watch || !catchedUp) {
+  while (
+    (opts.watch && (!(opts.watch instanceof AbortSignal) || !opts.watch.aborted)) ||
+    !catchedUp
+  ) {
     const lastReq = performance.now()
 
     // Determine the range for this batch
@@ -264,12 +267,14 @@ async function* fetchEventsForward<T>(
     catchedUp ||= currentCheckpoint > batchEndCheckpoint
 
     if (opts.watch && catchedUp) {
-      let break$ = sleep(
+      let delay$ = AbortSignal.timeout(
         Math.max((opts.pollInterval || DEFAULT_POLL_INTERVAL) - (performance.now() - lastReq), 1),
-      ).then(() => false)
-      if (opts.watch instanceof Promise)
-        break$ = Promise.race([break$, opts.watch.then(() => true)])
-      if (await break$) break
+      )
+      if (opts.watch instanceof AbortSignal) {
+        if (opts.watch.aborted) break
+        delay$ = AbortSignal.any([opts.watch, delay$])
+      }
+      await signalToPromise(delay$).catch(() => false)
     }
   }
 }

--- a/ccip-sdk/src/sui/events.ts
+++ b/ccip-sdk/src/sui/events.ts
@@ -268,7 +268,10 @@ async function* fetchEventsForward<T>(
 
     if (opts.watch && catchedUp) {
       let delay$ = AbortSignal.timeout(
-        Math.max((opts.pollInterval || DEFAULT_POLL_INTERVAL) - (performance.now() - lastReq), 1),
+        Math.max(
+          Math.ceil((opts.pollInterval || DEFAULT_POLL_INTERVAL) - (performance.now() - lastReq)),
+          1,
+        ),
       )
       if (opts.watch instanceof AbortSignal) {
         if (opts.watch.aborted) break

--- a/ccip-sdk/src/sui/index.ts
+++ b/ccip-sdk/src/sui/index.ts
@@ -219,7 +219,7 @@ export class SuiChain extends Chain<typeof ChainFamily.Sui> {
    * @throws {@link CCIPTopicsInvalidError} if topics format is invalid
    */
   async *getLogs(opts: LogFilter & { versionAsHash?: boolean }) {
-    if (opts.watch && this.abort) {
+    if (opts.watch) {
       opts = {
         ...opts,
         watch:

--- a/ccip-sdk/src/sui/index.ts
+++ b/ccip-sdk/src/sui/index.ts
@@ -219,6 +219,15 @@ export class SuiChain extends Chain<typeof ChainFamily.Sui> {
    * @throws {@link CCIPTopicsInvalidError} if topics format is invalid
    */
   async *getLogs(opts: LogFilter & { versionAsHash?: boolean }) {
+    if (opts.watch && this.abort) {
+      opts = {
+        ...opts,
+        watch:
+          opts.watch instanceof AbortSignal
+            ? AbortSignal.any([opts.watch, this.abort])
+            : this.abort,
+      }
+    }
     if (!opts.address) throw new CCIPLogsAddressRequiredError()
 
     // Extract the event type from topics

--- a/ccip-sdk/src/ton/index.ts
+++ b/ccip-sdk/src/ton/index.ts
@@ -55,7 +55,6 @@ import {
   decodeAddress,
   networkInfo,
   parseTypeAndVersion,
-  sleep,
 } from '../utils.ts'
 import { generateUnsignedExecuteReport } from './exec.ts'
 import {
@@ -206,8 +205,8 @@ export class TONChain extends Chain<typeof ChainFamily.TON> {
     const { logger = console } = ctx ?? {}
     if (!url.endsWith('/jsonRPC')) url += '/jsonRPC'
 
-    let fetchFn
-    let httpAdapter
+    let fetchFn: typeof fetch | undefined
+    let httpAdapter: AxiosAdapter | undefined
     if (['toncenter.com', 'tonapi.io'].some((d) => url.includes(d))) {
       logger.warn(
         'Public TONCenter API calls are rate-limited to ~1 req/sec, some commands may be slow',
@@ -216,6 +215,20 @@ export class TONChain extends Chain<typeof ChainFamily.TON> {
       httpAdapter = (getAdapter as (name: string, config: object) => AxiosAdapter)('fetch', {
         env: { fetch: fetchFn },
       })
+    }
+
+    // Wrap the adapter (or the default 'http' adapter) so that every TonClient axios
+    // request inherits the abort signal. Without this, raceAc.abort() fires and prints
+    // "Aborting RPC race" but the in-flight axios socket has no signal to cancel against
+    // and stays alive in the keep-alive pool, preventing natural process exit.
+    if (ctx?.abort) {
+      const abort = ctx.abort
+      const base = httpAdapter ?? (getAdapter as (name: string) => AxiosAdapter)('http')
+      httpAdapter = (config) =>
+        base({
+          ...config,
+          signal: config.signal ? AbortSignal.any([config.signal as AbortSignal, abort]) : abort,
+        })
     }
 
     const client = new TonClient({ endpoint: url, httpAdapter })
@@ -372,6 +385,15 @@ export class TONChain extends Chain<typeof ChainFamily.TON> {
    * @throws {@link CCIPTopicsInvalidError} if topics format is invalid
    */
   async *getLogs(opts: LogFilter): AsyncIterableIterator<ChainLog> {
+    if (opts.watch && this.abort) {
+      opts = {
+        ...opts,
+        watch:
+          opts.watch instanceof AbortSignal
+            ? AbortSignal.any([opts.watch, this.abort])
+            : this.abort,
+      }
+    }
     let topics
     if (opts.topics?.length) {
       if (!opts.topics.every((topic) => typeof topic === 'string'))
@@ -1081,7 +1103,7 @@ export class TONChain extends Chain<typeof ChainFamily.TON> {
       address: onRamp,
       topics: [crc32('CCIPMessageSent')],
       startTime,
-      watch: sleep(5 * 60e3 /* 5m timeout */),
+      watch: AbortSignal.timeout(5 * 60e3 /* 5m timeout */),
     })) {
       const msg = TONChain.decodeMessage(log)
       if (!msg) continue
@@ -1159,7 +1181,7 @@ export class TONChain extends Chain<typeof ChainFamily.TON> {
       messageId: message.messageId,
       sourceChainSelector: message.sourceChainSelector,
       startTime,
-      watch: sleep(10 * 60e3 /* 10m */),
+      watch: AbortSignal.timeout(10 * 60e3 /* 10m */),
     })) {
       return exec // break and return on first yield
     }

--- a/ccip-sdk/src/ton/index.ts
+++ b/ccip-sdk/src/ton/index.ts
@@ -385,7 +385,7 @@ export class TONChain extends Chain<typeof ChainFamily.TON> {
    * @throws {@link CCIPTopicsInvalidError} if topics format is invalid
    */
   async *getLogs(opts: LogFilter): AsyncIterableIterator<ChainLog> {
-    if (opts.watch && this.abort) {
+    if (opts.watch) {
       opts = {
         ...opts,
         watch:

--- a/ccip-sdk/src/ton/logs.test.ts
+++ b/ccip-sdk/src/ton/logs.test.ts
@@ -505,7 +505,7 @@ describe('TON logs unit tests', () => {
         )
 
         // Create a promise that resolves after a short delay to stop watching
-        const stopWatch = new Promise((resolve) => setTimeout(resolve, 50))
+        const stopWatch = AbortSignal.timeout(50)
 
         const results: ChainTransaction[] = []
         for await (const tx of streamTransactionsForAddress(
@@ -541,7 +541,7 @@ describe('TON logs unit tests', () => {
         )
 
         // Create a promise that resolves quickly to stop the loop
-        const stopWatch = new Promise((resolve) => setTimeout(resolve, 50))
+        const stopWatch = AbortSignal.timeout(50)
 
         const results: ChainTransaction[] = []
         for await (const tx of streamTransactionsForAddress(
@@ -571,7 +571,7 @@ describe('TON logs unit tests', () => {
           createMockChainTransaction(tx.hash().toString('base64'), Number(tx.lt)),
         )
 
-        const stopWatch = new Promise((resolve) => setTimeout(resolve, 30))
+        const stopWatch = AbortSignal.timeout(30)
 
         const results: ChainTransaction[] = []
         const startTime = performance.now()
@@ -979,10 +979,7 @@ describe('TON logs unit tests', () => {
             createMockChainTransaction(tx.hash().toString('base64'), Number(tx.lt)),
           )
 
-          let resolveCancel: () => void
-          const cancelPromise = new Promise<void>((resolve) => {
-            resolveCancel = resolve
-          })
+          const cancelAc = new AbortController()
 
           const results: ChainTransaction[] = []
 
@@ -991,7 +988,7 @@ describe('TON logs unit tests', () => {
             {
               address: TEST_ADDRESS,
               startBlock: 100,
-              watch: cancelPromise,
+              watch: cancelAc.signal,
               pollInterval: 100,
             },
             { provider: mockProvider, getTransaction: mockGetTransaction },
@@ -1002,7 +999,7 @@ describe('TON logs unit tests', () => {
           results.push(first.value)
 
           // Cancel after short delay
-          setTimeout(() => resolveCancel!(), 10)
+          setTimeout(() => cancelAc.abort(), 10)
 
           // Try to get more (should stop)
           for await (const tx of iterator) {

--- a/ccip-sdk/src/ton/logs.ts
+++ b/ccip-sdk/src/ton/logs.ts
@@ -5,7 +5,7 @@ import type { LogFilter } from '../chain.ts'
 import { CCIPLogsRequiresStartError, CCIPLogsWatchRequiresFinalityError } from '../errors/index.ts'
 import { CCIPLogsAddressRequiredError } from '../errors/specialized.ts'
 import type { ChainTransaction } from '../types.ts'
-import { sleep } from '../utils.ts'
+import { signalToPromise } from '../utils.ts'
 
 const DEFAULT_POLL_INTERVAL = 5000
 
@@ -46,16 +46,9 @@ async function* fetchTxsForward(
   yield* allTxs // all past logs
 
   if (allTxs.length) until = allTxs[allTxs.length - 1]!.lt
-  let lastReq = performance.now()
   // if not watch mode, returns
-  while (opts.watch) {
-    let break$ = sleep(
-      Math.max((opts.pollInterval || DEFAULT_POLL_INTERVAL) - (performance.now() - lastReq), 1),
-    ).then(() => false)
-    if (opts.watch instanceof Promise) break$ = Promise.race([break$, opts.watch.then(() => true)])
-    if (await break$) break
-
-    lastReq = performance.now()
+  while (opts.watch && (!(opts.watch instanceof AbortSignal) || !opts.watch.aborted)) {
+    const lastReq = performance.now()
     batch = await provider.getTransactions(Address.parse(opts.address!), {
       limit,
       to_lt: until?.toString(),
@@ -67,6 +60,15 @@ async function* fetchTxsForward(
       until = tx.lt
       yield tx
     }
+
+    let delay$ = AbortSignal.timeout(
+      Math.max((opts.pollInterval || DEFAULT_POLL_INTERVAL) - (performance.now() - lastReq), 1),
+    )
+    if (opts.watch instanceof AbortSignal) {
+      if (opts.watch.aborted) break
+      delay$ = AbortSignal.any([opts.watch, delay$])
+    }
+    await signalToPromise(delay$).catch(() => false)
   }
 }
 

--- a/ccip-sdk/src/ton/logs.ts
+++ b/ccip-sdk/src/ton/logs.ts
@@ -62,7 +62,10 @@ async function* fetchTxsForward(
     }
 
     let delay$ = AbortSignal.timeout(
-      Math.max((opts.pollInterval || DEFAULT_POLL_INTERVAL) - (performance.now() - lastReq), 1),
+      Math.max(
+        Math.ceil((opts.pollInterval || DEFAULT_POLL_INTERVAL) - (performance.now() - lastReq)),
+        1,
+      ),
     )
     if (opts.watch instanceof AbortSignal) {
       if (opts.watch.aborted) break

--- a/ccip-sdk/src/utils.ts
+++ b/ccip-sdk/src/utils.ts
@@ -744,7 +744,7 @@ const perHostnameRateLimits: Record<string, RateLimit> = {}
  */
 export function createRateLimitedFetch(
   opts: Partial<RateLimitOpts> = {},
-  { logger = console }: WithLogger = {},
+  { logger = console, abort }: { abort?: AbortSignal } & WithLogger = {},
 ): typeof fetch {
   opts.maxRequests ??= 40
   opts.maxRetries ??= 5
@@ -792,6 +792,12 @@ export function createRateLimitedFetch(
         await rl.waitForRateLimit(opts_, method)
         rl.recordRequest(method)
 
+        if (init?.signal && abort) init.signal = AbortSignal.any([init.signal, abort])
+        else if (abort) {
+          if (!init) init = {}
+          init.signal = abort
+        }
+        abort?.throwIfAborted()
         const response = await globalThis.fetch(
           input instanceof Request ? input.clone() : input,
           init,
@@ -902,3 +908,30 @@ const util =
         }),
       }
 export { util }
+
+const registry = new FinalizationRegistry(
+  ({ signal, listener }: { signal: AbortSignal; listener: () => void }) =>
+    signal.removeEventListener('abort', listener),
+)
+
+/**
+ * Converts an AbortSignal into a Promise that rejects when the signal is aborted.
+ * @param signal - AbortSignal to convert
+ * @returns Promise that rejects with the signal's reason when aborted
+ */
+export function signalToPromise(signal: AbortSignal): Promise<never> {
+  if (signal.aborted) return Promise.reject(signal.reason as Error)
+
+  const { promise, reject } = Promise.withResolvers<never>()
+  const weakReject = new WeakRef(reject)
+
+  const listener = () => {
+    const rejectFn = weakReject.deref()
+    rejectFn?.(signal.reason)
+  }
+
+  signal.addEventListener('abort', listener, { once: true })
+  registry.register(promise, { signal, listener })
+
+  return promise
+}

--- a/ccip-sdk/src/utils.ts
+++ b/ccip-sdk/src/utils.ts
@@ -811,7 +811,7 @@ export function createRateLimitedFetch(
           logger.debug(
             'fetched',
             response.status,
-            response.headers,
+            // response.headers,
             body,
             // ((await response.clone().json()) as { result: unknown })?.result,
           )

--- a/docs/adding-new-chain.md
+++ b/docs/adding-new-chain.md
@@ -198,7 +198,7 @@ Your constructor should:
 
 1. **Call `super(network, ctx)`** - The base class handles logger and API client initialization
 2. **Store your chain's client** - The SDK client for your chain (e.g., ethers provider, Solana connection)
-3. **Setup `destroy$` pattern** - For resource cleanup (see Engineering Patterns)
+3. **Wire `abort` signal** - For resource cleanup and watch-loop cancellation (see Engineering Patterns)
 4. **Memoize expensive methods** - Cache RPC calls like `getTransaction`, `typeAndVersion` (see Engineering Patterns)
 
 **Reference:** See `EVMChain` or `SolanaChain` constructors for complete examples.
@@ -329,17 +329,21 @@ The SDK uses `micro-memoize` to cache expensive RPC calls. Memoize methods in yo
 
 **Methods to memoize:** `typeAndVersion`, `getTransaction`, `getTokenInfo`, `getTokenForTokenPool`, `getNativeTokenForRouter`, `getTokenAdminRegistryFor`, `getFeeTokens`
 
-### Resource Cleanup (`destroy$` Pattern)
+### Resource Cleanup (AbortSignal Pattern)
 
-Chain instances hold network connections that need cleanup.
+Chain instances hold network connections that need cleanup. The SDK uses the standard `AbortSignal` / `AbortController` API instead of a custom `destroy$` promise.
 
 **Pattern:**
 
-1. Create `destroy$: Promise<void>` that resolves when `destroy()` is called
-2. Use `destroy$.finally()` to clean up the client connection
-3. In `getLogs`, integrate `destroy$` with watch cancellation via `Promise.race`
+1. Pass an `abort?: AbortSignal` in `ChainContext` (the base `Chain` class stores it as `this.abort`)
+2. In your constructor (or `fromUrl` factory), attach a one-time abort listener on `ctx?.abort` to destroy the client:
+   ```ts
+   ctx?.abort?.addEventListener('abort', () => client.destroy(), { once: true })
+   ```
+3. In `getLogs`, merge per-call watch signals with `this.abort` via `AbortSignal.any([this.abort, opts.watch])`
+4. For explicit per-chain cleanup (e.g., in tests), call `chain.provider.destroy()` directly or fire the signal
 
-**Reference:** See `EVMChain` constructor for the pattern.
+**Reference:** See `EVMChain` constructor for the complete pattern.
 
 ### Error Handling Conventions
 
@@ -360,7 +364,8 @@ Chain instances hold network connections that need cleanup.
 
 - Forward iteration from required `startBlock`/`startTime` hints
 - Watch mode validation and polling
-- Integration with `destroy$` for cancellation
+- Integration with `this.abort` (merged via `AbortSignal.any`) for cancellation
+- Poll delays use `AbortSignal.timeout(ms)` instead of `sleep(ms)` promises
 
 **Reference:** See `ccip-sdk/src/evm/index.ts` for complete implementations.
 
@@ -391,7 +396,7 @@ Before submitting your PR:
 - [ ] Chain class extends `Chain<typeof ChainFamily.YourChain>`
 - [ ] Static registration block added (`static { supportedChains[...] = ... }`)
 - [ ] All abstract methods implemented
-- [ ] `destroy$` cleanup pattern implemented
+- [ ] AbortSignal cleanup wired in constructor (`ctx?.abort?.addEventListener('abort', () => ..., { once: true })`)
 - [ ] Key methods memoized (see Engineering Patterns)
 
 **Types and Exports:**

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,27 @@
         "node": ">=20.0.0"
       }
     },
+    "ccip-api-ref/node_modules/react": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
+      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "ccip-api-ref/node_modules/react-dom": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
+      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.5"
+      }
+    },
     "ccip-cli": {
       "name": "@chainlink/ccip-cli",
       "version": "1.6.0",
@@ -72,7 +93,7 @@
         "@chainlink/ccip-sdk": "^1.6.0",
         "@coral-xyz/anchor": "^0.29.0",
         "@ethers-ext/signer-ledger": "^6.0.0-beta.1",
-        "@inquirer/prompts": "8.4.1",
+        "@inquirer/prompts": "8.4.2",
         "@ledgerhq/hw-app-aptos": "6.37.0",
         "@ledgerhq/hw-app-solana": "7.9.0",
         "@ledgerhq/hw-transport-node-hid": "6.32.0",
@@ -102,39 +123,10 @@
         "typescript-eslint": "8.58.2"
       }
     },
-    "ccip-cli/node_modules/cliui": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
-      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^7.2.0",
-        "strip-ansi": "^7.1.0",
-        "wrap-ansi": "^9.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "ccip-cli/node_modules/string-width": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "ccip-cli/node_modules/yargs": {
       "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
       "license": "MIT",
       "dependencies": {
         "cliui": "^9.0.1",
@@ -150,6 +142,8 @@
     },
     "ccip-cli/node_modules/yargs-parser": {
       "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
       "license": "ISC",
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=23"
@@ -169,8 +163,8 @@
         "@ton/core": "0.63.1",
         "@ton/crypto": "^3.3.0",
         "@ton/ton": "^16.2.4",
-        "abitype": "1.2.3",
-        "axios": "1.15.0",
+        "abitype": "1.2.4",
+        "axios": "1.15.2",
         "bn.js": "^5.2.3",
         "borsh": "^2.0.0",
         "bs58": "^6.0.0",
@@ -210,6 +204,8 @@
     },
     "ccip-sdk/node_modules/borsh": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/borsh/-/borsh-2.0.0.tgz",
+      "integrity": "sha512-kc9+BgR3zz9+cjbwM8ODoUB4fs3X3I5A/HtX7LZKxCLaMrEeDFoBpnhZY//DTS1VZBSs6S5v46RZRbZjRFspEg==",
       "license": "Apache-2.0"
     },
     "node_modules/@0no-co/graphql.web": {
@@ -247,15 +243,15 @@
       "license": "MIT"
     },
     "node_modules/@algolia/abtesting": {
-      "version": "1.16.2",
-      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.16.2.tgz",
-      "integrity": "sha512-n9s6bEV6imdtIEd+BGP7WkA4pEZ5YTdgQ05JQhHwWawHg3hyjpNwC0TShGz6zWhv+jfLDGA/6FFNbySFS0P9cw==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.17.0.tgz",
+      "integrity": "sha512-nuhHZdTiCtRzJEe9VSNzyqE9cOQMt01UWBzymFnjbgwrxxZpbGHQde6Oa/y9zyspTCjbUtb7Q5HQek1CLiLyeg==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.2",
-        "@algolia/requester-browser-xhr": "5.50.2",
-        "@algolia/requester-fetch": "5.50.2",
-        "@algolia/requester-node-http": "5.50.2"
+        "@algolia/client-common": "5.51.0",
+        "@algolia/requester-browser-xhr": "5.51.0",
+        "@algolia/requester-fetch": "5.51.0",
+        "@algolia/requester-node-http": "5.51.0"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -294,99 +290,99 @@
       }
     },
     "node_modules/@algolia/client-abtesting": {
-      "version": "5.50.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.50.2.tgz",
-      "integrity": "sha512-52iq0vHy1sphgnwoZyx5PmbEt8hsh+m7jD123LmBs6qy4GK7LbYZIeKd+nSnSipN2zvKRZ2zScS6h9PW3J7SXg==",
+      "version": "5.51.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.51.0.tgz",
+      "integrity": "sha512-PKrKlIla1U2J7mFcIQn6N3pWP4oySmkxShnbbDsj/H7818gKbET5KsUwsVoNjWIxHKTJMCTcQ7ekAJ8Ea23NMg==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.2",
-        "@algolia/requester-browser-xhr": "5.50.2",
-        "@algolia/requester-fetch": "5.50.2",
-        "@algolia/requester-node-http": "5.50.2"
+        "@algolia/client-common": "5.51.0",
+        "@algolia/requester-browser-xhr": "5.51.0",
+        "@algolia/requester-fetch": "5.51.0",
+        "@algolia/requester-node-http": "5.51.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-analytics": {
-      "version": "5.50.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.50.2.tgz",
-      "integrity": "sha512-WpPIUg+cSG2aPUG0gS8Ko9DwRgbRPUZxJkolhL2aCsmSlcEEZT65dILrfg5ovcxtx0Kvr+xtBVsTMtsQWRtPDQ==",
+      "version": "5.51.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.51.0.tgz",
+      "integrity": "sha512-U+HCY1K16Km91pIRL1kN6bW6BbGFAF/WhkRSCx4wyl1aFpbrlhSFQs/dAwWbmyBiHWwVWhl7stWHQ1pum5EfMw==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.2",
-        "@algolia/requester-browser-xhr": "5.50.2",
-        "@algolia/requester-fetch": "5.50.2",
-        "@algolia/requester-node-http": "5.50.2"
+        "@algolia/client-common": "5.51.0",
+        "@algolia/requester-browser-xhr": "5.51.0",
+        "@algolia/requester-fetch": "5.51.0",
+        "@algolia/requester-node-http": "5.51.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-common": {
-      "version": "5.50.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.50.2.tgz",
-      "integrity": "sha512-Gj2MgtArGcsr82kIqRlo6/dCAFjrs2gLByEqyRENuT7ugrSMFuqg1vDzeBjRL1t3EJEJCFtT0PLX3gB8A6Hq4Q==",
+      "version": "5.51.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.51.0.tgz",
+      "integrity": "sha512-YPJ3dEuZLCRp846Az94t6Z2gwSNRazP+SmBco7p6SCa4fYrtIE820PDXYZshbNrj2Z8Qfbmv7BQ1Lecl5L3G/w==",
       "license": "MIT",
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-insights": {
-      "version": "5.50.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.50.2.tgz",
-      "integrity": "sha512-CUqoid5jDpmrc0oK3/xuZXFt6kwT0P9Lw7/nsM14YTr6puvmi+OUKmURpmebQF22S2vCG8L1DAoXXujxQUi/ug==",
+      "version": "5.51.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.51.0.tgz",
+      "integrity": "sha512-/gEwLlR7fQ7YjOW+ADRZ0NxLDtpTC61FSzlZ01Gdl1kTJfU0Rq3Y/TYqwxGxlQGcUiXtGzrpjxXWh3Y0TZD6NA==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.2",
-        "@algolia/requester-browser-xhr": "5.50.2",
-        "@algolia/requester-fetch": "5.50.2",
-        "@algolia/requester-node-http": "5.50.2"
+        "@algolia/client-common": "5.51.0",
+        "@algolia/requester-browser-xhr": "5.51.0",
+        "@algolia/requester-fetch": "5.51.0",
+        "@algolia/requester-node-http": "5.51.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-personalization": {
-      "version": "5.50.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.50.2.tgz",
-      "integrity": "sha512-AndZWFoc0gbP5901OeQJ73BazgGgSGiBEba4ohdoJuZwHTO2Gio8Q4L1VLmytMBYcviVigB0iICToMvEJxI4ug==",
+      "version": "5.51.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.51.0.tgz",
+      "integrity": "sha512-nRwUN1Y2cKyOAFZyIBagkEfZSIhP05nWhT4Rjwl84lcjECssYggftrAODrZ4leakXxSGjhxs/AdaAFEIBqwVFA==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.2",
-        "@algolia/requester-browser-xhr": "5.50.2",
-        "@algolia/requester-fetch": "5.50.2",
-        "@algolia/requester-node-http": "5.50.2"
+        "@algolia/client-common": "5.51.0",
+        "@algolia/requester-browser-xhr": "5.51.0",
+        "@algolia/requester-fetch": "5.51.0",
+        "@algolia/requester-node-http": "5.51.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-query-suggestions": {
-      "version": "5.50.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.50.2.tgz",
-      "integrity": "sha512-NWoL+psEkz5dIzweaByVXuEB45wS8/rk0E0AhMMnaVJdVs7TcACPH2/OURm+N0xRDITkTHqCna823rd6Uqntdg==",
+      "version": "5.51.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.51.0.tgz",
+      "integrity": "sha512-pybzYCG7VoQKppo+z5iZOKpW8XqtFxhsAIRgEaNboCnfypKukiBHJAwB+pmr7vMZXBsOHwklGYWwCG82e8qshA==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.2",
-        "@algolia/requester-browser-xhr": "5.50.2",
-        "@algolia/requester-fetch": "5.50.2",
-        "@algolia/requester-node-http": "5.50.2"
+        "@algolia/client-common": "5.51.0",
+        "@algolia/requester-browser-xhr": "5.51.0",
+        "@algolia/requester-fetch": "5.51.0",
+        "@algolia/requester-node-http": "5.51.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-search": {
-      "version": "5.50.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.50.2.tgz",
-      "integrity": "sha512-ypSboUJ3XJoQz5DeDo82hCnrRuwq3q9ZdFhVKAik9TnZh1DvLqoQsrbBjXg7C7zQOtV/Qbge/HmyoV6V5L7MhQ==",
+      "version": "5.51.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.51.0.tgz",
+      "integrity": "sha512-DWVIlj6RqcvdhwP0gBU9OpOQPnHdcAk9jlT+z8rsNb2+liWv4eUlfQZ7saGBraFsnygEHD3PtdppIHvqwBAb5w==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.2",
-        "@algolia/requester-browser-xhr": "5.50.2",
-        "@algolia/requester-fetch": "5.50.2",
-        "@algolia/requester-node-http": "5.50.2"
+        "@algolia/client-common": "5.51.0",
+        "@algolia/requester-browser-xhr": "5.51.0",
+        "@algolia/requester-fetch": "5.51.0",
+        "@algolia/requester-node-http": "5.51.0"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -399,81 +395,81 @@
       "license": "MIT"
     },
     "node_modules/@algolia/ingestion": {
-      "version": "1.50.2",
-      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.50.2.tgz",
-      "integrity": "sha512-VlR2FRXLw2bCB94SQo6zxg/Qi+547aOji6Pb+dKE7h1DMCCY317St+OpjpmgzE+bT2O9ALIc0V4nVIBOd7Gy+Q==",
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.51.0.tgz",
+      "integrity": "sha512-bA25s12iUDJi/X8M7tWlPRT8GeOhls/yDbdoUqinz27lNqsOlcM1UrAxIKdIZ6lm3sXit+ewPIz1pS2x6rXu8g==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.2",
-        "@algolia/requester-browser-xhr": "5.50.2",
-        "@algolia/requester-fetch": "5.50.2",
-        "@algolia/requester-node-http": "5.50.2"
+        "@algolia/client-common": "5.51.0",
+        "@algolia/requester-browser-xhr": "5.51.0",
+        "@algolia/requester-fetch": "5.51.0",
+        "@algolia/requester-node-http": "5.51.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/monitoring": {
-      "version": "1.50.2",
-      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.50.2.tgz",
-      "integrity": "sha512-Cmvfp2+qopzQt8OilU97rhLhosq7ZrB6uieok3EwFUqG/aalPg6DgfCmu0yJMrYe+KMC1qRVt1MTRAUwLknUMQ==",
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.51.0.tgz",
+      "integrity": "sha512-zj+RcE5e0NE0/ew6oEOTgOplPHry+w2oi7h0Y87lhdq4E0d7xLS31KVB8kKfCGkrG7AYtZvrcyvLOKS5d0no4Q==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.2",
-        "@algolia/requester-browser-xhr": "5.50.2",
-        "@algolia/requester-fetch": "5.50.2",
-        "@algolia/requester-node-http": "5.50.2"
+        "@algolia/client-common": "5.51.0",
+        "@algolia/requester-browser-xhr": "5.51.0",
+        "@algolia/requester-fetch": "5.51.0",
+        "@algolia/requester-node-http": "5.51.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/recommend": {
-      "version": "5.50.2",
-      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.50.2.tgz",
-      "integrity": "sha512-jrkuyKoOM7dFWQ/6Y4hQAse2SC3L/RldG6GnPjMvAj65h+7Ubb51S0pKk4ofSStF0xm4LCNe0C4T6XX4nOFDiQ==",
+      "version": "5.51.0",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.51.0.tgz",
+      "integrity": "sha512-/HDgccfye1Rq3bPxaSCsvSEBHzSMmtpM9ZRGRtAuC62Cv+ql/76IWnxjGTDXtqIJ+/j7ZlFYAzq9fkp95wF2SQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.2",
-        "@algolia/requester-browser-xhr": "5.50.2",
-        "@algolia/requester-fetch": "5.50.2",
-        "@algolia/requester-node-http": "5.50.2"
+        "@algolia/client-common": "5.51.0",
+        "@algolia/requester-browser-xhr": "5.51.0",
+        "@algolia/requester-fetch": "5.51.0",
+        "@algolia/requester-node-http": "5.51.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-browser-xhr": {
-      "version": "5.50.2",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.50.2.tgz",
-      "integrity": "sha512-4107YLJqCudPiBUlwnk6oTSUVwU7ab+qL1SfQGEDYI8DZH5gsf1ekPt9JykXRKYXf2IfouFL5GiCY/PHTFIjYw==",
+      "version": "5.51.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.51.0.tgz",
+      "integrity": "sha512-nJdW+WBwGlXWMJbxxB7/AJPvNq0lLJSudXmIQCJbmH8jsOXQhRpAtoCD4ceLyJKv3ze9JbQu4Gqu5JDLckuFcw==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.2"
+        "@algolia/client-common": "5.51.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-fetch": {
-      "version": "5.50.2",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.50.2.tgz",
-      "integrity": "sha512-vOrd3MQpLgmf6wXAueTuZ/cA0W4uRwIHHaxNy3h+a6YcNn6bCV/gFdZuv3F13v593zRU2k5R75NmvRWLenvMrw==",
+      "version": "5.51.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.51.0.tgz",
+      "integrity": "sha512-bsBgRI/1h1mjS3eCyfGau78yGZVmiDLmT1aU6dMnk75/T0SgKqnSKNpQ53xKoDYVChGDcNnpHXWpoUSo8MH1+w==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.2"
+        "@algolia/client-common": "5.51.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-node-http": {
-      "version": "5.50.2",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.50.2.tgz",
-      "integrity": "sha512-Mu9BFtgzGqDUy5Bcs2nMyoILIFSN13GKQaklKAFIsd0K3/9CpNyfeBc+/+Qs6mFZLlxG9qzullO7h+bjcTBuGQ==",
+      "version": "5.51.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.51.0.tgz",
+      "integrity": "sha512-zPrIDVPpmKWgrjmWOqpqrhqAhNjvVkjoj+mqw2NBPxEOuKNzP0H+Qz5NJLLTOepBVj1UFedFaF3AUgxLsB9ukQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.2"
+        "@algolia/client-common": "5.51.0"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -670,15 +666,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^3.0.2"
-      }
-    },
     "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -687,12 +674,6 @@
       "bin": {
         "semver": "bin/semver.js"
       }
-    },
-    "node_modules/@babel/helper-compilation-targets/node_modules/yallist": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "license": "ISC"
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
       "version": "7.28.6",
@@ -4451,23 +4432,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/@docusaurus/core/node_modules/wrap-ansi": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
     "node_modules/@docusaurus/cssnano-preset": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.10.0.tgz",
@@ -6977,21 +6941,21 @@
       }
     },
     "node_modules/@inquirer/prompts": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.4.1.tgz",
-      "integrity": "sha512-AH5xPQ997K7e0F0vulPlteIHke2awMkFi8F0dBemrDfmvtPmHJo82mdHbONC4F/t8d1NHwrbI5cGVI+RbLWdoQ==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.4.2.tgz",
+      "integrity": "sha512-XJmn/wY4AX56l1BRU+ZjDrFtg9+2uBEi4JvJQj82kwJDQKiPgSn4CEsbfGGygS4Gw6rkL4W18oATjfVfaqub2Q==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/checkbox": "^5.1.3",
-        "@inquirer/confirm": "^6.0.11",
-        "@inquirer/editor": "^5.1.0",
-        "@inquirer/expand": "^5.0.12",
-        "@inquirer/input": "^5.0.11",
-        "@inquirer/number": "^4.0.11",
-        "@inquirer/password": "^5.0.11",
-        "@inquirer/rawlist": "^5.2.7",
-        "@inquirer/search": "^4.1.7",
-        "@inquirer/select": "^5.1.3"
+        "@inquirer/checkbox": "^5.1.4",
+        "@inquirer/confirm": "^6.0.12",
+        "@inquirer/editor": "^5.1.1",
+        "@inquirer/expand": "^5.0.13",
+        "@inquirer/input": "^5.0.12",
+        "@inquirer/number": "^4.0.12",
+        "@inquirer/password": "^5.0.12",
+        "@inquirer/rawlist": "^5.2.8",
+        "@inquirer/search": "^4.1.8",
+        "@inquirer/select": "^5.1.4"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
@@ -7605,12 +7569,12 @@
       }
     },
     "node_modules/@ledgerhq/client-ids": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/client-ids/-/client-ids-0.8.2.tgz",
-      "integrity": "sha512-mfds5IyuJLDEwzIzHrYwii1YjP3EkY+txMInWDeektnafzC0nkKOirhluoCKUqtetwBuTUBYLDCf2eyfbmdtrQ==",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/client-ids/-/client-ids-0.8.3.tgz",
+      "integrity": "sha512-+0lR1JPxlV7ln2CForSLRj1jritH0+s6D4sP8RJysgv5aDFVdxZl0Wo4mpvxvnudqISqgN3Y3eyXnMNjJ7/1yA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ledgerhq/live-env": "^2.32.0",
+        "@ledgerhq/live-env": "^2.33.0",
         "@reduxjs/toolkit": "2.11.2",
         "uuid": "^9.0.0"
       }
@@ -7649,51 +7613,24 @@
       }
     },
     "node_modules/@ledgerhq/domain-service": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/domain-service/-/domain-service-1.7.4.tgz",
-      "integrity": "sha512-7QYkml4MBRMzQsj92xsafI6xum8xuyztTKKRGWMlV9kN47EdMukiOnr5Ywt6SZD3cDJ6cBWxtwj8n853LcdBcQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/domain-service/-/domain-service-1.8.0.tgz",
+      "integrity": "sha512-4L5OQy89saTZUIAIcsFNEwwyXkcJUsNC6Fj/V98fzCpUMqm5XHBXSiiF2B8sNCIx+fcghW9ELXJniB2ijBWZKw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ledgerhq/errors": "^6.33.0",
+        "@ledgerhq/errors": "^6.34.0",
         "@ledgerhq/logs": "^6.17.0",
-        "@ledgerhq/types-live": "^6.104.0",
+        "@ledgerhq/types-live": "^6.105.0",
         "axios": "1.13.2",
         "eip55": "^2.1.1",
         "react": "19.0.0",
         "react-dom": "19.0.0"
       }
     },
-    "node_modules/@ledgerhq/domain-service/node_modules/react": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
-      "integrity": "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@ledgerhq/domain-service/node_modules/react-dom": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.0.0.tgz",
-      "integrity": "sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==",
-      "license": "MIT",
-      "dependencies": {
-        "scheduler": "^0.25.0"
-      },
-      "peerDependencies": {
-        "react": "^19.0.0"
-      }
-    },
-    "node_modules/@ledgerhq/domain-service/node_modules/scheduler": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
-      "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
-      "license": "MIT"
-    },
     "node_modules/@ledgerhq/errors": {
-      "version": "6.33.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-6.33.0.tgz",
-      "integrity": "sha512-9iMdjB0Hfxfd8HGMVM0TDPfxBXhJ4MtGKyFlm8aveSHSXjcTjGtCkcnk4OUZ6ZHopBb69BFR+HC2N/ob9xuNgA==",
+      "version": "6.34.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-6.34.0.tgz",
+      "integrity": "sha512-l16K56FzPoXBMT5J4EpnIBmRLTYkpSyYj3z4er+rmbwq0t9dDG/UaRvFeBpwB2gqGcYWcue14qF9Wkuos/43eA==",
       "license": "Apache-2.0"
     },
     "node_modules/@ledgerhq/hw-app-aptos": {
@@ -7751,36 +7688,36 @@
       }
     },
     "node_modules/@ledgerhq/hw-transport-mocker": {
-      "version": "6.34.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-mocker/-/hw-transport-mocker-6.34.0.tgz",
-      "integrity": "sha512-gFxz0oZXNIoye6qKHddjyprBTErvvEPic2SZbbZHXMc4KHkZuSmpkLOrzqs+iPMiT8OqykuYHV3wAzU2Mu1+Ww==",
+      "version": "6.34.1",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-mocker/-/hw-transport-mocker-6.34.1.tgz",
+      "integrity": "sha512-TfrE+nhKYS+j7DpJ5worRrf1buV7HasLnT/pwJT5Hhs8ve6QN6Aaz4d4t4/FWCy4CqKaROyL0/Piu046/dQwiQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ledgerhq/hw-transport": "6.35.0",
+        "@ledgerhq/hw-transport": "6.35.1",
         "@ledgerhq/logs": "^6.17.0",
         "rxjs": "7.8.2"
       }
     },
     "node_modules/@ledgerhq/hw-transport-mocker/node_modules/@ledgerhq/devices": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-8.14.0.tgz",
-      "integrity": "sha512-eMGOaagkMJrqGtqemYNraPg38FA0I/UUEPrbrC+vOZu1qeoG+Sek3gjuJih6rMK4efUfcI4Zs19w/Hv/58fwkQ==",
+      "version": "8.14.1",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-8.14.1.tgz",
+      "integrity": "sha512-q6tOUO963tFPrsJtdzu5juC8xIAIRe6etLSZ+ZhwgUivTHNJbmFFBxMU3p19dwn8VaKRvbw0pxJv+qmokMYpRA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ledgerhq/errors": "^6.33.0",
+        "@ledgerhq/errors": "^6.34.0",
         "@ledgerhq/logs": "^6.17.0",
         "rxjs": "7.8.2",
         "semver": "7.7.3"
       }
     },
     "node_modules/@ledgerhq/hw-transport-mocker/node_modules/@ledgerhq/hw-transport": {
-      "version": "6.35.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-6.35.0.tgz",
-      "integrity": "sha512-BFk4Zr5gfzT40RT6nj0NQTNB25bxWD3QWhdrOA6Mi/CChFTdGomjOuAhWHla2kH50ft8M5UsiiUeHoR+56J69g==",
+      "version": "6.35.1",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-6.35.1.tgz",
+      "integrity": "sha512-YCkk9koo0FzCzHvLVpdrQ3+EQOPMpp/fSednHhk7AiaJC/c+pX6wKevUDp1MLcq7gUHbVOXyYYpqoW6A97w8OA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ledgerhq/devices": "8.14.0",
-        "@ledgerhq/errors": "^6.33.0",
+        "@ledgerhq/devices": "8.14.1",
+        "@ledgerhq/errors": "^6.34.0",
         "@ledgerhq/logs": "^6.17.0",
         "events": "^3.3.0"
       }
@@ -7814,38 +7751,38 @@
       }
     },
     "node_modules/@ledgerhq/hw-transport-node-hid-noevents": {
-      "version": "6.35.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-node-hid-noevents/-/hw-transport-node-hid-noevents-6.35.0.tgz",
-      "integrity": "sha512-5ZPsxoaLOsXmV/mb7kaewmD7f1SXMcsrW+xfMNFUg73S5tC5n+apHerkd9FoQm32QOQ6CQPpW6kz5f5c5pNcug==",
+      "version": "6.35.1",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-node-hid-noevents/-/hw-transport-node-hid-noevents-6.35.1.tgz",
+      "integrity": "sha512-3NVgVYiACSXh1S1lgRjogNloF4Bewllv/nDydv8/Nc0DrnXJSGPNC+anl0ZR3cVo5Rg+iuZ1AvUKJFtmQZtt1A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ledgerhq/devices": "8.14.0",
-        "@ledgerhq/errors": "^6.33.0",
-        "@ledgerhq/hw-transport": "6.35.0",
+        "@ledgerhq/devices": "8.14.1",
+        "@ledgerhq/errors": "^6.34.0",
+        "@ledgerhq/hw-transport": "6.35.1",
         "@ledgerhq/logs": "^6.17.0",
         "node-hid": "2.1.2"
       }
     },
     "node_modules/@ledgerhq/hw-transport-node-hid-noevents/node_modules/@ledgerhq/devices": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-8.14.0.tgz",
-      "integrity": "sha512-eMGOaagkMJrqGtqemYNraPg38FA0I/UUEPrbrC+vOZu1qeoG+Sek3gjuJih6rMK4efUfcI4Zs19w/Hv/58fwkQ==",
+      "version": "8.14.1",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-8.14.1.tgz",
+      "integrity": "sha512-q6tOUO963tFPrsJtdzu5juC8xIAIRe6etLSZ+ZhwgUivTHNJbmFFBxMU3p19dwn8VaKRvbw0pxJv+qmokMYpRA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ledgerhq/errors": "^6.33.0",
+        "@ledgerhq/errors": "^6.34.0",
         "@ledgerhq/logs": "^6.17.0",
         "rxjs": "7.8.2",
         "semver": "7.7.3"
       }
     },
     "node_modules/@ledgerhq/hw-transport-node-hid-noevents/node_modules/@ledgerhq/hw-transport": {
-      "version": "6.35.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-6.35.0.tgz",
-      "integrity": "sha512-BFk4Zr5gfzT40RT6nj0NQTNB25bxWD3QWhdrOA6Mi/CChFTdGomjOuAhWHla2kH50ft8M5UsiiUeHoR+56J69g==",
+      "version": "6.35.1",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-6.35.1.tgz",
+      "integrity": "sha512-YCkk9koo0FzCzHvLVpdrQ3+EQOPMpp/fSednHhk7AiaJC/c+pX6wKevUDp1MLcq7gUHbVOXyYYpqoW6A97w8OA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ledgerhq/devices": "8.14.0",
-        "@ledgerhq/errors": "^6.33.0",
+        "@ledgerhq/devices": "8.14.1",
+        "@ledgerhq/errors": "^6.34.0",
         "@ledgerhq/logs": "^6.17.0",
         "events": "^3.3.0"
       }
@@ -7863,9 +7800,9 @@
       }
     },
     "node_modules/@ledgerhq/live-env": {
-      "version": "2.32.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/live-env/-/live-env-2.32.0.tgz",
-      "integrity": "sha512-5/6gQDRJCxluC3dy8WdtpfE13xLhwOOi07FF6uU57jtx4Pe2C8qKtvA4wnZD5I7R3RAKS4o84meSshGXNplcPA==",
+      "version": "2.33.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/live-env/-/live-env-2.33.0.tgz",
+      "integrity": "sha512-kDjMJp7zUTlxO6oNAiGV913jSg45GVPPybxG+RJKPyjdWtdBPD0LKGggx+zMzh8a2JAVAETG0+QLi0ZTYXkDtg==",
       "license": "Apache-2.0",
       "dependencies": {
         "rxjs": "7.8.2",
@@ -7879,12 +7816,12 @@
       "license": "Apache-2.0"
     },
     "node_modules/@ledgerhq/types-live": {
-      "version": "6.104.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/types-live/-/types-live-6.104.0.tgz",
-      "integrity": "sha512-5WLoFeKaassNM9dDKkiv8FCn5JRntghq208IV/MEDNj02oTkaZSHFUVuBFQEw3d6m2svkF40aMlI2gnf0tNMoQ==",
+      "version": "6.105.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/types-live/-/types-live-6.105.0.tgz",
+      "integrity": "sha512-Mojj/8wUwTi9HQ0Z3XShUfapeMDrY+F9E0i7rYJO/a9qAFor8Qtb567YLfyb+NVv+HIv+YabW94NgtJ3L/8jLA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ledgerhq/client-ids": "0.8.2",
+        "@ledgerhq/client-ids": "0.8.3",
         "bignumber.js": "^9.1.2",
         "rxjs": "7.8.2"
       }
@@ -7978,30 +7915,6 @@
         "resolve": "~1.22.2"
       }
     },
-    "node_modules/@microsoft/tsdoc-config/node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/@microsoft/tsdoc-config/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@mysten/bcs": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@mysten/bcs/-/bcs-2.0.3.tgz",
@@ -8010,6 +7923,15 @@
       "dependencies": {
         "@mysten/utils": "^0.3.1",
         "@scure/base": "^2.0.0"
+      }
+    },
+    "node_modules/@mysten/bcs/node_modules/@scure/base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@mysten/sui": {
@@ -8065,67 +7987,37 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@mysten/sui/node_modules/@scure/base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@mysten/sui/node_modules/@scure/bip32": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-2.0.1.tgz",
-      "integrity": "sha512-4Md1NI5BzoVP+bhyJaY3K6yMesEFzNS1sE/cP+9nuvE7p/b0kx9XbpDHHFl8dHtufcbdHRUUQdRqLIPHN/s7yA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-2.2.0.tgz",
+      "integrity": "sha512-zFr7t2F+a9+5tB7QbarF2HQNYrgjCNaoLAupZdKkrFMYMozJf5zqH2WJCQibMzm1qQ0QogrxVGO3qXfQDYMaQg==",
       "license": "MIT",
       "dependencies": {
-        "@noble/curves": "2.0.1",
-        "@noble/hashes": "2.0.1",
-        "@scure/base": "2.0.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@mysten/sui/node_modules/@scure/bip32/node_modules/@noble/curves": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.0.1.tgz",
-      "integrity": "sha512-vs1Az2OOTBiP4q0pwjW5aF0xp9n4MxVrmkFBxc6EKZc6ddYx5gaZiAsZoq0uRRXWbi3AT/sBqn05eRPtn1JCPw==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "2.0.1"
-      },
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@mysten/sui/node_modules/@scure/bip32/node_modules/@noble/hashes": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
-      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20.19.0"
+        "@noble/curves": "2.2.0",
+        "@noble/hashes": "2.2.0",
+        "@scure/base": "2.2.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@mysten/sui/node_modules/@scure/bip39": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-2.0.1.tgz",
-      "integrity": "sha512-PsxdFj/d2AcJcZDX1FXN3dDgitDDTmwf78rKZq1a6c1P1Nan1X/Sxc7667zU3U+AN60g7SxxP0YCVw2H/hBycg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-2.2.0.tgz",
+      "integrity": "sha512-T/Bj/YvYMNkIPq6EENO6/rcs2e7qTNuyoUXf0KBFDmp0ZDu0H2X4Lq6yC3i0c8PcWkov5EbW+yQZZbdMmk154A==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "2.0.1",
-        "@scure/base": "2.0.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@mysten/sui/node_modules/@scure/bip39/node_modules/@noble/hashes": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
-      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20.19.0"
+        "@noble/hashes": "2.2.0",
+        "@scure/base": "2.2.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -8138,6 +8030,15 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@scure/base": "^2.0.0"
+      }
+    },
+    "node_modules/@mysten/utils/node_modules/@scure/base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -8820,6 +8721,19 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/@parcel/watcher/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/@peculiar/asn1-cms": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.6.1.tgz",
@@ -9069,29 +8983,23 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/@redocly/ajv/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
-    },
     "node_modules/@redocly/config": {
-      "version": "0.48.0",
-      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.48.0.tgz",
-      "integrity": "sha512-8W3wz+Q7y4e9klJWlYOvQWK5r7P2Mo589vcjtlT5coOxsyAdt53k8Vb8iAqnRiGWExbjBQmSbL2XbuU747Nf6Q==",
+      "version": "0.48.1",
+      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.48.1.tgz",
+      "integrity": "sha512-vq8GM3e0KiglqkwE5Lb9XayrmZY4dHCs21BsvV92yAZN68f1N9cZUuwY1SwnztPbH06dn9uLzubBl/JNfImqfA==",
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "2.7.2"
       }
     },
     "node_modules/@redocly/openapi-core": {
-      "version": "2.29.0",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-2.29.0.tgz",
-      "integrity": "sha512-hIbOw1ZY01NhjEGwAuG/OXy19EAY31W7J7b061aNpCzJ8+mFyyy52X4CTrpF2c0rbemSLobXowvAEddVSX1QzQ==",
+      "version": "2.29.2",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-2.29.2.tgz",
+      "integrity": "sha512-je4yu+QgSOSx+wN5IcpCaoZwNAAnaLnmSeN8GDC6lX2l51ukyQBFjZ+/LeCrVgOrUA3aRZRRHgZoRtcemIfm+A==",
       "license": "MIT",
       "dependencies": {
         "@redocly/ajv": "^8.18.0",
-        "@redocly/config": "^0.48.0",
+        "@redocly/config": "^0.48.1",
         "ajv": "npm:@redocly/ajv@8.18.0",
         "ajv-formats": "^3.0.1",
         "colorette": "^1.2.0",
@@ -9106,28 +9014,17 @@
         "npm": ">=10"
       }
     },
-    "node_modules/@redocly/openapi-core/node_modules/ajv": {
-      "name": "@redocly/ajv",
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-F+LMD2IDIXuHxgpLJh3nkLj9+tSaEzoUWd+7fONGq5pe2169FUDjpEkOfEpoGLz1sbZni/69p07OsecNfAOpqA==",
+    "node_modules/@redocly/openapi-core/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
+      "engines": {
+        "node": ">=12"
       },
       "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
-    },
-    "node_modules/@redocly/openapi-core/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
     },
     "node_modules/@reduxjs/toolkit": {
       "version": "2.11.2",
@@ -9156,9 +9053,9 @@
       }
     },
     "node_modules/@scure/base": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
-      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -9178,15 +9075,6 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/@scure/bip32/node_modules/@scure/base": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
-      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@scure/bip39": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
@@ -9196,15 +9084,6 @@
         "@noble/hashes": "~1.8.0",
         "@scure/base": "~1.2.5"
       },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@scure/bip39/node_modules/@scure/base": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
-      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
-      "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
@@ -9385,15 +9264,18 @@
       }
     },
     "node_modules/@solana/codecs-core": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0-rc.1.tgz",
-      "integrity": "sha512-bauxqMfSs8EHD0JKESaNmNuNvkvHSuN3bbWAF5RjOfDu2PugxHrvRebmYauvSumZ3cTfQ4HJJX6PG5rN852qyQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.3.0.tgz",
+      "integrity": "sha512-oG+VZzN6YhBHIoSKgS5ESM9VIGzhWjEHEGNPSibiDTxFhsFWxNaz8LbMDPjBUE69r9wmdGLkrQ+wVPbnJcZPvw==",
       "license": "MIT",
       "dependencies": {
-        "@solana/errors": "2.0.0-rc.1"
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": ">=5"
+        "typescript": ">=5.3.3"
       }
     },
     "node_modules/@solana/codecs-data-structures": {
@@ -9410,7 +9292,19 @@
         "typescript": ">=5"
       }
     },
-    "node_modules/@solana/codecs-numbers": {
+    "node_modules/@solana/codecs-data-structures/node_modules/@solana/codecs-core": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0-rc.1.tgz",
+      "integrity": "sha512-bauxqMfSs8EHD0JKESaNmNuNvkvHSuN3bbWAF5RjOfDu2PugxHrvRebmYauvSumZ3cTfQ4HJJX6PG5rN852qyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/codecs-data-structures/node_modules/@solana/codecs-numbers": {
       "version": "2.0.0-rc.1",
       "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0-rc.1.tgz",
       "integrity": "sha512-J5i5mOkvukXn8E3Z7sGIPxsThRCgSdgTWJDQeZvucQ9PT6Y3HiVXJ0pcWiOWAoQ3RX8e/f4I3IC+wE6pZiJzDQ==",
@@ -9421,6 +9315,50 @@
       },
       "peerDependencies": {
         "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/codecs-data-structures/node_modules/@solana/errors": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0-rc.1.tgz",
+      "integrity": "sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "commander": "^12.1.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/codecs-data-structures/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@solana/codecs-numbers": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.3.0.tgz",
+      "integrity": "sha512-jFvvwKJKffvG7Iz9dmN51OGB7JBcy2CJ6Xf3NqD/VP90xak66m/Lg48T01u5IQ/hc15mChVHiBm+HHuOFDUrQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.3.0",
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
       }
     },
     "node_modules/@solana/codecs-strings": {
@@ -9438,7 +9376,32 @@
         "typescript": ">=5"
       }
     },
-    "node_modules/@solana/errors": {
+    "node_modules/@solana/codecs-strings/node_modules/@solana/codecs-core": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0-rc.1.tgz",
+      "integrity": "sha512-bauxqMfSs8EHD0JKESaNmNuNvkvHSuN3bbWAF5RjOfDu2PugxHrvRebmYauvSumZ3cTfQ4HJJX6PG5rN852qyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/codecs-strings/node_modules/@solana/codecs-numbers": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0-rc.1.tgz",
+      "integrity": "sha512-J5i5mOkvukXn8E3Z7sGIPxsThRCgSdgTWJDQeZvucQ9PT6Y3HiVXJ0pcWiOWAoQ3RX8e/f4I3IC+wE6pZiJzDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/codecs-strings/node_modules/@solana/errors": {
       "version": "2.0.0-rc.1",
       "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0-rc.1.tgz",
       "integrity": "sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ==",
@@ -9454,6 +9417,90 @@
         "typescript": ">=5"
       }
     },
+    "node_modules/@solana/codecs-strings/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@solana/codecs/node_modules/@solana/codecs-core": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0-rc.1.tgz",
+      "integrity": "sha512-bauxqMfSs8EHD0JKESaNmNuNvkvHSuN3bbWAF5RjOfDu2PugxHrvRebmYauvSumZ3cTfQ4HJJX6PG5rN852qyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/codecs/node_modules/@solana/codecs-numbers": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0-rc.1.tgz",
+      "integrity": "sha512-J5i5mOkvukXn8E3Z7sGIPxsThRCgSdgTWJDQeZvucQ9PT6Y3HiVXJ0pcWiOWAoQ3RX8e/f4I3IC+wE6pZiJzDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/codecs/node_modules/@solana/errors": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0-rc.1.tgz",
+      "integrity": "sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "commander": "^12.1.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/codecs/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@solana/errors": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.3.0.tgz",
+      "integrity": "sha512-66RI9MAbwYV0UtP7kGcTBVLxJgUxoZGm8Fbc0ah+lGiAw17Gugco6+9GrJCV83VyF2mDWyYnYM9qdI3yjgpnaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.4.1",
+        "commander": "^14.0.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
     "node_modules/@solana/errors/node_modules/chalk": {
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
@@ -9464,6 +9511,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@solana/errors/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@solana/options": {
@@ -9480,6 +9536,59 @@
       },
       "peerDependencies": {
         "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/options/node_modules/@solana/codecs-core": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0-rc.1.tgz",
+      "integrity": "sha512-bauxqMfSs8EHD0JKESaNmNuNvkvHSuN3bbWAF5RjOfDu2PugxHrvRebmYauvSumZ3cTfQ4HJJX6PG5rN852qyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/options/node_modules/@solana/codecs-numbers": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0-rc.1.tgz",
+      "integrity": "sha512-J5i5mOkvukXn8E3Z7sGIPxsThRCgSdgTWJDQeZvucQ9PT6Y3HiVXJ0pcWiOWAoQ3RX8e/f4I3IC+wE6pZiJzDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/options/node_modules/@solana/errors": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0-rc.1.tgz",
+      "integrity": "sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "commander": "^12.1.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/options/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/@solana/spl-token": {
@@ -9554,56 +9663,6 @@
         "superstruct": "^2.0.2"
       }
     },
-    "node_modules/@solana/web3.js/node_modules/@solana/codecs-core": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.3.0.tgz",
-      "integrity": "sha512-oG+VZzN6YhBHIoSKgS5ESM9VIGzhWjEHEGNPSibiDTxFhsFWxNaz8LbMDPjBUE69r9wmdGLkrQ+wVPbnJcZPvw==",
-      "license": "MIT",
-      "dependencies": {
-        "@solana/errors": "2.3.0"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.3.3"
-      }
-    },
-    "node_modules/@solana/web3.js/node_modules/@solana/codecs-numbers": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.3.0.tgz",
-      "integrity": "sha512-jFvvwKJKffvG7Iz9dmN51OGB7JBcy2CJ6Xf3NqD/VP90xak66m/Lg48T01u5IQ/hc15mChVHiBm+HHuOFDUrQg==",
-      "license": "MIT",
-      "dependencies": {
-        "@solana/codecs-core": "2.3.0",
-        "@solana/errors": "2.3.0"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.3.3"
-      }
-    },
-    "node_modules/@solana/web3.js/node_modules/@solana/errors": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.3.0.tgz",
-      "integrity": "sha512-66RI9MAbwYV0UtP7kGcTBVLxJgUxoZGm8Fbc0ah+lGiAw17Gugco6+9GrJCV83VyF2mDWyYnYM9qdI3yjgpnaQ==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^5.4.1",
-        "commander": "^14.0.0"
-      },
-      "bin": {
-        "errors": "bin/cli.mjs"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.3.3"
-      }
-    },
     "node_modules/@solana/web3.js/node_modules/base-x": {
       "version": "3.0.11",
       "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.11.tgz",
@@ -9620,27 +9679,6 @@
       "license": "MIT",
       "dependencies": {
         "base-x": "^3.0.2"
-      }
-    },
-    "node_modules/@solana/web3.js/node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@solana/web3.js/node_modules/commander": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
       }
     },
     "node_modules/@solana/web3.js/node_modules/superstruct": {
@@ -10798,24 +10836,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@types/update-notifier/node_modules/wrap-ansi": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
@@ -10922,6 +10942,20 @@
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.2.tgz",
+      "integrity": "sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
     "node_modules/@typescript-eslint/project-service": {
       "version": "8.58.2",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.2.tgz",
@@ -10954,6 +10988,20 @@
         "@typescript-eslint/types": "8.58.2",
         "@typescript-eslint/visitor-keys": "8.58.2"
       },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager/node_modules/@typescript-eslint/types": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.2.tgz",
+      "integrity": "sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -11004,10 +11052,24 @@
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
-    "node_modules/@typescript-eslint/types": {
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/types": {
       "version": "8.58.2",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.2.tgz",
       "integrity": "sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.0.tgz",
+      "integrity": "sha512-nLzdsT1gdOgFxxxwrlNVUBzSNBEEHJ86bblmk4QAS6stfig7rcJzWKqCyxFy3YRRHXDWEkb2NralA1nOYkkm/A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11046,6 +11108,20 @@
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/@typescript-eslint/types": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.2.tgz",
+      "integrity": "sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
     "node_modules/@typescript-eslint/utils": {
       "version": "8.58.2",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.2.tgz",
@@ -11070,6 +11146,20 @@
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/types": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.2.tgz",
+      "integrity": "sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
     "node_modules/@typescript-eslint/visitor-keys": {
       "version": "8.58.2",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.2.tgz",
@@ -11088,10 +11178,25 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/@typescript-eslint/types": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.2.tgz",
+      "integrity": "sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "deprecated": "Potential CWE-502 - Update to 1.3.1 or higher",
       "license": "ISC"
     },
     "node_modules/@unrs/resolver-binding-android-arm-eabi": {
@@ -11556,9 +11661,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/abitype": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.3.tgz",
-      "integrity": "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.4.tgz",
+      "integrity": "sha512-dpKH+N27vRjarMVTFFkeY445VTKftzGWpL0FiT7xmVmzQRKazZexzC5uHG0f6XKsVLAuUlndnbGau6lRejClxg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/wevm"
@@ -11684,19 +11789,34 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "name": "@redocly/ajv",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-F+LMD2IDIXuHxgpLJh3nkLj9+tSaEzoUWd+7fONGq5pe2169FUDjpEkOfEpoGLz1sbZni/69p07OsecNfAOpqA==",
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-draft-04": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^8.5.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/ajv-formats": {
@@ -11716,57 +11836,38 @@
         }
       }
     },
-    "node_modules/ajv-formats/node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+    "node_modules/ajv-keywords": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
+        "fast-deep-equal": "^3.1.3"
       },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
-    },
-    "node_modules/ajv-keywords": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "license": "MIT",
       "peerDependencies": {
-        "ajv": "^6.9.1"
+        "ajv": "^8.8.2"
       }
     },
     "node_modules/algoliasearch": {
-      "version": "5.50.2",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.50.2.tgz",
-      "integrity": "sha512-Tfp26yoNWurUjfgK4GOrVJQhSNXu9tJtHfFFNosgT2YClG+vPyUjX/gbC8rG39qLncnZg8Fj34iarQWpMkqefw==",
+      "version": "5.51.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.51.0.tgz",
+      "integrity": "sha512-u3XS8HaTzt5YN90KPsOXMRjYJUMVD1dtr6yi4NXQluMbZ5IjQNBu1MEabdAxFhYtEuexqomPMSmRIhQJUd3QSg==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/abtesting": "1.16.2",
-        "@algolia/client-abtesting": "5.50.2",
-        "@algolia/client-analytics": "5.50.2",
-        "@algolia/client-common": "5.50.2",
-        "@algolia/client-insights": "5.50.2",
-        "@algolia/client-personalization": "5.50.2",
-        "@algolia/client-query-suggestions": "5.50.2",
-        "@algolia/client-search": "5.50.2",
-        "@algolia/ingestion": "1.50.2",
-        "@algolia/monitoring": "1.50.2",
-        "@algolia/recommend": "5.50.2",
-        "@algolia/requester-browser-xhr": "5.50.2",
-        "@algolia/requester-fetch": "5.50.2",
-        "@algolia/requester-node-http": "5.50.2"
+        "@algolia/abtesting": "1.17.0",
+        "@algolia/client-abtesting": "5.51.0",
+        "@algolia/client-analytics": "5.51.0",
+        "@algolia/client-common": "5.51.0",
+        "@algolia/client-insights": "5.51.0",
+        "@algolia/client-personalization": "5.51.0",
+        "@algolia/client-query-suggestions": "5.51.0",
+        "@algolia/client-search": "5.51.0",
+        "@algolia/ingestion": "1.51.0",
+        "@algolia/monitoring": "1.51.0",
+        "@algolia/recommend": "5.51.0",
+        "@algolia/requester-browser-xhr": "5.51.0",
+        "@algolia/requester-fetch": "5.51.0",
+        "@algolia/requester-node-http": "5.51.0"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -11802,6 +11903,47 @@
         "string-width": "^4.1.0"
       }
     },
+    "node_modules/ansi-align/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-align/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/ansi-align/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-align/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-html-community": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ansi-html-community/-/ansi-html-community-0.0.8.tgz",
@@ -11827,12 +11969,15 @@
       }
     },
     "node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
       "engines": {
-        "node": ">=12"
+        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
@@ -11864,18 +12009,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/anymatch/node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/are-docs-informative": {
@@ -11997,9 +12130,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
@@ -12128,9 +12261,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.20",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.20.tgz",
-      "integrity": "sha512-1AaXxEPfXT+GvTBJFuy4yXVHWJBXa4OdbIebGN/wX5DlsIkU0+wzGnd2lOzokSk51d5LUmqjgBLRLlypLUqInQ==",
+      "version": "2.10.21",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.21.tgz",
+      "integrity": "sha512-Q+rUQ7Uz8AHM7DEaNdwvfFCTq7a43lNTzuS94eiWqwyxfV/wJv+oUivef51T91mmRY4d4A1u9rcSvkeufCVXlA==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -12427,23 +12560,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/boxen/node_modules/wrap-ansi": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/brace-expansion": {
@@ -12790,9 +12906,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001788",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
-      "integrity": "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==",
+      "version": "1.0.30001790",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001790.tgz",
+      "integrity": "sha512-bOoxfJPyYo+ds6W0YfptaCWbFnJYjh2Y1Eow5lRv+vI2u8ganPZqNm1JwNh0t2ELQCqIWg4B3dWEusgAmsoyOw==",
       "funding": [
         {
           "type": "opencollective",
@@ -12833,21 +12949,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/chalk/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/change-case": {
@@ -13011,18 +13112,6 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/chokidar/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/chownr": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
@@ -13114,30 +13203,7 @@
         "@colors/colors": "1.5.0"
       }
     },
-    "node_modules/cli-width": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
-      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "node_modules/cliui": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/cliui/node_modules/ansi-regex": {
+    "node_modules/cli-table3/node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
@@ -13146,22 +13212,27 @@
         "node": ">=8"
       }
     },
-    "node_modules/cliui/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+    "node_modules/cli-table3/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/cli-table3/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "license": "MIT",
       "dependencies": {
-        "color-convert": "^2.0.1"
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/cliui/node_modules/strip-ansi": {
+    "node_modules/cli-table3/node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
@@ -13173,18 +13244,53 @@
         "node": ">=8"
       }
     },
-    "node_modules/cliui/node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "license": "MIT",
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "license": "ISC",
       "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=20"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
@@ -13534,6 +13640,18 @@
       },
       "peerDependencies": {
         "webpack": "^5.1.0"
+      }
+    },
+    "node_modules/copy-webpack-plugin/node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/copy-webpack-plugin/node_modules/globby": {
@@ -15137,9 +15255,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
-      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.1.tgz",
+      "integrity": "sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -15238,9 +15356,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.340",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.340.tgz",
-      "integrity": "sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA==",
+      "version": "1.5.344",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.344.tgz",
+      "integrity": "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==",
       "license": "ISC"
     },
     "node_modules/elliptic": {
@@ -15339,13 +15457,13 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.20.1",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
-      "integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.0.tgz",
+      "integrity": "sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA==",
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
-        "tapable": "^2.3.0"
+        "tapable": "^2.3.3"
       },
       "engines": {
         "node": ">=10.13.0"
@@ -15946,6 +16064,43 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/eslint/node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/espree": {
       "version": "11.2.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
@@ -16472,18 +16627,6 @@
         "node": ">=8.6.0"
       }
     },
-    "node_modules/fast-glob/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -16596,23 +16739,6 @@
         "node": ">=0.8.0"
       }
     },
-    "node_modules/fdir": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/feed": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/feed/-/feed-4.2.2.tgz",
@@ -16673,6 +16799,37 @@
       "peerDependencies": {
         "webpack": "^4.0.0 || ^5.0.0"
       }
+    },
+    "node_modules/file-loader/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/file-loader/node_modules/ajv-keywords": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^6.9.1"
+      }
+    },
+    "node_modules/file-loader/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "license": "MIT"
     },
     "node_modules/file-loader/node_modules/schema-utils": {
       "version": "3.3.0",
@@ -17144,15 +17301,15 @@
       }
     },
     "node_modules/glob-parent": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "license": "ISC",
       "dependencies": {
-        "is-glob": "^4.0.3"
+        "is-glob": "^4.0.1"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">= 6"
       }
     },
     "node_modules/glob-to-regex.js": {
@@ -18715,20 +18872,6 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "license": "MIT"
     },
-    "node_modules/jayson/node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "extraneous": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
-    },
     "node_modules/jayson/node_modules/ws": {
       "version": "7.5.10",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
@@ -18765,18 +18908,6 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-util/node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/jest-worker": {
@@ -18967,9 +19098,9 @@
       }
     },
     "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
@@ -19344,13 +19475,12 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
       }
     },
     "node_modules/lunr": {
@@ -21770,18 +21900,6 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/micromatch/node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/mime": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
@@ -22195,9 +22313,9 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.37",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
-      "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
+      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
       "license": "MIT"
     },
     "node_modules/normalize-path": {
@@ -22271,6 +22389,37 @@
       "peerDependencies": {
         "webpack": "^4.0.0 || ^5.0.0"
       }
+    },
+    "node_modules/null-loader/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/null-loader/node_modules/ajv-keywords": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^6.9.1"
+      }
+    },
+    "node_modules/null-loader/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "license": "MIT"
     },
     "node_modules/null-loader/node_modules/schema-utils": {
       "version": "3.3.0",
@@ -22582,36 +22731,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/openapi-to-postmanv2/node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/openapi-to-postmanv2/node_modules/ajv-draft-04": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
-      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "ajv": "^8.5.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/openapi-to-postmanv2/node_modules/ajv-formats": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
@@ -22633,12 +22752,6 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "license": "MIT"
-    },
-    "node_modules/openapi-to-postmanv2/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
     "node_modules/openapi-to-postmanv2/node_modules/yaml": {
@@ -22684,9 +22797,9 @@
       }
     },
     "node_modules/ox": {
-      "version": "0.14.17",
-      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.17.tgz",
-      "integrity": "sha512-jOzNb2Wlfzsr8z/GoCtd1bf6OSRuWuysvbhnHGD+7fV1WRbcBR6B0RYoe3xWnUedF7zp4l5APmS7CzAhUok/lA==",
+      "version": "0.14.20",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.20.tgz",
+      "integrity": "sha512-rby38C3nDn8eQkf29Zgw4hkCZJ64Qqi0zRPWL8ENUQ7JVuoITqrVtwWQgM/He19SCMUEc7hS/Sjw0jIOSLJhOw==",
       "dev": true,
       "funding": [
         {
@@ -23129,6 +23242,16 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/path-to-regexp": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.9.0.tgz",
@@ -23160,12 +23283,12 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
-        "node": ">=12"
+        "node": ">=8.6"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -25522,25 +25645,31 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
-      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
+      "integrity": "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
-      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.0.0.tgz",
+      "integrity": "sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==",
       "license": "MIT",
       "dependencies": {
-        "scheduler": "^0.27.0"
+        "scheduler": "^0.25.0"
       },
       "peerDependencies": {
-        "react": "^19.2.5"
+        "react": "^19.0.0"
       }
+    },
+    "node_modules/react-dom/node_modules/scheduler": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
+      "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
+      "license": "MIT"
     },
     "node_modules/react-fast-compare": {
       "version": "3.2.2",
@@ -25567,9 +25696,9 @@
       }
     },
     "node_modules/react-hook-form": {
-      "version": "7.72.1",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.72.1.tgz",
-      "integrity": "sha512-RhwBoy2ygeVZje+C+bwJ8g0NjTdBmDlJvAUHTxRjTmSUKPYsKfMphkS2sgEMotsY03bP358yEYlnUeZy//D9Ig==",
+      "version": "7.73.1",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.73.1.tgz",
+      "integrity": "sha512-VAfVYOPcx3piiEVQy95vyFmBwbVUsP/AUIN+mpFG8h11yshDd444nn0VyfaGWSRnhOLVgiDu7HIuBtAIzxn9dA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -25810,18 +25939,6 @@
       },
       "engines": {
         "node": ">=8.10.0"
-      }
-    },
-    "node_modules/readdirp/node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/rechoir": {
@@ -26719,22 +26836,6 @@
         "url": "https://opencollective.com/webpack"
       }
     },
-    "node_modules/schema-utils/node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
     "node_modules/schema-utils/node_modules/ajv-formats": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
@@ -26751,24 +26852,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/schema-utils/node_modules/ajv-keywords": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
-      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3"
-      },
-      "peerDependencies": {
-        "ajv": "^8.8.2"
-      }
-    },
-    "node_modules/schema-utils/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
     },
     "node_modules/scrypt-js": {
       "version": "3.0.1",
@@ -27666,44 +27749,20 @@
       }
     },
     "node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
       "license": "MIT",
       "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
       },
       "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "license": "MIT"
-    },
-    "node_modules/string-width/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
+        "node": ">=18"
       },
-      "engines": {
-        "node": ">=8"
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/stringify-entities": {
@@ -28048,6 +28107,18 @@
         "tailwindcss": ">=3.0.0 || insiders"
       }
     },
+    "node_modules/tailwindcss/node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/tailwindcss/node_modules/lilconfig": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
@@ -28058,9 +28129,9 @@
       }
     },
     "node_modules/tapable": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.2.tgz",
-      "integrity": "sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -28121,10 +28192,20 @@
         "node": ">=6"
       }
     },
+    "node_modules/tar/node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/terser": {
-      "version": "5.46.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.1.tgz",
-      "integrity": "sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ==",
+      "version": "5.46.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.2.tgz",
+      "integrity": "sha512-uxfo9fPcSgLDYob/w1FuL0c99MWiJDnv+5qXSQc5+Ki5NjVNsYi66INnMFBjf6uFz6OnX12piJQPF4IpjJTNTw==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
@@ -28140,9 +28221,9 @@
       }
     },
     "node_modules/terser-webpack-plugin": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.4.0.tgz",
-      "integrity": "sha512-Bn5vxm48flOIfkdl5CaD2+1CiUVbonWQ3KQPyP7/EuIl9Gbzq/gQFOzaMFUEgVjB1396tcK0SG8XcNJ/2kDH8g==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.5.0.tgz",
+      "integrity": "sha512-UYhptBwhWvfIjKd/UuFo6D8uq9xpGLDK+z8EDsj/zWhrTaH34cKEbrkMKfV5YWqGBvAYA3tlzZbs2R+qYrbQJA==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
@@ -28311,6 +28392,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/tinypool": {
@@ -28959,6 +29069,18 @@
         "url": "https://github.com/yeoman/update-notifier?sponsor=1"
       }
     },
+    "node_modules/update-notifier/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/update-notifier/node_modules/boxen": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-8.0.1.tgz",
@@ -29005,23 +29127,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/update-notifier/node_modules/string-width": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/update-notifier/node_modules/type-fest": {
       "version": "4.41.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
@@ -29047,6 +29152,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/update-notifier/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/uri-js": {
@@ -29097,6 +29219,37 @@
           "optional": true
         }
       }
+    },
+    "node_modules/url-loader/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/url-loader/node_modules/ajv-keywords": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^6.9.1"
+      }
+    },
+    "node_modules/url-loader/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "license": "MIT"
     },
     "node_modules/url-loader/node_modules/schema-utils": {
       "version": "3.3.0",
@@ -29349,9 +29502,9 @@
       }
     },
     "node_modules/viem": {
-      "version": "2.48.1",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-2.48.1.tgz",
-      "integrity": "sha512-GJC3gKV1Hngeo1IB9YanJKHH2pcmoqDymyPxddmzDtG8boXA7eFw8qdnn1PSaToJ93f3LpOZPlLLJ9beAF/Lzg==",
+      "version": "2.48.4",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.48.4.tgz",
+      "integrity": "sha512-mReP/rgY2P+WeeRSG4sUvccCLKfyAW1C73Y3KkobAqgzYmVna9qyUMNE44xIUkDtfvRuC33r24UhF4baBYovsg==",
       "dev": true,
       "funding": [
         {
@@ -29367,7 +29520,7 @@
         "@scure/bip39": "1.6.0",
         "abitype": "1.2.3",
         "isows": "1.0.7",
-        "ox": "0.14.17",
+        "ox": "0.14.20",
         "ws": "8.18.3"
       },
       "peerDependencies": {
@@ -29393,6 +29546,28 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/viem/node_modules/abitype": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.3.tgz",
+      "integrity": "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/wevm"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4",
+        "zod": "^3.22.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/viem/node_modules/ws": {
@@ -29593,20 +29768,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10"
-      }
-    },
-    "node_modules/webpack-bundle-analyzer/node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "extraneous": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
       }
     },
     "node_modules/webpack-bundle-analyzer/node_modules/ws": {
@@ -29837,9 +29998,9 @@
       }
     },
     "node_modules/webpack-sources": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.4.tgz",
-      "integrity": "sha512-7tP1PdV4vF+lYPnkMR0jMY5/la2ub5Fc/8VQrrU+lXkiM6C4TjVfGw7iKfyhnTQOsD+6Q/iKw0eFciziRgD58Q==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.4.0.tgz",
+      "integrity": "sha512-gHwIe1cgBvvfLeu1Yz/dcFpmHfKDVxxyqI+kzqmuxZED81z2ChxpyqPaWcNqigPywhaEke7AjSGga+kxY55gjQ==",
       "license": "MIT",
       "engines": {
         "node": ">=10.13.0"
@@ -30046,34 +30207,52 @@
       }
     },
     "node_modules/wrap-ansi": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
-      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
       "license": "MIT",
       "dependencies": {
-        "ansi-styles": "^6.2.1",
-        "string-width": "^7.0.0",
-        "strip-ansi": "^7.1.0"
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "license": "MIT"
+    },
     "node_modules/wrap-ansi/node_modules/string-width": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
       "license": "MIT",
       "dependencies": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
-        "strip-ansi": "^7.1.0"
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -30209,14 +30388,10 @@
       }
     },
     "node_modules/yallist": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
-      }
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "license": "ISC"
     },
     "node_modules/yaml": {
       "version": "2.8.3",
@@ -30264,6 +30439,78 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "overrides": {
     "bigint-buffer": "npm:@trufflesuite/bigint-buffer@1.1.10",
-    "axios": "1.15.0",
+    "axios": "1.15.2",
     "tar": "7.5.13",
     "elliptic": "6.6.1",
     "js-yaml": "4.1.1",


### PR DESCRIPTION
- more explicit, less leak prone
- fixes a few leaks in dangling Chain instances in the cli providers race
- gets rid of a bunch of leaky Promise.races
- GC-friendly
- `destroy` method is kept, but now is on `Chain` class, and connects directly to the new `abort` signal property, which is then is cascaded to the providers and in-flight requests
- Should fix cli's `Pending handles after main completion:` warning and 5s delay on exit after work is done