### PR TITLE
feat(solana): add heap frame support to manual exec

### DIFF
--- a/ccip-cli/src/commands/manual-exec.ts
+++ b/ccip-cli/src/commands/manual-exec.ts
@@ -14,6 +14,9 @@
  *
  * # Execute with custom gas limit
  * ccip-cli manual-exec 0xSourceTxHash... --gas-limit 500000
+ *
+ * # Execute with custom Solana heap frame
+ * ccip-cli manual-exec 0xMessageId... --heap-frame-bytes 262144
  * ```
  *
  * @packageDocumentation
@@ -80,6 +83,11 @@ export const builder = (yargs: Argv) =>
         type: 'number',
         describe:
           'Override gas limit for tokens releaseOrMint calls (0 keeps original, v1.5..v1.6 only)',
+      },
+      'heap-frame-bytes': {
+        type: 'number',
+        describe:
+          'For Solana, request a transaction-wide heap frame size in bytes (must be a multiple of 1024).',
       },
       'estimate-gas-limit': {
         type: 'number',

--- a/ccip-sdk/src/chain.ts
+++ b/ccip-sdk/src/chain.ts
@@ -558,6 +558,8 @@ export type ExecuteOpts = (
   gasLimit?: number
   /** For EVM (v1.5..v1.6), overrides gasLimit on tokenPool call */
   tokensGasLimit?: number
+  /** For Solana, request a transaction-wide heap frame size in bytes (must be a multiple of 1024). */
+  heapFrameBytes?: number
   /** For Solana, send report in chunks to OffRamp, to later execute */
   forceBuffer?: boolean
   /** For Solana, create and extend addresses in a lookup table before executing */

--- a/ccip-sdk/src/solana/exec.ts
+++ b/ccip-sdk/src/solana/exec.ts
@@ -7,6 +7,7 @@ import {
   type TransactionInstruction,
   AddressLookupTableAccount,
   AddressLookupTableProgram,
+  ComputeBudgetProgram,
   PublicKey,
   SystemProgram,
 } from '@solana/web3.js'
@@ -47,7 +48,12 @@ export async function generateUnsignedExecuteReport(
   payer: PublicKey,
   offramp: PublicKey,
   execReport: ExecutionInput<CCIPMessage_V1_6_Solana>,
-  opts?: { forceLookupTable?: boolean; forceBuffer?: boolean; clearLeftoverAccounts?: boolean },
+  opts?: {
+    forceLookupTable?: boolean
+    forceBuffer?: boolean
+    clearLeftoverAccounts?: boolean
+    heapFrameBytes?: number
+  },
 ): Promise<UnsignedSolanaTx> {
   const { connection, logger = console } = ctx
 
@@ -125,6 +131,18 @@ export async function generateUnsignedExecuteReport(
     })
     .remainingAccounts(accounts.slice(12))
     .instruction()
+
+  if (opts?.heapFrameBytes != null && opts.heapFrameBytes % 1024 !== 0) {
+    throw new Error(
+      `heapFrameBytes must be a multiple of 1024, got ${opts.heapFrameBytes}`,
+    )
+  }
+
+  if (opts?.heapFrameBytes) {
+    instructions.push(
+      ComputeBudgetProgram.requestHeapFrame({ bytes: opts.heapFrameBytes }),
+    )
+  }
 
   // actual exec tx
   let execIndex = instructions.length


### PR DESCRIPTION
## Summary
- add optional `heapFrameBytes` to execute options
- request a Solana heap frame before the main `manuallyExecute` instruction
- expose `--heap-frame-bytes` in `ccip-cli manual-exec`

## Why
Some Solana CCIP executions that combine token transfer + receiver CPI can fail with `memory allocation failed, out of memory` even when compute unit limits are sufficient. This adds a supported manual-execution path for those cases through the public SDK/CLI.

## Scope
This updates the public tooling path only (`ccip-sdk` / `ccip-cli`). It does not change Atlas automatic execution behavior.

## Validation
- `npm run typecheck -w ccip-sdk`
- `npm run typecheck -w ccip-cli`
- `npm run build -w ccip-sdk`
- `npm run build -w ccip-cli`