### PR TITLE
fix: manualExec v1.5 messages from API (messageId) from cli

### DIFF
--- a/ccip-cli/src/commands/manual-exec.ts
+++ b/ccip-cli/src/commands/manual-exec.ts
@@ -214,7 +214,6 @@ async function manualExec(
         routerOrRamp: offRamp,
         message: request.message,
       })
-      logger.info('Estimated gasLimit override:', estimated)
       const withBuffer = estimated + Math.ceil((estimated * argv.estimateGasLimit) / 100)
       const origLimit = Number(
         'ccipReceiveGasLimit' in request.message
@@ -225,15 +224,20 @@ async function manualExec(
       )
       if (origLimit >= withBuffer) {
         logger.warn(
-          'Estimated +',
-          argv.estimateGasLimit,
-          '% =',
-          withBuffer,
+          'Estimated =',
+          estimated,
+          ...(argv.estimateGasLimit ? ['+', argv.estimateGasLimit, '% =', withBuffer] : []),
           '< original gasLimit =',
           origLimit,
           '. Leaving unchanged.',
         )
       } else {
+        if (argv.format !== Format.json)
+          output.write(
+            'Estimated gasLimit override:',
+            estimated,
+            ...(argv.estimateGasLimit ? ['+', argv.estimateGasLimit, '% =', withBuffer] : []),
+          )
         argv.gasLimit = withBuffer
         argv.tokensGasLimit ??= 0
       }
@@ -250,12 +254,6 @@ async function manualExec(
               bigIntReplacer,
               2,
             ),
-          )
-        } else {
-          output.write(
-            'Estimated gasLimit override:',
-            estimated,
-            ...(argv.estimateGasLimit ? ['+', argv.estimateGasLimit, '% =', withBuffer] : []),
           )
         }
         return

--- a/ccip-cli/src/index.ts
+++ b/ccip-cli/src/index.ts
@@ -24,6 +24,8 @@ import { hideBin } from 'yargs/helpers'
 import { Format } from './commands/index.ts'
 
 util.inspect.defaultOptions.depth = 6 // print down to tokenAmounts in requests
+Error.stackTraceLimit = 50 // show more stack frames for better debugging
+
 // generate:nofail
 // `const VERSION = '${require('./package.json').version}-${require('child_process').execSync('git rev-parse --short HEAD').toString().trim()}'`
 const VERSION = '1.6.0-faa7467f'

--- a/ccip-sdk/src/chain.ts
+++ b/ccip-sdk/src/chain.ts
@@ -700,8 +700,7 @@ export abstract class Chain<F extends ChainFamily = ChainFamily> {
       ])
       if (trans.timestamp <= finalizedTs) return true
     }
