### PR TITLE
show: fix api codepath with receipt txHash with >1 execs

### DIFF
--- a/ccip-cli/src/commands/show.ts
+++ b/ccip-cli/src/commands/show.ts
@@ -271,7 +271,7 @@ export async function showRequests(ctx: Ctx, argv: Parameters<typeof handler>[0]
         const res = []
         for (const log of logs) {
           const receipt = (dest.constructor as ChainStatic).decodeReceipt(log)
-          if (!receipt) continue
+          if (receipt?.messageId !== request.message.messageId) continue
           res.push({ receipt, log, timestamp: request.metadata!.receiptTimestamp! })
         }
         cancelWaitFinalized?.()


### PR DESCRIPTION
when receipt has multiple execs (e.g. batched execs) and we're `show`ing from API (i.e. messageId provided as entrypoint), filter only execs for current request