### PR TITLE
Feat/api fcr

### DIFF
--- a/ccip-sdk/src/api/api.test.ts
+++ b/ccip-sdk/src/api/api.test.ts
@@ -317,6 +317,7 @@ describe('CCIPAPIClient', () => {
   })
 
   describe('getMessageById', () => {
+    // v1.x lane fixture (no requestedFinalityConfig in extraArgs — GenericExtraArgsV2)
     const mockMessageResponse = {
       messageId: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
       sender: '0x742d35cc6634c0532925a3b8d5c8c22c5b2d8a3e',
@@ -362,6 +363,56 @@ describe('CCIPAPIClient', () => {
       receiptTimestamp: '2023-12-01T10:45:00Z',
       deliveryTime: 900000,
       data: '0xabcdef',
+    }
+
+    // v2.0 lane fixture (GenericExtraArgsV3 with requestedFinalityConfig)
+    // Tests that requestedFinalityConfig '0x00010000' decodes to 'safe' finality
+    const mockV2MessageResponse = {
+      messageId: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      sender: '0x1111111111111111111111111111111111111111',
+      receiver: '0x2222222222222222222222222222222222222222',
+      status: 'SUCCESS',
+      sourceNetworkInfo: {
+        name: 'ethereum-testnet-sepolia-arbitrum-1',
+        chainSelector: '3478487238524512106',
+        chainId: '421614',
+        chainFamily: 'EVM',
+      },
+      destNetworkInfo: {
+        name: 'avalanche-testnet-fuji',
+        chainSelector: '14767482510784806043',
+        chainId: '43113',
+        chainFamily: 'EVM',
+      },
+      sendTransactionHash: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+      sendTimestamp: '2026-04-22T20:54:50.000Z',
+      tokenAmounts: [],
+      extraArgs: {
+        gasLimit: '0',
+        requestedFinalityConfig: '0x00010000',
+        ccvs: ['0x3333333333333333333333333333333333333333'],
+        ccvArgs: ['0x'],
+        executor: '0x4444444444444444444444444444444444444444',
+        executorArgs: '0x',
+        tokenReceiver: '0x2222222222222222222222222222222222222222',
+        tokenArgs: '0x0000000000000000000000000000000000000000000000000000000000000012',
+      },
+      readyForManualExecution: false,
+      finality: 0,
+      fees: {
+        fixedFeesDetails: {
+          tokenAddress: '0x5555555555555555555555555555555555555555',
+          totalAmount: '1055000000000000',
+        },
+      },
+      version: '2.0.0',
+      onramp: '0x6666666666666666666666666666666666666666',
+      origin: '0x1111111111111111111111111111111111111111',
+      sequenceNumber: '40',
+      receiptTransactionHash: '0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc',
+      receiptTimestamp: '2026-04-22T21:08:59.000Z',
+      deliveryTime: 849000,
+      data: '0x',
     }
 
     it('should fetch message by ID with correct URL', async () => {
@@ -426,6 +477,64 @@ describe('CCIPAPIClient', () => {
       assert.equal(result.metadata.sourceNetworkInfo.name, 'ethereum-mainnet')
       assert.equal(result.metadata.sourceNetworkInfo.chainSelector, 5009297550715157269n)
       assert.equal(result.metadata.destNetworkInfo.name, 'ethereum-mainnet-arbitrum-1')
+    })
+
+    it('should decode requestedFinalityConfig 0x00010000 (SAFE) into message.finality = "safe"', async () => {
+      const customFetch = mock.fn(() =>
+        Promise.resolve({
+          ok: true,
+          text: () => Promise.resolve(JSON.stringify(mockV2MessageResponse)),
+        }),
+      )
+      const client = new CCIPAPIClient(undefined, { fetch: customFetch as any })
+      const result = await client.getMessageById(mockV2MessageResponse.messageId)
+
+      assert.equal((result.message as any).finality, 'safe')
+      assert.ok(!('requestedFinalityConfig' in result.message))
+    })
+
+    it('should decode requestedFinalityConfig 0x00000000 (FINALIZED) into message.finality = "finalized"', async () => {
+      const response = {
+        ...mockV2MessageResponse,
+        extraArgs: { ...mockV2MessageResponse.extraArgs, requestedFinalityConfig: '0x00000000' },
+      }
+      const customFetch = mock.fn(() =>
+        Promise.resolve({ ok: true, text: () => Promise.resolve(JSON.stringify(response)) }),
+      )
+      const client = new CCIPAPIClient(undefined, { fetch: customFetch as any })
+      const result = await client.getMessageById(response.messageId)
+
+      assert.equal((result.message as any).finality, 'finalized')
+      assert.ok(!('requestedFinalityConfig' in result.message))
+    })
+
+    it('should decode requestedFinalityConfig 0x00000005 (BLOCK_DEPTH=5) into message.finality = 5', async () => {
+      const response = {
+        ...mockV2MessageResponse,
+        extraArgs: { ...mockV2MessageResponse.extraArgs, requestedFinalityConfig: '0x00000005' },
+      }
+      const customFetch = mock.fn(() =>
+        Promise.resolve({ ok: true, text: () => Promise.resolve(JSON.stringify(response)) }),
+      )
+      const client = new CCIPAPIClient(undefined, { fetch: customFetch as any })
+      const result = await client.getMessageById(response.messageId)
+
+      assert.equal((result.message as any).finality, 5)
+      assert.ok(!('requestedFinalityConfig' in result.message))
+    })
+
+    it('should leave message.finality as bigint for v1.x lanes (no requestedFinalityConfig)', async () => {
+      const customFetch = mock.fn(() =>
+        Promise.resolve({
+          ok: true,
+          text: () => Promise.resolve(JSON.stringify(mockMessageResponse)),
+        }),
+      )
+      const client = new CCIPAPIClient(undefined, { fetch: customFetch as any })
+      const result = await client.getMessageById(mockMessageResponse.messageId)
+
+      // v1.x: finality comes from top-level API field as bigint, not decoded
+      assert.equal(typeof (result.message as any).finality, 'bigint')
     })
 
     it('should throw CCIPMessageIdNotFoundError on 404', async () => {
@@ -1098,6 +1207,28 @@ describe('CCIPAPIClient', () => {
 
       assert.equal(page.data[0]!.status, 'UNKNOWN')
       assert.ok(warnFn.mock.calls.length > 0)
+    })
+
+    it('should pass through UNCONFIRMED status as a recognized value', async () => {
+      const responseWithUnconfirmed = {
+        ...mockSearchResponse,
+        data: [{ ...mockSearchResponse.data[0], status: 'UNCONFIRMED' }],
+      }
+      const customFetch = mock.fn(() =>
+        Promise.resolve({
+          ok: true,
+          text: () => Promise.resolve(JSON.stringify(responseWithUnconfirmed)),
+        }),
+      )
+      const warnFn = mock.fn()
+      const client = new CCIPAPIClient(undefined, {
+        fetch: customFetch as any,
+        logger: { log: () => {}, debug: () => {}, warn: warnFn } as any,
+      })
+      const page = await client.searchMessages({ sender: '0xSender' })
+
+      assert.equal(page.data[0]!.status, 'UNCONFIRMED')
+      assert.equal(warnFn.mock.calls.length, 0)
     })
 
     it('should log raw response via debug', async () => {

--- a/ccip-sdk/src/api/types.ts
+++ b/ccip-sdk/src/api/types.ts
@@ -40,6 +40,7 @@ export type RawNetworkInfo = {
   chainSelector: string
   chainId: string
   chainFamily: string
+  displayName: string | null
 }
 
 /** Token amount from API response */

--- a/ccip-sdk/src/requests.ts
+++ b/ccip-sdk/src/requests.ts
@@ -14,7 +14,7 @@ import {
   CCIPTokenNotInRegistryError,
 } from './errors/index.ts'
 import type { EVMChain } from './evm/index.ts'
-import { decodeExtraArgs } from './extra-args.ts'
+import { decodeExtraArgs, decodeFinalityRequested } from './extra-args.ts'
 import { supportedChains } from './supported-chains.ts'
 import {
   type AnyMessage,
@@ -129,7 +129,11 @@ function decodeJsonMessage(data: Record<string, unknown> | undefined) {
       Object.assign(data_, rest)
     }
   } else if (data_.extraArgs) {
-    Object.assign(data_, data_.extraArgs)
+    const { requestedFinalityConfig, ...rest } = data_.extraArgs as Record<string, unknown>
+    Object.assign(data_, rest)
+    if (requestedFinalityConfig != null) {
+      data_.finality = decodeFinalityRequested(parseInt(requestedFinalityConfig as string))
+    }
     delete data_.extraArgs
   }
 

--- a/ccip-sdk/src/types.ts
+++ b/ccip-sdk/src/types.ts
@@ -320,6 +320,8 @@ export const MessageStatus = {
   Verifying: 'VERIFYING',
   /** Message has been verified by the CCIP network */
   Verified: 'VERIFIED',
+  /** Execute called on destination but receiver has not confirmed yet (lane v1.x ANY → TON). */
+  Unconfirmed: 'UNCONFIRMED',
   /**
    * API returned an unrecognized status value.
    * This typically means the CCIP API has new status values that this SDK version


### PR DESCRIPTION
This pull request adds improved support for decoding message finality and status in the CCIP SDK, particularly for v2.0 message lanes. It introduces logic to decode the `requestedFinalityConfig` field into a user-friendly `finality` value, ensures legacy (v1.x) behavior is preserved, and adds support for the new `UNCONFIRMED` message status. It also updates type definitions to include a new field.

**Finality decoding and handling:**
- [`ccip-sdk/src/requests.ts`](diffhunk://#diff-b81ef54d709010c60e65f5bef6259dd146094d6f2c05ecaac273c1742f96e767L132-R136): Adds logic in `decodeJsonMessage` to extract and decode `requestedFinalityConfig` from `extraArgs`, mapping it to a user-friendly `finality` property using the new `decodeFinalityRequested` function.
- [`ccip-sdk/src/requests.ts`](diffhunk://#diff-b81ef54d709010c60e65f5bef6259dd146094d6f2c05ecaac273c1742f96e767L17-R17): Imports and uses the new `decodeFinalityRequested` utility.

**Testing for finality decoding:**
- [`ccip-sdk/src/api/api.test.ts`](diffhunk://#diff-0d7ed0f31f3a97370c343b470d2bf12a6d28075caeeeb78ec5832de59d104a03R368-R417): Adds comprehensive tests for decoding `requestedFinalityConfig` values (such as `0x00010000` to `"safe"`, `0x00000000` to `"finalized"`, and block depth values), and ensures v1.x messages retain their legacy behavior. [[1]](diffhunk://#diff-0d7ed0f31f3a97370c343b470d2bf12a6d28075caeeeb78ec5832de59d104a03R368-R417) [[2]](diffhunk://#diff-0d7ed0f31f3a97370c343b470d2bf12a6d28075caeeeb78ec5832de59d104a03R482-R539)
- [`ccip-sdk/src/api/api.test.ts`](diffhunk://#diff-0d7ed0f31f3a97370c343b470d2bf12a6d28075caeeeb78ec5832de59d104a03R320): Adds fixture data for both v1.x and v2.0 lanes to support these tests.

**Support for new status values:**
- [`ccip-sdk/src/types.ts`](diffhunk://#diff-aa0438dc850efb4282ea7d7770191a316fb945fb0cf5941aab9c2d9f431a2154R323-R324): Adds `Unconfirmed` to the `MessageStatus` enum to support the new `UNCONFIRMED` status from the API.
- [`ccip-sdk/src/api/api.test.ts`](diffhunk://#diff-0d7ed0f31f3a97370c343b470d2bf12a6d28075caeeeb78ec5832de59d104a03R1212-R1233): Adds a test to ensure the `UNCONFIRMED` status is recognized and passed through without warnings.

**Type definition updates:**
- [`ccip-sdk/src/api/types.ts`](diffhunk://#diff-c3146918cf79179a464ed76be1510000a89b1aa7326ce369920e5a9b4b0f5c37R43): Adds a `displayName` field to the `RawNetworkInfo` type to support enhanced network display capabilities.