### PR TITLE
Fix/timestamps

### DIFF
--- a/ccip-cli/src/commands/show.ts
+++ b/ccip-cli/src/commands/show.ts
@@ -322,7 +322,7 @@ export async function showRequests(ctx: Ctx, argv: Parameters<typeof handler>[0]
       offRamp,
       messageId: request.message.messageId,
       sourceChainSelector: request.message.sourceChainSelector,
-      startTime: request.tx.timestamp,
+      startTime: request.log.blockTimestamp,
       verifications: !argv.wait ? await verifications$ : undefined,
       watch: argv.wait && ctx.abort,
     })

--- a/ccip-cli/src/commands/utils.ts
+++ b/ccip-cli/src/commands/utils.ts
@@ -89,11 +89,23 @@ tokenTransfers =\t[${req.message.tokenAmounts.map((ta) => ('token' in ta ? ta.to
  * @returns Object with Date timestamp.
  */
 export function withDateTimestamp<
-  T extends { readonly timestamp: number } | { readonly tx: { readonly timestamp: number } },
+  T extends
+    | { readonly timestamp: number }
+    | { readonly blockTimestamp: number }
+    | { readonly log: { readonly blockTimestamp: number } }
+    | { readonly tx: { readonly timestamp: number } },
 >(obj: T): Omit<T, 'timestamp'> & { timestamp: Date } {
   return {
     ...obj,
-    timestamp: new Date(('timestamp' in obj ? obj.timestamp : obj.tx.timestamp) * 1e3),
+    timestamp: new Date(
+      ('timestamp' in obj
+        ? obj.timestamp
+        : 'blockTimestamp' in obj
+          ? obj.blockTimestamp
+          : 'log' in obj
+            ? obj.log.blockTimestamp
+            : obj.tx.timestamp) * 1e3,
+    ),
   }
 }
 
@@ -333,11 +345,11 @@ export async function prettyRequest(this: Ctx, request: CCIPRequest, source?: Ch
     transactionHash: displayTxHash,
     logIndex: request.log.index,
     blockNumber: request.log.blockNumber,
-    timestamp: `${formatDate(request.tx.timestamp)} (${formatDuration(Date.now() / 1e3 - request.tx.timestamp)} ago)`,
+    timestamp: `${formatDate(request.log.blockTimestamp)} (${formatDuration(Date.now() / 1e3 - request.log.blockTimestamp)} ago)`,
     finalized:
       finalized &&
-      (finalized < request.tx.timestamp
-        ? formatDuration(request.tx.timestamp - finalized) + ' left'
+      (finalized < request.log.blockTimestamp
+        ? formatDuration(request.log.blockTimestamp - finalized) + ' left'
         : true),
     fee: await formatToken(source, {
       token: request.message.feeToken,
@@ -366,7 +378,7 @@ export async function prettyVerifications(
   this: Ctx,
   dest: Chain,
   verifications: CCIPVerifications,
-  request: PickDeep<CCIPRequest, 'tx.timestamp' | 'lane.destChainSelector'>,
+  request: PickDeep<CCIPRequest, 'log.blockTimestamp' | 'lane.destChainSelector'>,
 ) {
   const destFamily = networkInfo(request.lane.destChainSelector).family
 
@@ -383,7 +395,7 @@ export async function prettyVerifications(
       contract: formatDisplayAddress(verifications.log.address, destFamily),
       transactionHash: formatDisplayTxHash(verifications.log.transactionHash, destFamily),
       blockNumber: verifications.log.blockNumber,
-      timestamp: `${formatDate(timestamp)} (${formatDuration(timestamp - request.tx.timestamp)} after request)`,
+      timestamp: `${formatDate(timestamp)} (${formatDuration(timestamp - request.log.blockTimestamp)} after request)`,
     })
   } else {
     let ts = 0
@@ -393,7 +405,7 @@ export async function prettyVerifications(
     prettyTable.call(this, {
       ...verifications,
       ...(ts && {
-        timestamp: `${formatDate(ts)} (${formatDuration(ts - request.tx.timestamp)} after request)`,
+        timestamp: `${formatDate(ts)} (${formatDuration(ts - request.log.blockTimestamp)} after request)`,
       }),
     })
   }
@@ -515,7 +527,7 @@ export function prettyTable(
 export function prettyReceipt(
   this: Ctx,
   receipt: CCIPExecution,
-  request: PickDeep<CCIPRequest, 'tx.timestamp' | 'lane.destChainSelector'>,
+  request: PickDeep<CCIPRequest, 'log.blockTimestamp' | 'lane.destChainSelector'>,
   origin?: string,
 ) {
   const destFamily = networkInfo(request.lane.destChainSelector).family
@@ -532,7 +544,7 @@ export function prettyReceipt(
     transactionHash: formatDisplayTxHash(receipt.log.transactionHash, destFamily),
     logIndex: receipt.log.index,
     blockNumber: receipt.log.blockNumber,
-    timestamp: `${formatDate(receipt.timestamp)} (${formatDuration(receipt.timestamp - request.tx.timestamp)} after request)`,
+    timestamp: `${formatDate(receipt.log.blockTimestamp)} (${formatDuration(receipt.log.blockTimestamp - request.log.blockTimestamp)} after request)`,
   })
 }
 

--- a/ccip-sdk/src/api/index.ts
+++ b/ccip-sdk/src/api/index.ts
@@ -827,6 +827,7 @@ export class CCIPAPIClient {
       topics: [lane.version < CCIPVersion.V1_6 ? 'CCIPSendRequested' : 'CCIPMessageSent'],
       index: Number(sendLogIndex),
       blockNumber: Number(sendBlockNumber),
+      blockTimestamp: sendTimestamp_,
     }
 
     // Build tx from API data

--- a/ccip-sdk/src/aptos/index.ts
+++ b/ccip-sdk/src/aptos/index.ts
@@ -140,7 +140,7 @@ export class AptosChain extends Chain<typeof ChainFamily.Aptos> {
       {
         maxSize: 100,
         async: true,
-        transformKey: ([arg]) => [(arg as { ledgerVersion: number }).ledgerVersion],
+        transformKey: ([arg]: [{ ledgerVersion: bigint | number }]) => [Number(arg.ledgerVersion)],
       },
     )
   }
@@ -216,16 +216,18 @@ export class AptosChain extends Chain<typeof ChainFamily.Aptos> {
     }
     if (tx.type !== TransactionResponseType.User) throw new CCIPAptosTransactionTypeInvalidError()
 
+    const timestamp = +tx.timestamp / 1e6
     return {
       hash: tx.hash,
       blockNumber: +tx.version,
       from: tx.sender,
-      timestamp: +tx.timestamp / 1e6,
+      timestamp,
       logs: tx.events.map((event, index) => ({
         address: event.type.slice(0, event.type.lastIndexOf('::')),
         transactionHash: tx.hash,
         index,
         blockNumber: +tx.version, // we use version as Aptos' blockNumber, as blockHeight isn't very useful
+        blockTimestamp: timestamp,
         data: event.data as Record<string, unknown>,
         topics: [event.type.slice(event.type.lastIndexOf('::') + 2)],
       })),

--- a/ccip-sdk/src/aptos/index.ts
+++ b/ccip-sdk/src/aptos/index.ts
@@ -9,7 +9,6 @@ import {
 } from '@aptos-labs/ts-sdk'
 import { type BytesLike, concat, isBytesLike, isHexString } from 'ethers'
 import { memoize } from 'micro-memoize'
-import type { PickDeep } from 'type-fest'
 
 import {
   type ChainContext,
@@ -77,7 +76,7 @@ import {
 } from '../utils.ts'
 import { getTokenInfo } from './token.ts'
 import type { CCIPMessage_V1_6_EVM } from '../evm/messages.ts'
-import { buildMessageForDest, decodeMessage, getMessagesInBatch } from '../requests.ts'
+import { buildMessageForDest, decodeMessage } from '../requests.ts'
 export type { UnsignedAptosTx }
 
 /**
@@ -246,20 +245,6 @@ export class AptosChain extends Chain<typeof ChainFamily.Aptos> {
       }
     }
     yield* streamAptosLogs(this, opts)
-  }
-
-  /** {@inheritDoc Chain.getMessagesInBatch} */
-  override async getMessagesInBatch<
-    R extends PickDeep<
-      CCIPRequest,
-      'lane' | `log.${'topics' | 'address' | 'blockNumber'}` | 'message.sequenceNumber'
-    >,
-  >(
-    request: R,
-    range: Pick<CommitReport, 'minSeqNr' | 'maxSeqNr'>,
-    opts?: { page?: number },
-  ): Promise<R['message'][]> {
-    return getMessagesInBatch(this, request, range, opts)
   }
 
   /** {@inheritDoc Chain.typeAndVersion} */

--- a/ccip-sdk/src/aptos/logs.ts
+++ b/ccip-sdk/src/aptos/logs.ts
@@ -251,6 +251,7 @@ export async function* streamAptosLogs(
         ? `${ev.version}`
         : (await getUserTxByVersion(ctx.provider, +ev.version)).hash,
       data: ev.data as Record<string, unknown>,
+      blockTimestamp: await getVersionTimestamp(ctx.provider, +ev.version),
     }
   }
 }

--- a/ccip-sdk/src/canton/index.ts
+++ b/ccip-sdk/src/canton/index.ts
@@ -322,6 +322,7 @@ export class CantonChain extends Chain<typeof ChainFamily.Canton> {
         transactionHash: hash,
         index,
         blockNumber: tx.offset,
+        blockTimestamp: timestamp,
         topics: templateId ? [templateId] : [],
         data: inner,
       }
@@ -795,6 +796,7 @@ export class CantonChain extends Chain<typeof ChainFamily.Canton> {
           index: 0,
           address: '',
           blockNumber: 0,
+          blockTimestamp: 0,
           transactionHash: updateId,
           data: response.transaction,
         }
@@ -1054,6 +1056,7 @@ export class CantonChain extends Chain<typeof ChainFamily.Canton> {
       index: 0,
       address: '',
       blockNumber: 0,
+      blockTimestamp: 0,
       transactionHash: updateId,
       data: response.transaction,
     }

--- a/ccip-sdk/src/canton/index.ts
+++ b/ccip-sdk/src/canton/index.ts
@@ -1,5 +1,4 @@
 import { type BytesLike, id as keccak256Utf8 } from 'ethers'
-import type { PickDeep } from 'type-fest'
 
 import {
   type ChainContext,
@@ -23,7 +22,6 @@ import { CCV_INDEXER_URL } from '../evm/const.ts'
 import type { ExtraArgs } from '../extra-args.ts'
 import type { LeafHasher } from '../hasher/common.ts'
 import { type NetworkInfo, ChainFamily, networkInfo } from '../networks.ts'
-import { getMessagesInBatch } from '../requests.ts'
 import { supportedChains } from '../supported-chains.ts'
 import {
   type CCIPExecution,
@@ -343,22 +341,6 @@ export class CantonChain extends Chain<typeof ChainFamily.Canton> {
    */
   getLogs(_opts: LogFilter): AsyncIterableIterator<ChainLog> {
     throw new CCIPNotImplementedError('CantonChain.getLogs')
-  }
-
-  /**
-   * {@inheritDoc Chain.getMessagesInBatch}
-   */
-  override async getMessagesInBatch<
-    R extends PickDeep<
-      CCIPRequest,
-      'lane' | `log.${'topics' | 'address' | 'blockNumber'}` | 'message.sequenceNumber'
-    >,
-  >(
-    request: R,
-    commit: Pick<CommitReport, 'minSeqNr' | 'maxSeqNr'>,
-    opts?: { page?: number },
-  ): Promise<R['message'][]> {
-    return getMessagesInBatch(this, request, commit, opts)
   }
 
   /**
@@ -1055,13 +1037,13 @@ export class CantonChain extends Chain<typeof ChainFamily.Canton> {
       topics: [],
       index: 0,
       address: '',
-      blockNumber: 0,
-      blockTimestamp: 0,
+      blockNumber: response.transaction.offset,
+      blockTimestamp: timestamp,
       transactionHash: updateId,
       data: response.transaction,
     }
 
-    return { receipt, log, timestamp }
+    return { receipt, log }
   }
 
   /**

--- a/ccip-sdk/src/chain.ts
+++ b/ccip-sdk/src/chain.ts
@@ -1,5 +1,5 @@
 import { type BytesLike, dataLength, keccak256 } from 'ethers'
-import type { PickDeep, SetOptional } from 'type-fest'
+import type { PickDeep } from 'type-fest'
 
 import { type LaneLatencyResponse, CCIPAPIClient } from './api/index.ts'
 import type { UnsignedAptosTx } from './aptos/types.ts'
@@ -32,7 +32,7 @@ import type { LeafHasher } from './hasher/common.ts'
 import { decodeMessageV1 } from './messages.ts'
 import { type ChainFamily, type NetworkInfo, networkInfo } from './networks.ts'
 import { getOffchainTokenData } from './offchain.ts'
-import { getMessagesInRange, getMessagesInTx } from './requests.ts'
+import { getMessagesInBatch, getMessagesInRange, getMessagesInTx } from './requests.ts'
 import { DEFAULT_GAS_LIMIT } from './shared/constants.ts'
 import type { UnsignedSolanaTx } from './solana/types.ts'
 import type { UnsignedSuiTx } from './sui/types.ts'
@@ -682,23 +682,18 @@ export abstract class Chain<F extends ChainFamily = ChainFamily> {
    * ```
    */
   async waitFinalized({
-    request: { log, tx },
+    request: { log },
     finality = 'finalized',
     abort,
   }: {
-    request: SetOptional<
-      PickDeep<
-        CCIPRequest,
-        | `log.${'address' | 'blockNumber' | 'transactionHash' | 'topics' | 'tx.timestamp'}`
-        | 'tx.timestamp'
-      >,
-      'tx'
+    request: PickDeep<
+      CCIPRequest,
+      `log.${'address' | 'blockNumber' | 'transactionHash' | 'topics' | 'blockTimestamp'}`
     >
     finality?: number | 'finalized'
     abort?: AbortSignal
   }): Promise<true> {
-    const timestamp = log.tx?.timestamp ?? tx?.timestamp
-    if (!timestamp || Date.now() / 1e3 - timestamp > 60) {
+    if (!log.blockTimestamp || Date.now() / 1e3 - log.blockTimestamp > 60) {
       // only try to fetch tx if request is old enough (>60s)
       const [trans, finalizedTs] = await Promise.all([
         this.getTransaction(log.transactionHash),
@@ -889,16 +884,20 @@ export abstract class Chain<F extends ChainFamily = ChainFamily> {
    * console.log(`Found ${messages.length} messages in batch`)
    * ```
    */
-  getMessagesInBatch?<
+  getMessagesInBatch<
     R extends PickDeep<
       CCIPRequest,
-      'lane' | `log.${'topics' | 'address' | 'blockNumber'}` | 'message.sequenceNumber'
+      | 'lane'
+      | `log.${'topics' | 'address' | 'blockNumber' | 'blockTimestamp'}`
+      | 'message.sequenceNumber'
     >,
   >(
     request: R,
     range: Pick<CommitReport, 'minSeqNr' | 'maxSeqNr'>,
     opts?: { page?: number },
-  ): Promise<R['message'][]>
+  ): Promise<R['message'][]> {
+    return getMessagesInBatch(this, request, range, opts)
+  }
 
   /**
    * Fetch input data needed for executing messages
@@ -924,7 +923,7 @@ export abstract class Chain<F extends ChainFamily = ChainFamily> {
     }
     // other messages in same batch are available from `source` side;
     // not needed for chain families supporting only >=v2
-    const messagesInBatch = await this.getMessagesInBatch!(request, verifications.report, opts)
+    const messagesInBatch = await this.getMessagesInBatch(request, verifications.report, opts)
     const execReportProof = calculateManualExecProof(
       messagesInBatch,
       request.lane,
@@ -1368,7 +1367,7 @@ export abstract class Chain<F extends ChainFamily = ChainFamily> {
     /** CCIPRequest subset object */
     request: PickDeep<
       CCIPRequest,
-      'lane' | `message.${'sequenceNumber' | 'messageId'}` | 'tx.timestamp'
+      'lane' | `message.${'sequenceNumber' | 'messageId'}` | 'log.blockTimestamp'
     >
   } & Pick<LogFilter, 'page' | 'watch' | 'startBlock'>): Promise<CCIPVerifications> {
     return getOnchainCommitReport(this, offRamp, request, hints)
@@ -1516,8 +1515,7 @@ export abstract class Chain<F extends ChainFamily = ChainFamily> {
       )
         continue
 
-      const timestamp = log.tx?.timestamp ?? (await this.getBlockTimestamp(log.blockNumber))
-      yield { receipt, log, timestamp }
+      yield { receipt, log }
       if (receipt.state === ExecutionState.Success) break
     }
   }
@@ -1540,11 +1538,10 @@ export abstract class Chain<F extends ChainFamily = ChainFamily> {
   async getExecutionReceiptInTx(tx: string | ChainTransaction): Promise<CCIPExecution> {
     if (typeof tx === 'string') tx = await this.getTransaction(tx)
     for (const log of tx.logs) {
-      const rcpt = (this.constructor as ChainStatic).decodeReceipt(log)
-      if (!rcpt) continue
+      const receipt = (this.constructor as ChainStatic).decodeReceipt(log)
+      if (!receipt) continue
 
-      const timestamp = tx.timestamp
-      return { receipt: rcpt, log, timestamp }
+      return { receipt, log }
     }
     throw new CCIPExecTxRevertedError(tx.hash)
   }

--- a/ccip-sdk/src/commits.test.ts
+++ b/ccip-sdk/src/commits.test.ts
@@ -327,6 +327,7 @@ describe('getOnchainCommitReport', () => {
       blockNumber: 12346,
       transactionHash: '0xTxHash',
       index: 0,
+      blockTimestamp: 1234567890,
       topics: encoded.topics,
       data: encoded.data,
     }
@@ -385,6 +386,7 @@ describe('getOnchainCommitReport', () => {
       blockNumber: 12346,
       transactionHash: '0xTxHash',
       index: 0,
+      blockTimestamp: 1234567890,
       topics: encoded.topics,
       data: encoded.data,
     }
@@ -438,6 +440,7 @@ describe('getOnchainCommitReport', () => {
       blockNumber: 12346,
       transactionHash: '0xTxHash',
       index: 0,
+      blockTimestamp: 1234567890,
       topics: encoded.topics,
       data: encoded.data,
     }
@@ -497,6 +500,7 @@ describe('getOnchainCommitReport', () => {
       blockNumber: 12346,
       transactionHash: '0xTxHash',
       index: 0,
+      blockTimestamp: 1234567890,
       topics: encoded.topics,
       data: encoded.data,
     }
@@ -564,6 +568,7 @@ describe('getOnchainCommitReport', () => {
       blockNumber: 12346,
       transactionHash: '0xTxHash1',
       index: 0,
+      blockTimestamp: 1234567890,
       topics: encoded1.topics,
       data: encoded1.data,
     }
@@ -573,6 +578,7 @@ describe('getOnchainCommitReport', () => {
       blockNumber: 12347,
       transactionHash: '0xTxHash2',
       index: 0,
+      blockTimestamp: 1234567890,
       topics: encoded2.topics,
       data: encoded2.data,
     }
@@ -628,6 +634,7 @@ describe('getOnchainCommitReport', () => {
       blockNumber: 12346,
       transactionHash: '0xTxHash',
       index: 0,
+      blockTimestamp: 1234567890,
       topics: encoded.topics,
       data: encoded.data,
     }

--- a/ccip-sdk/src/commits.test.ts
+++ b/ccip-sdk/src/commits.test.ts
@@ -344,7 +344,7 @@ describe('getOnchainCommitReport', () => {
     const request = {
       lane,
       message: { sequenceNumber: 1n } as any,
-      tx: { timestamp: 1700000000 },
+      log: { blockTimestamp: 1700000000 },
     }
 
     const hints = { startBlock: 12345 }
@@ -403,7 +403,7 @@ describe('getOnchainCommitReport', () => {
     const request = {
       lane,
       message: { sequenceNumber: 1n } as any,
-      tx: { timestamp: 1700000000 },
+      log: { blockTimestamp: 1700000000 },
     }
 
     const hints = { startBlock: 12345 }
@@ -457,7 +457,7 @@ describe('getOnchainCommitReport', () => {
     const request = {
       lane,
       message: { sequenceNumber: 4n } as any,
-      tx: { timestamp: 1700000000 },
+      log: { blockTimestamp: 1700000000 },
     }
 
     const hints = { startBlock: 12345 }
@@ -517,7 +517,7 @@ describe('getOnchainCommitReport', () => {
     const request = {
       lane,
       message: { sequenceNumber: 5n } as any,
-      tx: { timestamp: 1700000000 },
+      log: { blockTimestamp: 1700000000 },
     }
 
     const hints = { startBlock: 12345 }
@@ -595,7 +595,7 @@ describe('getOnchainCommitReport', () => {
     const request = {
       lane,
       message: { sequenceNumber: 5n } as any,
-      tx: { timestamp: 1700000000 },
+      log: { blockTimestamp: 1700000000 },
     }
 
     const hints = { startBlock: 12345 }
@@ -652,7 +652,7 @@ describe('getOnchainCommitReport', () => {
     const request = {
       lane,
       message: { sequenceNumber: 3n } as any,
-      tx: { timestamp: requestTimestamp },
+      log: { blockTimestamp: requestTimestamp },
     }
 
     // No hints provided, should use timestamp

--- a/ccip-sdk/src/commits.ts
+++ b/ccip-sdk/src/commits.ts
@@ -21,8 +21,11 @@ export async function getOnchainCommitReport(
   {
     lane,
     message,
-    tx: { timestamp: requestTimestamp },
-  }: PickDeep<CCIPRequest, 'lane' | `message.${'sequenceNumber' | 'messageId'}` | 'tx.timestamp'>,
+    log: { blockTimestamp: requestTimestamp },
+  }: PickDeep<
+    CCIPRequest,
+    'lane' | `message.${'sequenceNumber' | 'messageId'}` | 'log.blockTimestamp'
+  >,
   hints?: Pick<LogFilter, 'page' | 'watch' | 'startBlock'>,
 ): Promise<CCIPVerifications> {
   for await (const log of dest.getLogs({

--- a/ccip-sdk/src/evm/fork.test.ts
+++ b/ccip-sdk/src/evm/fork.test.ts
@@ -496,7 +496,7 @@ describe('EVM Fork Tests', { skip, timeout: 180_000 }, () => {
         offRamp,
         messageId: successMsg.messageId,
         sourceChainSelector: request.message.sourceChainSelector,
-        startTime: request.tx.timestamp,
+        startTime: request.log.blockTimestamp,
       })) {
         if (exec.receipt.state === ExecutionState.Success) {
           foundSuccess = true
@@ -506,7 +506,7 @@ describe('EVM Fork Tests', { skip, timeout: 180_000 }, () => {
             successMsg.messageId,
             'receipt messageId should match',
           )
-          assert.ok(exec.timestamp > 0, 'execution should have a positive timestamp')
+          assert.ok(exec.log.blockTimestamp > 0, 'execution should have a positive timestamp')
           break
         }
       }
@@ -542,7 +542,7 @@ describe('EVM Fork Tests', { skip, timeout: 180_000 }, () => {
           offRamp,
           messageId: failedMsg.messageId,
           sourceChainSelector: request.message.sourceChainSelector,
-          startTime: request.tx.timestamp,
+          startTime: request.log.blockTimestamp,
         })) {
           assert.notEqual(
             exec.receipt.state,
@@ -1327,7 +1327,7 @@ describe('EVM Fork Tests', { skip, timeout: 180_000 }, () => {
 
       assert.equal(execution.receipt.messageId, MESSAGE_ID, 'receipt messageId should match')
       assert.ok(execution.log.transactionHash, 'execution log should have a transaction hash')
-      assert.ok(execution.timestamp > 0, 'execution should have a positive timestamp')
+      assert.ok(execution.log.blockTimestamp > 0, 'execution should have a positive timestamp')
       assert.ok(
         execution.receipt.state === ExecutionState.Success,
         'execution state should be Success',
@@ -1371,7 +1371,7 @@ describe('EVM Fork Tests', { skip, timeout: 180_000 }, () => {
         'receipt messageId should match',
       )
       assert.ok(execution.log.transactionHash, 'execution log should have a transaction hash')
-      assert.ok(execution.timestamp > 0, 'execution should have a positive timestamp')
+      assert.ok(execution.log.blockTimestamp > 0, 'execution should have a positive timestamp')
       assert.ok(
         execution.receipt.state === ExecutionState.Success,
         'execution state should be Success',
@@ -1406,7 +1406,7 @@ describe('EVM Fork Tests', { skip, timeout: 180_000 }, () => {
         'receipt messageId should match',
       )
       assert.ok(execution.log.transactionHash, 'should have tx hash')
-      assert.ok(execution.timestamp > 0, 'should have timestamp')
+      assert.ok(execution.log.blockTimestamp > 0, 'should have timestamp')
       assert.equal(execution.receipt.state, ExecutionState.Success)
 
       fujiWithApi.provider.destroy()
@@ -1436,7 +1436,7 @@ describe('EVM Fork Tests', { skip, timeout: 180_000 }, () => {
       )
       assert.equal(execution.receipt.messageId, messageId, 'receipt messageId should match')
       assert.ok(execution.log.transactionHash, 'should have tx hash')
-      assert.ok(execution.timestamp > 0, 'should have timestamp')
+      assert.ok(execution.log.blockTimestamp > 0, 'should have timestamp')
       assert.equal(execution.receipt.state, ExecutionState.Success)
 
       fujiWithApi.provider.destroy()
@@ -1471,7 +1471,7 @@ describe('EVM Fork Tests', { skip, timeout: 180_000 }, () => {
       )
       assert.equal(execution.receipt.messageId, messageId, 'receipt messageId should match')
       assert.ok(execution.log.transactionHash, 'should have tx hash')
-      assert.ok(execution.timestamp > 0, 'should have timestamp')
+      assert.ok(execution.log.blockTimestamp > 0, 'should have timestamp')
       assert.equal(execution.receipt.state, ExecutionState.Success)
 
       sepoliaWithApi.provider.destroy()
@@ -1505,7 +1505,7 @@ describe('EVM Fork Tests', { skip, timeout: 180_000 }, () => {
       )
       assert.equal(execution.receipt.messageId, msg.messageId, 'receipt messageId should match')
       assert.ok(execution.log.transactionHash, 'should have tx hash')
-      assert.ok(execution.timestamp > 0, 'should have timestamp')
+      assert.ok(execution.log.blockTimestamp > 0, 'should have timestamp')
       assert.equal(execution.receipt.state, ExecutionState.Success)
 
       sepoliaWithApi.provider.destroy()

--- a/ccip-sdk/src/evm/index.ts
+++ b/ccip-sdk/src/evm/index.ts
@@ -71,7 +71,7 @@ import {
 import type { LeafHasher } from '../hasher/common.ts'
 import { decodeMessageV1 } from '../messages.ts'
 import { CCTP_FINALITY_FAST, getUsdcBurnFees } from '../offchain.ts'
-import { buildMessageForDest, decodeMessage, getMessagesInBatch } from '../requests.ts'
+import { buildMessageForDest, decodeMessage } from '../requests.ts'
 import { supportedChains } from '../supported-chains.ts'
 import {
   type CCIPExecution,
@@ -446,7 +446,9 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
   override getMessagesInBatch<
     R extends PickDeep<
       CCIPRequest,
-      'lane' | `log.${'topics' | 'address' | 'blockNumber'}` | 'message.sequenceNumber'
+      | 'lane'
+      | `log.${'topics' | 'address' | 'blockNumber' | 'blockTimestamp'}`
+      | 'message.sequenceNumber'
     >,
   >(
     request: R,
@@ -461,7 +463,7 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
         topics: [[request.log.topics[0]!], [toBeHex(request.lane.destChainSelector, 32)]],
       }
     }
-    return getMessagesInBatch(this, request, range, opts_)
+    return super.getMessagesInBatch(request, range, opts_)
   }
 
   /** {@inheritDoc Chain.typeAndVersion} */

--- a/ccip-sdk/src/evm/index.ts
+++ b/ccip-sdk/src/evm/index.ts
@@ -2,9 +2,12 @@ import {
   type BytesLike,
   type JsonRpcApiProvider,
   type Log,
+  type LogParams,
+  type Network,
   type Result,
   type Signer,
   type TransactionReceipt,
+  type TransactionReceiptParams,
   type TransactionRequest,
   type TransactionResponse,
   Contract,
@@ -13,6 +16,7 @@ import {
   ZeroAddress,
   formatUnits,
   getAddress,
+  getNumber,
   hexlify,
   isBytesLike,
   isError,
@@ -228,37 +232,84 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
     this.provider = provider
     this.abort.addEventListener('abort', () => this.provider.destroy(), { once: true })
 
-    this.typeAndVersion = memoize(this.typeAndVersion.bind(this))
+    const getBlockTimestamp = memoize(this.getBlockTimestamp.bind(this), {
+      async: true,
+      maxArgs: 1,
+      maxSize: 1024,
+    })
+    this.getBlockTimestamp = getBlockTimestamp
 
-    this.provider.getBlock = memoize(provider.getBlock.bind(provider), {
-      maxSize: 100,
-      maxArgs: 1,
-      async: true,
-      forceUpdate: ([block]) => typeof block !== 'number' || block <= 0,
-    })
+    /** ethers doesn't support logs' new `blockTimestamp` property; to workaround having to do
+     * another roundtrip for it, we hook in these Provider methods, which have access to the 'raw'
+     * payloads of getTransactionReceipts and getLogs, cache the timestamps, and populate from
+     * cached this.getBlockTimestamp inside getTransaction and getEvmLogs */
+    type RawLog = { blockNumber: number | string; blockTimestamp?: string | number }
+    this.provider._wrapTransactionReceipt = (
+      value: TransactionReceiptParams,
+      network: Network,
+    ): TransactionReceipt => {
+      // on provider.getTransactionReceipt, cache logs block timestamp, hidden by ethers
+      if (value.logs.length && (value.logs[0] as RawLog).blockTimestamp)
+        getBlockTimestamp.cache.set(
+          [getNumber(value.logs[0]!.blockNumber)],
+          Promise.resolve(getNumber((value.logs[0]! as RawLog).blockTimestamp!)),
+        )
+      return (
+        this.provider.constructor as typeof JsonRpcApiProvider
+      ).prototype._wrapTransactionReceipt.call(this.provider, value, network)
+    }
+    this.provider._wrapLog = (value: LogParams, network: Network): Log => {
+      // on provider.getLogs, cache logs block timestamp, hidden by ethers
+      if ((value as RawLog).blockTimestamp)
+        getBlockTimestamp.cache.set(
+          [getNumber(value.blockNumber)],
+          Promise.resolve(getNumber((value as RawLog).blockTimestamp!)),
+        )
+      return (this.provider.constructor as typeof JsonRpcApiProvider).prototype._wrapLog.call(
+        this.provider,
+        value,
+        network,
+      )
+    }
+
+    this.typeAndVersion = memoize(this.typeAndVersion.bind(this), { async: true, maxArgs: 1 })
+
     this.getTransaction = memoize(this.getTransaction.bind(this), {
-      maxSize: 100,
-      transformKey: (args) =>
-        typeof args[0] !== 'string'
-          ? [(args[0] as unknown as TransactionReceipt).hash]
-          : (args as unknown as string[]),
-    })
-    this.getTokenForTokenPool = memoize(this.getTokenForTokenPool.bind(this))
-    this.getNativeTokenForRouter = memoize(this.getNativeTokenForRouter.bind(this), {
-      maxArgs: 1,
       async: true,
+      maxSize: 100,
+      transformKey: ([tx]: [TransactionReceipt | string]) =>
+        typeof tx !== 'string' ? [tx.hash] : [tx],
     })
-    this.getTokenInfo = memoize(this.getTokenInfo.bind(this))
+    this.getTokenForTokenPool = memoize(this.getTokenForTokenPool.bind(this), {
+      async: true,
+      maxArgs: 1,
+      maxSize: 1024,
+    })
+    this.getNativeTokenForRouter = memoize(this.getNativeTokenForRouter.bind(this), {
+      async: true,
+      maxArgs: 1,
+    })
+    this.getTokenInfo = memoize(this.getTokenInfo.bind(this), {
+      async: true,
+      maxArgs: 1,
+      maxSize: 1024,
+    })
     this.getTokenAdminRegistryFor = memoize(this.getTokenAdminRegistryFor.bind(this), {
       async: true,
       maxArgs: 1,
+      maxSize: 100,
     })
-    this.getFeeTokens = memoize(this.getFeeTokens.bind(this), { async: true, maxArgs: 1 })
-    this.detectUsdcDomains = memoize(this.detectUsdcDomains.bind(this))
-    this.resolveVerifier = memoize(this.resolveVerifier.bind(this))
+    this.getFeeTokens = memoize(this.getFeeTokens.bind(this), {
+      async: true,
+      maxArgs: 1,
+      maxSize: 100,
+    })
+    this.detectUsdcDomains = memoize(this.detectUsdcDomains.bind(this), { async: true })
+    this.resolveVerifier = memoize(this.resolveVerifier.bind(this), { async: true })
     this.getFeeQuoterFor = memoize(this.getFeeQuoterFor.bind(this), {
       async: true,
       maxArgs: 1,
+      maxSize: 100,
     })
   }
 
@@ -358,14 +409,19 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
   /** {@inheritDoc Chain.getTransaction} */
   async getTransaction(hash: string | TransactionReceipt): Promise<ChainTransaction> {
     const tx = typeof hash === 'string' ? await this.provider.getTransactionReceipt(hash) : hash
-    if (!tx) throw new CCIPTransactionNotFoundError(hash as string)
+    if (!tx)
+      throw new CCIPTransactionNotFoundError(hash as string, {
+        context: { network: this.network.name },
+      })
     const timestamp = await this.getBlockTimestamp(tx.blockNumber)
     const chainTx = {
       ...tx,
       timestamp,
       logs: [] as ChainLog[],
     }
-    const logs: ChainLog[] = tx.logs.map((l) => Object.assign(l, { tx: chainTx }))
+    const logs: ChainLog[] = tx.logs.map((l) =>
+      Object.assign(l, { blockTimestamp: timestamp, tx: chainTx }),
+    )
     chainTx.logs = logs
     return chainTx
   }
@@ -373,7 +429,7 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
   /** {@inheritDoc Chain.getLogs} */
   async *getLogs(
     filter: SetFieldType<LogFilter, 'endBlock', EVMEndBlockTag>,
-  ): AsyncIterableIterator<Log> {
+  ): AsyncIterableIterator<Log & { blockTimestamp: number }> {
     if (filter.watch) {
       filter = {
         ...filter,

--- a/ccip-sdk/src/evm/logs.ts
+++ b/ccip-sdk/src/evm/logs.ts
@@ -40,8 +40,12 @@ function isInvalidBlockRangesError(
  */
 export async function* getEvmLogs(
   filter: SetFieldType<LogFilter, 'endBlock', EVMEndBlockTag>,
-  ctx: { provider: JsonRpcApiProvider; abort?: AbortSignal } & WithLogger,
-): AsyncIterableIterator<Log> {
+  ctx: {
+    provider: JsonRpcApiProvider
+    getBlockTimestamp: (block: EVMEndBlockTag) => Promise<number>
+    abort?: AbortSignal
+  } & WithLogger,
+): AsyncIterableIterator<Log & { blockTimestamp: number }> {
   const { provider, logger = console } = ctx
 
   if (filter.startBlock == null && filter.startTime == null) throw new CCIPLogsRequiresStartError()
@@ -68,7 +72,7 @@ export async function* getEvmLogs(
   filter.endBlock ||= 'latest'
   const { number: endBlock } = (await provider.getBlock(filter.endBlock))!
   filter.startBlock ??= await getSomeBlockNumberBefore(
-    async (block: number) => (await provider.getBlock(block))!.timestamp, // cached
+    (block: number) => ctx.getBlockTimestamp(block), // cached
     endBlock,
     filter.startTime!,
     ctx,
@@ -89,7 +93,12 @@ export async function* getEvmLogs(
     const logs = await provider.getLogs(filter_)
     if (logs.length)
       latestLogBlockNumber = Math.max(latestLogBlockNumber, logs[logs.length - 1]!.blockNumber)
-    yield* logs
+    const logs_ = await Promise.all(
+      logs.map(async (l) =>
+        Object.assign(l, { blockTimestamp: await ctx.getBlockTimestamp(l.blockNumber) }),
+      ),
+    )
+    yield* logs_
   }
 
   // watch mode, otherwise return
@@ -109,7 +118,12 @@ export async function* getEvmLogs(
     })
     if (logs.length)
       latestLogBlockNumber = Math.max(latestLogBlockNumber, logs[logs.length - 1]!.blockNumber)
-    yield* logs
+    const logs_ = await Promise.all(
+      logs.map(async (l) =>
+        Object.assign(l, { blockTimestamp: await ctx.getBlockTimestamp(l.blockNumber) }),
+      ),
+    )
+    yield* logs_
 
     const contAc = new AbortController()
     let contSignal = contAc.signal

--- a/ccip-sdk/src/explorer.test.ts
+++ b/ccip-sdk/src/explorer.test.ts
@@ -64,6 +64,7 @@ describe('getCCIPExplorerLinks', () => {
       topics: [],
       data: '0x',
       blockNumber: 12345,
+      blockTimestamp: 1234567890,
       transactionHash: '0xaf8c73a7f872c831da535a62e3837fe5a62f1b92e4b09fddc773b956c3c27d56',
     },
     tx: {

--- a/ccip-sdk/src/logs.test.ts
+++ b/ccip-sdk/src/logs.test.ts
@@ -29,9 +29,21 @@ async function consume(iterable: AsyncIterable<unknown>) {
 
 describe('logs start position validation', () => {
   it('requires startBlock or startTime for EVM logs', async () => {
-    await assert.rejects(() => consume(getEvmLogs({}, { provider: {} as JsonRpcApiProvider })), {
-      name: 'CCIPLogsRequiresStartError',
-    })
+    await assert.rejects(
+      () =>
+        consume(
+          getEvmLogs(
+            {},
+            {
+              provider: {} as JsonRpcApiProvider,
+              getBlockTimestamp: async () => Math.floor(Date.now() / 1000),
+            },
+          ),
+        ),
+      {
+        name: 'CCIPLogsRequiresStartError',
+      },
+    )
   })
 
   it('requires startBlock or startTime for Solana logs', async () => {
@@ -97,7 +109,14 @@ describe('EVM logs block tags', () => {
     const provider = { getBlock, getLogs } as unknown as JsonRpcApiProvider
 
     await consume(
-      getEvmLogs({ startBlock: 100, endBlock: 'safe' }, { provider, logger: silentLogger }),
+      getEvmLogs(
+        { startBlock: 100, endBlock: 'safe' },
+        {
+          provider,
+          logger: silentLogger,
+          getBlockTimestamp: async (block) => (await getBlock(block)).timestamp,
+        },
+      ),
     )
 
     assert.equal(getBlock.mock.calls[0]!.arguments[0], 'safe')

--- a/ccip-sdk/src/requests.test.ts
+++ b/ccip-sdk/src/requests.test.ts
@@ -277,7 +277,7 @@ describe('getMessageById', () => {
     })
     assert.equal(result.log.index, 1)
     assert.ok(result.message)
-    assert.equal(result.tx.timestamp, 1234567890)
+    assert.equal(result.log.blockTimestamp, 1234567890)
     assert.equal(result.lane.version, CCIPVersion.V1_2)
   })
 
@@ -517,7 +517,7 @@ describe('getMessagesInBatch', () => {
     assert.equal(calls[0]!.startTime, undefined)
     assert.equal(calls[0]!.endBefore, undefined)
     assert.equal(calls[1]!.endBlock, 300)
-    assert.equal(calls[1]!.startTime, 0)
+    assert.ok(calls[1]!.startTime && calls[1]!.startTime <= 1234567890)
     assert.equal(calls[1]!.startBlock, undefined)
     assert.equal(calls[1]!.endBefore, undefined)
   })

--- a/ccip-sdk/src/requests.test.ts
+++ b/ccip-sdk/src/requests.test.ts
@@ -65,6 +65,7 @@ class MockChain {
         topics: Array.isArray(opts.topics?.[0]) ? opts.topics[0] : [topic0],
         data: mockedMessage(1),
         blockNumber: 12000,
+        blockTimestamp: 1234567890,
         transactionHash: '0x123',
       },
     ]
@@ -165,6 +166,7 @@ describe('getMessagesInTx', () => {
           topics: [topic0],
           data: mockedMessage(1),
           blockNumber: 12000,
+          blockTimestamp: 1234567890,
           transactionHash: '0x123',
           index: 0,
         },
@@ -192,6 +194,7 @@ describe('getMessagesInTx', () => {
           topics: [topic0],
           data: JSON.stringify(mockedMessage(1), bigIntReplacer),
           blockNumber: 12000,
+          blockTimestamp: 1234567890,
           transactionHash: '0x123',
           index: 0,
         },
@@ -200,6 +203,7 @@ describe('getMessagesInTx', () => {
           topics: [topic0],
           data: mockedMessage(2),
           blockNumber: 12000,
+          blockTimestamp: 1234567890,
           transactionHash: '0x123',
           index: 1,
         },
@@ -262,6 +266,7 @@ describe('getMessageById', () => {
           topics: [topic0],
           data: msg,
           blockNumber: 12000,
+          blockTimestamp: 1234567890,
           transactionHash: '0x123',
         }
       })(),
@@ -287,6 +292,7 @@ describe('getMessageById', () => {
           topics: [topic0],
           data: mockedMessage(2),
           blockNumber: 12000,
+          blockTimestamp: 1234567890,
           transactionHash: '0x123',
         }
       })(),
@@ -342,6 +348,7 @@ describe('getMessagesInBatch', () => {
         address: rampAddress,
         topics: [topic0],
         blockNumber: 12000,
+        blockTimestamp: 1234567890,
         transactionHash: '0x123',
         index: 0,
         data: mockedMessage(9),
@@ -385,6 +392,7 @@ describe('getMessagesInBatch', () => {
         address: rampAddress,
         topics: [topic0],
         blockNumber: 1,
+        blockTimestamp: 1234567890,
         transactionHash: '0x123',
         index: 0,
         data: mockedMessage(5),
@@ -421,6 +429,7 @@ describe('getMessagesInBatch', () => {
           topics: [topic0],
           data: mockedMessage(5),
           blockNumber: 1,
+          blockTimestamp: 1234567890,
           transactionHash: '0x123',
         }
       })(),
@@ -444,6 +453,7 @@ describe('getMessagesInBatch', () => {
         blockNumber: 500,
         transactionHash: '0x500',
         index: 0,
+        blockTimestamp: 1234567890,
         data: mockedMessage(5),
       },
       message: {
@@ -485,6 +495,7 @@ describe('getMessagesInBatch', () => {
             topics: [topic0],
             data: mockedMessage(seq),
             blockNumber: seq * 100,
+            blockTimestamp: 1234567890,
             transactionHash: `0x${seq}`,
           }
         }
@@ -524,6 +535,7 @@ describe('getMessagesInRange', () => {
           topics: [topic0],
           data: mockedMessage(1),
           blockNumber: 12000,
+          blockTimestamp: 1234567890,
           transactionHash: '0x111',
           tx: {
             hash: '0x111',
@@ -539,6 +551,7 @@ describe('getMessagesInRange', () => {
           topics: [topic0],
           data: { notAMessage: true }, // non-CCIP log
           blockNumber: 12000,
+          blockTimestamp: 1234567890,
           transactionHash: '0x222',
         }
         yield {
@@ -547,6 +560,7 @@ describe('getMessagesInRange', () => {
           topics: [topic0],
           data: mockedMessage(2),
           blockNumber: 12001,
+          blockTimestamp: 1234567891,
           transactionHash: '0x333',
           tx: {
             hash: '0x333',
@@ -624,6 +638,7 @@ describe('getMessagesInRange', () => {
           topics: [topic0],
           data: v16Message,
           blockNumber: 15000,
+          blockTimestamp: 1234567890,
           transactionHash: '0xV16Tx',
           tx: {
             hash: '0xV16Tx',
@@ -706,6 +721,7 @@ describe('getMessagesInRange', () => {
           topics: [topic0],
           data: mockedMessage(1),
           blockNumber: 12000,
+          blockTimestamp: 1234567890,
           transactionHash: '0xNoTxLog',
           // no tx field
         }

--- a/ccip-sdk/src/requests.ts
+++ b/ccip-sdk/src/requests.ts
@@ -1,5 +1,4 @@
 import { type BytesLike, hexlify, isBytesLike, toBigInt } from 'ethers'
-import { memoize } from 'micro-memoize'
 import type { PickDeep } from 'type-fest'
 
 import type { Chain, ChainStatic, LogFilter } from './chain.ts'
@@ -327,7 +326,7 @@ export async function getMessagesInBatch<
   R extends PickDeep<
     CCIPRequest,
     | 'lane'
-    | `log.${'topics' | 'address' | 'blockNumber' | 'tx.timestamp'}`
+    | `log.${'topics' | 'address' | 'blockNumber' | 'blockTimestamp'}`
     | 'message.sequenceNumber'
   >,
 >(
@@ -339,7 +338,7 @@ export async function getMessagesInBatch<
   // short-circuit trivial batchSize=1
   if (minSeqNr === maxSeqNr) return [request.message]
 
-  type LogAnchor = PickDeep<ChainLog, 'blockNumber' | 'tx.timestamp'>
+  type LogAnchor = Pick<R['log'], 'blockNumber' | 'blockTimestamp'>
   type BatchEntry = { log: LogAnchor; message: R['message'] }
 
   const baseFilter = {
@@ -350,19 +349,6 @@ export async function getMessagesInBatch<
   }
 
   const entries: BatchEntry[] = []
-
-  const getLogTimestamp = memoize(
-    async (log: LogAnchor): Promise<number> => {
-      if (log.tx?.timestamp != null) {
-        getLogTimestamp.cache.set([log], Promise.resolve(log.tx.timestamp))
-        return log.tx.timestamp
-      }
-      const timestamp = source.getBlockTimestamp(log.blockNumber)
-      getLogTimestamp.cache.set([log], timestamp)
-      return timestamp
-    },
-    { async: true, transformKey: ([log]) => [log.blockNumber] as const },
-  )
 
   const collectForward = async (filter: Parameters<C['getLogs']>[0]): Promise<boolean> => {
     // on first, collect up to batch end; on subsequent, collect up to before earliest seen
@@ -410,11 +396,13 @@ export async function getMessagesInBatch<
   while (!done && entries[0]!.message.sequenceNumber > minSeqNr) {
     const earliest = entries[0]!
     const earliestBefore = earliest.message.sequenceNumber
-    const earliestTimestamp = await getLogTimestamp(earliest.log)
 
     done = await collectForward({
       ...baseFilter,
-      startTime: Math.max(0, earliestTimestamp - BATCH_LOG_LOOKBACK_SECONDS * 2 ** retries),
+      startTime: Math.max(
+        0,
+        earliest.log.blockTimestamp - BATCH_LOG_LOOKBACK_SECONDS * 2 ** retries,
+      ),
       endBlock: earliest.log.blockNumber,
     })
 

--- a/ccip-sdk/src/solana/decodeMessage.test.ts
+++ b/ccip-sdk/src/solana/decodeMessage.test.ts
@@ -20,6 +20,7 @@ describe('SolanaChain.decodeMessage', () => {
       address: 'CcipQ6z7nULJPwQyZnbRwiupj9Virv8oLJwSgxN2b55P',
       blockNumber: 12345,
       transactionHash: '0x123',
+      blockTimestamp: 1234567890,
     }
 
     const message = SolanaChain.decodeMessage(mockLog) as CCIPMessage<typeof CCIPVersion.V1_6>
@@ -75,6 +76,7 @@ describe('SolanaChain.decodeMessage', () => {
       address: 'CcipQ6z7nULJPwQyZnbRwiupj9Virv8oLJwSgxN2b55P',
       blockNumber: 12345,
       transactionHash: '0x123',
+      blockTimestamp: 1234567890,
     }
 
     assert.equal(SolanaChain.decodeMessage(invalidLog), undefined)
@@ -88,6 +90,7 @@ describe('SolanaChain.decodeMessage', () => {
       address: 'CcipQ6z7nULJPwQyZnbRwiupj9Virv8oLJwSgxN2b55P',
       blockNumber: 12345,
       transactionHash: '0x123',
+      blockTimestamp: 1234567890,
     }
 
     assert.equal(SolanaChain.decodeMessage(invalidLog), undefined)

--- a/ccip-sdk/src/solana/fork.test.ts
+++ b/ccip-sdk/src/solana/fork.test.ts
@@ -252,7 +252,7 @@ describe('Solana Fork Tests', { skip, timeout: 180_000 }, () => {
         'receipt messageId should match',
       )
       assert.ok(execution.log.transactionHash, 'should have tx hash')
-      assert.ok(execution.timestamp > 0, 'should have timestamp')
+      assert.ok(execution.log.blockTimestamp > 0, 'should have timestamp')
       assert.equal(execution.receipt.state, ExecutionState.Success, 'execution should succeed')
 
       // Confirm by re-reading the execution tx and decoding the ExecutionStateChanged log

--- a/ccip-sdk/src/solana/index.ts
+++ b/ccip-sdk/src/solana/index.ts
@@ -129,7 +129,7 @@ import {
   simulateAndSendTxs,
   simulationProvider,
 } from './utils.ts'
-import { buildMessageForDest, getMessagesInBatch } from '../requests.ts'
+import { buildMessageForDest } from '../requests.ts'
 import { patchBorsh } from './patchBorsh.ts'
 import { DEFAULT_GAS_LIMIT } from '../shared/constants.ts'
 export type { UnsignedSolanaTx }
@@ -502,7 +502,9 @@ export class SolanaChain extends Chain<typeof ChainFamily.Solana> {
   override async getMessagesInBatch<
     R extends PickDeep<
       CCIPRequest,
-      'lane' | `log.${'topics' | 'address' | 'blockNumber'}` | 'message.sequenceNumber'
+      | 'lane'
+      | `log.${'topics' | 'address' | 'blockNumber' | 'blockTimestamp'}`
+      | 'message.sequenceNumber'
     >,
   >(
     request: R,
@@ -520,7 +522,7 @@ export class SolanaChain extends Chain<typeof ChainFamily.Solana> {
       programs: [request.log.address],
       address: destChainStatePda.toBase58(),
     }
-    return getMessagesInBatch(this, request, range, opts_)
+    return super.getMessagesInBatch(request, range, opts_)
   }
 
   /** {@inheritDoc Chain.typeAndVersion} */

--- a/ccip-sdk/src/solana/index.ts
+++ b/ccip-sdk/src/solana/index.ts
@@ -223,25 +223,35 @@ export class SolanaChain extends Chain<typeof ChainFamily.Solana> {
 
     // Memoize expensive operations
     this.typeAndVersion = memoize(this.typeAndVersion.bind(this), {
-      maxArgs: 1,
       async: true,
+      maxArgs: 1,
+      maxSize: 100,
     })
     this.getBlockTimestamp = memoize(this.getBlockTimestamp.bind(this), {
       async: true,
-      maxSize: 100,
+      maxSize: 1024,
       forceUpdate: ([k]) => typeof k !== 'number' || k <= 0,
     })
     this.getTransaction = memoize(this.getTransaction.bind(this), {
-      maxSize: 100,
+      async: true,
       maxArgs: 1,
+      maxSize: 100,
     })
-    this.getTokenForTokenPool = memoize(this.getTokenForTokenPool.bind(this))
-    this.getTokenInfo = memoize(this.getTokenInfo.bind(this))
+    this.getTokenForTokenPool = memoize(this.getTokenForTokenPool.bind(this), {
+      async: true,
+      maxArgs: 1,
+      maxSize: 100,
+    })
+    this.getTokenInfo = memoize(this.getTokenInfo.bind(this), {
+      async: true,
+      maxArgs: 1,
+      maxSize: 100,
+    })
     this.connection.getSignaturesForAddress = memoize(
       this.connection.getSignaturesForAddress.bind(this.connection),
       {
-        maxSize: 100,
         async: true,
+        maxSize: 100,
         // if options.before is defined, caches for long, otherwise for short (recent signatures)
         expires: (key) => (key[1] ? 2 ** 31 - 1 : 5e3),
         transformKey: ([address, options, commitment]: [
@@ -267,10 +277,13 @@ export class SolanaChain extends Chain<typeof ChainFamily.Solana> {
         [(address as PublicKey).toString(), commitment] as const,
     })
 
-    this._getRouterConfig = memoize(this._getRouterConfig.bind(this), { maxArgs: 1 })
+    this._getRouterConfig = memoize(this._getRouterConfig.bind(this), { async: true, maxArgs: 1 })
 
-    this.getFeeTokens = memoize(this.getFeeTokens.bind(this), { maxArgs: 1 })
-    this.getOffRampsForRouter = memoize(this.getOffRampsForRouter.bind(this), { maxArgs: 1 })
+    this.getFeeTokens = memoize(this.getFeeTokens.bind(this), { async: true, maxArgs: 1 })
+    this.getOffRampsForRouter = memoize(this.getOffRampsForRouter.bind(this), {
+      async: true,
+      maxArgs: 1,
+    })
   }
 
   /**
@@ -391,7 +404,9 @@ export class SolanaChain extends Chain<typeof ChainFamily.Solana> {
       tx, // specialized solana transaction
     }
     // solana logs include circular reference to tx
-    chainTx.logs = logs_.map((l) => Object.assign(l, { tx: chainTx }))
+    chainTx.logs = logs_.map((l) =>
+      Object.assign(l, { blockTimestamp: tx.blockTime!, tx: chainTx }),
+    )
     return chainTx
   }
 

--- a/ccip-sdk/src/sui/index.ts
+++ b/ccip-sdk/src/sui/index.ts
@@ -5,7 +5,7 @@ import { SuiJsonRpcClient } from '@mysten/sui/jsonRpc'
 import { Transaction } from '@mysten/sui/transactions'
 import { isValidSuiAddress, isValidTransactionDigest, normalizeSuiAddress } from '@mysten/sui/utils'
 import { type BytesLike, dataLength, hexlify, isBytesLike, isHexString } from 'ethers'
-import type { PickDeep, SetOptional } from 'type-fest'
+import type { SetOptional } from 'type-fest'
 
 import {
   type ChainContext,
@@ -33,7 +33,7 @@ import {
 } from '../errors/index.ts'
 import type { EVMExtraArgsV2, ExtraArgs, SVMExtraArgsV1, SuiExtraArgsV1 } from '../extra-args.ts'
 import type { LeafHasher } from '../hasher/common.ts'
-import { decodeMessage, getMessagesInBatch } from '../requests.ts'
+import { decodeMessage } from '../requests.ts'
 import { decodeMoveExtraArgs, getMoveAddress } from '../shared/bcs-codecs.ts'
 import { supportedChains } from '../supported-chains.ts'
 import type {
@@ -250,20 +250,6 @@ export class SuiChain extends Chain<typeof ChainFamily.Sui> {
         topics: [topic],
       }
     }
-  }
-
-  /** {@inheritDoc Chain.getMessagesInBatch} */
-  override async getMessagesInBatch<
-    R extends PickDeep<
-      CCIPRequest,
-      'lane' | `log.${'topics' | 'address' | 'blockNumber'}` | 'message.sequenceNumber'
-    >,
-  >(
-    request: R,
-    range: Pick<CommitReport, 'minSeqNr' | 'maxSeqNr'>,
-    opts?: Pick<LogFilter, 'page'>,
-  ): Promise<R['message'][]> {
-    return getMessagesInBatch(this, request, range, opts)
   }
 
   /**

--- a/ccip-sdk/src/sui/index.ts
+++ b/ccip-sdk/src/sui/index.ts
@@ -182,6 +182,7 @@ export class SuiChain extends Chain<typeof ChainFamily.Sui> {
       },
     })
 
+    const timestamp = Number(txResponse.timestampMs || 0) / 1000
     // Extract events from the transaction
     const events: ChainLog[] = []
     if (txResponse.events?.length) {
@@ -196,6 +197,7 @@ export class SuiChain extends Chain<typeof ChainFamily.Sui> {
           transactionHash: digest,
           index: i,
           blockNumber: Number(txResponse.checkpoint || 0),
+          blockTimestamp: timestamp,
           data: event.parsedJson as Record<string, unknown>,
           topics: [eventName],
         })
@@ -206,7 +208,7 @@ export class SuiChain extends Chain<typeof ChainFamily.Sui> {
       hash: digest,
       logs: events,
       blockNumber: Number(txResponse.checkpoint || 0),
-      timestamp: Number(txResponse.timestampMs || 0) / 1000,
+      timestamp,
       from: txResponse.transaction?.data.sender || '',
     }
   }
@@ -236,12 +238,14 @@ export class SuiChain extends Chain<typeof ChainFamily.Sui> {
 
     for await (const event of streamSuiLogs<Record<string, unknown>>(this, opts)) {
       const eventData = event.contents?.json
+      const blockTimestamp = new Date(event.timestamp).getTime() / 1000
       if (!eventData) continue
       yield {
         address: opts.address,
         transactionHash: event.transaction!.digest,
         index: Number(event.sequenceNumber) || 0,
         blockNumber: Number(event.transaction?.effects.checkpoint.sequenceNumber || 0),
+        blockTimestamp,
         data: eventData,
         topics: [topic],
       }

--- a/ccip-sdk/src/ton/index.ts
+++ b/ccip-sdk/src/ton/index.ts
@@ -364,6 +364,7 @@ export class TONChain extends Chain<typeof ChainFamily.TON> {
         topics,
         data,
         blockNumber: res.blockNumber, // Note: This is lt (logical time), not block seqno
+        blockTimestamp: tx.now,
         transactionHash: res.hash,
         index,
         tx: res,

--- a/ccip-sdk/src/ton/index.ts
+++ b/ccip-sdk/src/ton/index.ts
@@ -5,7 +5,6 @@ import { TonClient } from '@ton/ton'
 import { type AxiosAdapter, getAdapter } from 'axios'
 import { type BytesLike, hexlify, isBytesLike, isHexString, toBeArray, toBeHex } from 'ethers'
 import { type Memoized, memoize } from 'micro-memoize'
-import type { PickDeep } from 'type-fest'
 
 import { streamTransactionsForAddress } from './logs.ts'
 import { generateUnsignedCcipSend, getFee as getFeeImpl } from './send.ts'
@@ -30,7 +29,7 @@ import {
 } from '../errors/index.ts'
 import type { EVMExtraArgsV2, ExtraArgs, SVMExtraArgsV1, SuiExtraArgsV1 } from '../extra-args.ts'
 import type { LeafHasher } from '../hasher/common.ts'
-import { buildMessageForDest, getMessagesInBatch } from '../requests.ts'
+import { buildMessageForDest } from '../requests.ts'
 import { supportedChains } from '../supported-chains.ts'
 import {
   type AnyMessage,
@@ -409,20 +408,6 @@ export class TONChain extends Chain<typeof ChainFamily.TON> {
         yield log
       }
     }
-  }
-
-  /** {@inheritDoc Chain.getMessagesInBatch} */
-  override async getMessagesInBatch<
-    R extends PickDeep<
-      CCIPRequest,
-      'lane' | `log.${'topics' | 'address' | 'blockNumber'}` | 'message.sequenceNumber'
-    >,
-  >(
-    request: R,
-    range: Pick<CommitReport, 'minSeqNr' | 'maxSeqNr'>,
-    opts?: Pick<LogFilter, 'page'>,
-  ): Promise<R['message'][]> {
-    return getMessagesInBatch(this, request, range, opts)
   }
 
   /** {@inheritDoc Chain.typeAndVersion} */

--- a/ccip-sdk/src/types.ts
+++ b/ccip-sdk/src/types.ts
@@ -327,8 +327,6 @@ export interface CCIPExecution {
   receipt: ExecutionReceipt
   /** Log event from the execution. */
   log: ChainLog
-  /** Unix timestamp of the execution. */
-  timestamp: number
 }
 
 /**

--- a/ccip-sdk/src/types.ts
+++ b/ccip-sdk/src/types.ts
@@ -109,6 +109,7 @@ export type ChainLog = Pick<
   EVMLog,
   'topics' | 'index' | 'address' | 'blockNumber' | 'transactionHash'
 > & {
+  blockTimestamp: number
   /** Log data as bytes or parsed object. */
   data: BytesLike | Record<string, unknown>
   /** Optional reference to the containing transaction. */


### PR DESCRIPTION
All 2026 EVM nodes return `blockTimestamp` inside logs payload for both `eth_getLogs` and `eth_getTransactionReceipt`; 
Still, ethers doesn't include it in those returned objects, requiring us to do an extra RPC roundtrip to fetch those.

We fix this by hooking into some Provider methods which get access to the raw payloads of those requests, and caching the result in Chain.getBlockTimestamp; see ethers-io/ethers.js#5104

Also, fix some caches, as micro-memoize's maxSize default=1