### PR TITLE
add search mesages to sidebar

### DIFF
--- a/ccip-api-ref/sidebars-sdk.ts
+++ b/ccip-api-ref/sidebars-sdk.ts
@@ -30,6 +30,7 @@ const sidebars: SidebarsConfig = {
       collapsed: false,
       items: [
         'guides/tracking-messages',
+        'guides/searching-messages',
         'guides/sending-messages',
         'guides/manual-execution',
         'guides/querying-data',

--- a/ccip-sdk/src/selectors.ts
+++ b/ccip-sdk/src/selectors.ts
@@ -1625,6 +1625,12 @@ const SELECTORS: Selectors = {
     network_type: 'TESTNET',
     family: 'EVM',
   },
+  '2026041003': {
+    selector: 604447335222770945n,
+    name: 'private-testnet-rhyolite',
+    network_type: 'TESTNET',
+    family: 'EVM',
+  },
   '2494104990': {
     selector: 13231703482326770598n,
     name: 'tron-testnet-shasta-evm',


### PR DESCRIPTION
This pull request introduces updates to both the documentation sidebar and the SDK selectors. The main changes include adding a new guide to the documentation and supporting an additional testnet in the SDK.

Documentation updates:

* Added a new "Searching Messages" guide to the SDK documentation sidebar to help users find information on searching for messages.

SDK enhancements:

* Added support for the `private-testnet-rhyolite` network in the `SELECTORS` object, enabling SDK operations on this new testnet.