-    const signals = [this.abort, abort].filter(Boolean) as AbortSignal[]
-    const watch = signals.length ? AbortSignal.any(signals) : true
+    const watch = abort ? AbortSignal.any([this.abort, abort]) : this.abort
     for await (const l of this.getLogs({
       address: log.address,
       startBlock: log.blockNumber,

--- a/ccip-sdk/src/chain.ts
+++ b/ccip-sdk/src/chain.ts
@@ -1183,11 +1183,23 @@ export abstract class Chain<F extends ChainFamily = ChainFamily> {
     opts: ExecuteOpts,
   ): Promise<Extract<ExecuteOpts, { input: unknown }>> {
     let opts_: Extract<typeof opts, { input: unknown }>
-    if ('input' in opts) {
+    if (
+      'input' in opts &&
+      ('encodedMessage' in opts.input || // v2
+        'feeValueJuels' in opts.input.message || // v1.6
+        'strict' in opts.input.message) // <=v1.5 with all required fields (API /messages lack some)
+    ) {
       opts_ = opts
-    } else if (!this.apiClient) throw new CCIPApiClientNotAvailableError()
-    else {
-      const { offRamp, ...input } = await this.apiClient.getExecutionInput(opts.messageId)
+    } else if (!this.apiClient) {
+      throw new CCIPApiClientNotAvailableError()
+    } else {
+      const messageId =
+        'messageId' in opts
+          ? opts.messageId
+          : 'message' in opts.input
+            ? opts.input.message.messageId
+            : keccak256(opts.input.encodedMessage)
+      const { offRamp, ...input } = await this.apiClient.getExecutionInput(messageId)
       opts_ = { ...opts, offRamp, input }
     }
 

--- a/ccip-sdk/src/evm/index.ts
+++ b/ccip-sdk/src/evm/index.ts
@@ -296,7 +296,7 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
   static async _getProvider(url: string, abort?: AbortSignal): Promise<JsonRpcApiProvider> {
     let providerReady: Promise<JsonRpcApiProvider>
     if (url.startsWith('ws')) {
-      const provider = new WebSocketProvider(url)
+      const provider = new WebSocketProvider(url, undefined, { staticNetwork: true })
       abort?.addEventListener('abort', () => void provider.destroy(), { once: true })
       providerReady = new Promise((resolve, reject) => {
         provider.websocket.onerror = reject
@@ -306,7 +306,7 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
           .catch(reject)
       })
     } else if (url.startsWith('http')) {
-      const provider = new JsonRpcProvider(url)
+      const provider = new JsonRpcProvider(url, undefined, { staticNetwork: true })
       abort?.addEventListener('abort', () => provider.destroy(), { once: true })
       providerReady = Promise.resolve(provider)
     } else {

--- a/ccip-sdk/src/evm/logs.ts
+++ b/ccip-sdk/src/evm/logs.ts
@@ -15,6 +15,19 @@ import type { WithLogger } from '../types.ts'
 /** Tags or values which can be used as `endBlock` in {@link EVMChain.getLogs} filter */
 export type EVMEndBlockTag = FinalityRequested | 'latest'
 
+function isInvalidBlockRangesError(
+  err: unknown,
+): err is { error: { code: number; message: string } } {
+  return !!(
+    err instanceof Error &&
+    'error' in err &&
+    typeof err.error === 'object' &&
+    err.error &&
+    'message' in err.error &&
+    err.error.message === 'invalid block range params'
+  )
+}
+
 /**
  * Implements Chain.getLogs for EVM.
  * Walks logs forward from `startBlock` or `startTime`; if neither is provided, throws.
@@ -85,7 +98,12 @@ export async function* getEvmLogs(
       ...(filter.topics?.length ? { topics: filter.topics } : {}),
     }
     logger.debug('evm watch getLogs:', filter_)
-    const logs = await provider.getLogs(filter_)
+    const logs = await provider.getLogs(filter_).catch((err) => {
+      if (isInvalidBlockRangesError(err)) {
+        return []
+      }
+      throw err
+    })
     if (logs.length)
       latestLogBlockNumber = Math.max(latestLogBlockNumber, logs[logs.length - 1]!.blockNumber)
     yield* logs

--- a/ccip-sdk/src/utils.ts
+++ b/ccip-sdk/src/utils.ts
@@ -909,29 +909,21 @@ const util =
       }
 export { util }
 
-const registry = new FinalizationRegistry(
-  ({ signal, listener }: { signal: AbortSignal; listener: () => void }) =>
-    signal.removeEventListener('abort', listener),
-)
-
 /**
  * Converts an AbortSignal into a Promise that rejects when the signal is aborted.
+ *
+ * The listener closure captures `reject` strongly and is held alive by the
+ * signal, so the promise cannot be GC'd while the signal is alive. The
+ * `once` option ensures the listener (and its reference to `reject`) is
+ * released as soon as the signal fires.
+ *
  * @param signal - AbortSignal to convert
  * @returns Promise that rejects with the signal's reason when aborted
  */
 export function signalToPromise(signal: AbortSignal): Promise<never> {
   if (signal.aborted) return Promise.reject(signal.reason as Error)
 
-  const { promise, reject } = Promise.withResolvers<never>()
-  const weakReject = new WeakRef(reject)
-
-  const listener = () => {
-    const rejectFn = weakReject.deref()
-    rejectFn?.(signal.reason)
-  }
-
-  signal.addEventListener('abort', listener, { once: true })
-  registry.register(promise, { signal, listener })
-
-  return promise
+  return new Promise<never>((_resolve, reject) => {
+    signal.addEventListener('abort', () => reject(signal.reason as Error), { once: true })
+  })
 }


### PR DESCRIPTION
- API v1.5 messages lack some required v1.2..v1.5 fields in main `/messages` endpoint: `strict` and `sourceTokenData`
- It errors when trying to `manualExec` one of those messages from CLI while passing a `messageId`, as it tries to specify a complete `input` to `execute`, but with API's message payload, which lacks those fields, and errors when trying to `manuallyExecute.populateTransaction`
- So, in this case, also fetch `/execution-inputs`, which contain raw data and those required fields
- These bugs shouldn't affect codepaths used by Explorer or other clients, which'll usually execute passing `messageId` to execute, not a whole `input` fetched from API