### PR TITLE
fixes: extend `lane` with FQ [v2], Chain.getLaneFeatures and offchain tokenData

### DIFF
--- a/ccip-sdk/src/chain.ts
+++ b/ccip-sdk/src/chain.ts
@@ -1305,7 +1305,7 @@ export abstract class Chain<F extends ChainFamily = ChainFamily> {
    * ```
    */
   async getOffchainTokenData(
-    request: PickDeep<CCIPRequest, 'tx.hash' | `message`>,
+    request: PickDeep<CCIPRequest, 'log.transactionHash' | `message`>,
   ): Promise<OffchainTokenData[]> {
     return getOffchainTokenData(request, this)
   }
@@ -1342,6 +1342,18 @@ export abstract class Chain<F extends ChainFamily = ChainFamily> {
             ? opts.input.message.messageId
             : keccak256(opts.input.encodedMessage)
       const { offRamp, ...input } = await this.apiClient.getExecutionInput(messageId)
+      if (
+        'offchainTokenData' in input &&
+        input.message.tokenAmounts.length &&
+        !input.offchainTokenData[0]
+      ) {
+        // sometimes, attestation data may not be available on API, so try again to getOffchainTokenData from attestation providers;
+        const req = await this.apiClient.getMessageById(messageId)
+        input.offchainTokenData = await this.getOffchainTokenData({
+          log: req.log,
+          message: input.message,
+        })
+      }
       opts_ = { ...opts, offRamp, input }
     }
 

--- a/ccip-sdk/src/chain.ts
+++ b/ccip-sdk/src/chain.ts
@@ -43,7 +43,6 @@ import {
   type CCIPMessage,
   type CCIPRequest,
   type CCIPVerifications,
-  type CCIPVersion,
   type ChainLog,
   type ChainTransaction,
   type CommitReport,
@@ -54,6 +53,7 @@ import {
   type MessageInput,
   type OffchainTokenData,
   type WithLogger,
+  CCIPVersion,
   ExecutionState,
 } from './types.ts'
 import { util, withRetry } from './utils.ts'
@@ -1552,12 +1552,44 @@ export abstract class Chain<F extends ChainFamily = ChainFamily> {
    * }
    * ```
    */
-  getLaneFeatures(_opts: {
+  async getLaneFeatures(opts: {
     router: string
     destChainSelector: bigint
     token?: string
   }): Promise<Partial<LaneFeatures>> {
-    return Promise.reject(new CCIPNotImplementedError('getLaneFeatures'))
+    const onRamp = await this.getOnRampForRouter(opts.router, opts.destChainSelector)
+    const [, version] = await this.typeAndVersion(onRamp)
+
+    const result: Partial<LaneFeatures> = {}
+
+    // default FTF value for V2_0+ lanes if no token/pool or pool doesn't specify
+    if (version >= CCIPVersion.V2_0) {
+      result[LaneFeature.FINALITY_FAST] = 1
+      result[LaneFeature.FINALITY_SAFE] = true
+    }
+
+    // FINALITY_FAST — V2_0+ only
+    if (opts.token) {
+      const { tokenPool } = await this.getRegistryTokenConfig(
+        await this.getTokenAdminRegistryFor(onRamp),
+        opts.token,
+      )
+      if (tokenPool) {
+        const { finalityDepth, finalitySafe } = await this.getTokenPoolConfig(tokenPool)
+        if (finalityDepth != null) result[LaneFeature.FINALITY_FAST] = finalityDepth
+        else delete result[LaneFeature.FINALITY_FAST]
+        if (finalitySafe) result[LaneFeature.FINALITY_SAFE] = true
+        else delete result[LaneFeature.FINALITY_SAFE]
+
+        const remote = await this.getTokenPoolRemote(tokenPool, opts.destChainSelector)
+        result[LaneFeature.RATE_LIMITS] = remote.outboundRateLimiterState
+        if ((finalityDepth || finalitySafe) && 'fastOutboundRateLimiterState' in remote) {
+          result[LaneFeature.FAST_RATE_LIMITS] = remote.fastOutboundRateLimiterState
+        }
+      }
+    }
+
+    return result
   }
 
   /**

--- a/ccip-sdk/src/evm/abi/FeeQuoter_2_0.ts
+++ b/ccip-sdk/src/evm/abi/FeeQuoter_2_0.ts
@@ -1,0 +1,1542 @@
+export default [
+  // generate:
+  // fetch('https://github.com/smartcontractkit/chainlink-ccip/raw/refs/heads/main/chains/evm/gobindings/generated/v2_0_0/fee_quoter/fee_quoter.go')
+  //   .then((res) => res.text())
+  //   .then((body) => body.match(/^\s*ABI: "(.*?)",$/m)?.[1])
+  //   .then((abi) => JSON.parse(abi.replace(/\\"/g, '"')))
+  //   .then((obj) => require('util').inspect(obj, {depth:99}).split('\n').slice(1, -1))
+  {
+    type: 'constructor',
+    inputs: [
+      {
+        name: 'staticConfig',
+        type: 'tuple',
+        internalType: 'struct FeeQuoter.StaticConfig',
+        components: [
+          {
+            name: 'maxFeeJuelsPerMsg',
+            type: 'uint96',
+            internalType: 'uint96',
+          },
+          {
+            name: 'linkToken',
+            type: 'address',
+            internalType: 'address',
+          },
+        ],
+      },
+      {
+        name: 'priceUpdaters',
+        type: 'address[]',
+        internalType: 'address[]',
+      },
+      {
+        name: 'tokenTransferFeeConfigArgs',
+        type: 'tuple[]',
+        internalType: 'struct FeeQuoter.TokenTransferFeeConfigArgs[]',
+        components: [
+          {
+            name: 'destChainSelector',
+            type: 'uint64',
+            internalType: 'uint64',
+          },
+          {
+            name: 'tokenTransferFeeConfigs',
+            type: 'tuple[]',
+            internalType: 'struct FeeQuoter.TokenTransferFeeConfigSingleTokenArgs[]',
+            components: [
+              {
+                name: 'token',
+                type: 'address',
+                internalType: 'address',
+              },
+              {
+                name: 'tokenTransferFeeConfig',
+                type: 'tuple',
+                internalType: 'struct FeeQuoter.TokenTransferFeeConfig',
+                components: [
+                  {
+                    name: 'feeUSDCents',
+                    type: 'uint32',
+                    internalType: 'uint32',
+                  },
+                  {
+                    name: 'destGasOverhead',
+                    type: 'uint32',
+                    internalType: 'uint32',
+                  },
+                  {
+                    name: 'destBytesOverhead',
+                    type: 'uint32',
+                    internalType: 'uint32',
+                  },
+                  {
+                    name: 'isEnabled',
+                    type: 'bool',
+                    internalType: 'bool',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        name: 'destChainConfigArgs',
+        type: 'tuple[]',
+        internalType: 'struct FeeQuoter.DestChainConfigArgs[]',
+        components: [
+          {
+            name: 'destChainSelector',
+            type: 'uint64',
+            internalType: 'uint64',
+          },
+          {
+            name: 'destChainConfig',
+            type: 'tuple',
+            internalType: 'struct FeeQuoter.DestChainConfig',
+            components: [
+              { name: 'isEnabled', type: 'bool', internalType: 'bool' },
+              {
+                name: 'maxDataBytes',
+                type: 'uint32',
+                internalType: 'uint32',
+              },
+              {
+                name: 'maxPerMsgGasLimit',
+                type: 'uint32',
+                internalType: 'uint32',
+              },
+              {
+                name: 'destGasOverhead',
+                type: 'uint32',
+                internalType: 'uint32',
+              },
+              {
+                name: 'destGasPerPayloadByteBase',
+                type: 'uint8',
+                internalType: 'uint8',
+              },
+              {
+                name: 'chainFamilySelector',
+                type: 'bytes4',
+                internalType: 'bytes4',
+              },
+              {
+                name: 'defaultTokenFeeUSDCents',
+                type: 'uint16',
+                internalType: 'uint16',
+              },
+              {
+                name: 'defaultTokenDestGasOverhead',
+                type: 'uint32',
+                internalType: 'uint32',
+              },
+              {
+                name: 'defaultTxGasLimit',
+                type: 'uint32',
+                internalType: 'uint32',
+              },
+              {
+                name: 'networkFeeUSDCents',
+                type: 'uint16',
+                internalType: 'uint16',
+              },
+              {
+                name: 'linkFeeMultiplierPercent',
+                type: 'uint8',
+                internalType: 'uint8',
+              },
+            ],
+          },
+        ],
+      },
+    ],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    name: 'acceptOwnership',
+    inputs: [],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    name: 'applyAuthorizedCallerUpdates',
+    inputs: [
+      {
+        name: 'authorizedCallerArgs',
+        type: 'tuple',
+        internalType: 'struct AuthorizedCallers.AuthorizedCallerArgs',
+        components: [
+          {
+            name: 'addedCallers',
+            type: 'address[]',
+            internalType: 'address[]',
+          },
+          {
+            name: 'removedCallers',
+            type: 'address[]',
+            internalType: 'address[]',
+          },
+        ],
+      },
+    ],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    name: 'applyDestChainConfigUpdates',
+    inputs: [
+      {
+        name: 'destChainConfigArgs',
+        type: 'tuple[]',
+        internalType: 'struct FeeQuoter.DestChainConfigArgs[]',
+        components: [
+          {
+            name: 'destChainSelector',
+            type: 'uint64',
+            internalType: 'uint64',
+          },
+          {
+            name: 'destChainConfig',
+            type: 'tuple',
+            internalType: 'struct FeeQuoter.DestChainConfig',
+            components: [
+              { name: 'isEnabled', type: 'bool', internalType: 'bool' },
+              {
+                name: 'maxDataBytes',
+                type: 'uint32',
+                internalType: 'uint32',
+              },
+              {
+                name: 'maxPerMsgGasLimit',
+                type: 'uint32',
+                internalType: 'uint32',
+              },
+              {
+                name: 'destGasOverhead',
+                type: 'uint32',
+                internalType: 'uint32',
+              },
+              {
+                name: 'destGasPerPayloadByteBase',
+                type: 'uint8',
+                internalType: 'uint8',
+              },
+              {
+                name: 'chainFamilySelector',
+                type: 'bytes4',
+                internalType: 'bytes4',
+              },
+              {
+                name: 'defaultTokenFeeUSDCents',
+                type: 'uint16',
+                internalType: 'uint16',
+              },
+              {
+                name: 'defaultTokenDestGasOverhead',
+                type: 'uint32',
+                internalType: 'uint32',
+              },
+              {
+                name: 'defaultTxGasLimit',
+                type: 'uint32',
+                internalType: 'uint32',
+              },
+              {
+                name: 'networkFeeUSDCents',
+                type: 'uint16',
+                internalType: 'uint16',
+              },
+              {
+                name: 'linkFeeMultiplierPercent',
+                type: 'uint8',
+                internalType: 'uint8',
+              },
+            ],
+          },
+        ],
+      },
+    ],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    name: 'applyTokenTransferFeeConfigUpdates',
+    inputs: [
+      {
+        name: 'tokenTransferFeeConfigArgs',
+        type: 'tuple[]',
+        internalType: 'struct FeeQuoter.TokenTransferFeeConfigArgs[]',
+        components: [
+          {
+            name: 'destChainSelector',
+            type: 'uint64',
+            internalType: 'uint64',
+          },
+          {
+            name: 'tokenTransferFeeConfigs',
+            type: 'tuple[]',
+            internalType: 'struct FeeQuoter.TokenTransferFeeConfigSingleTokenArgs[]',
+            components: [
+              {
+                name: 'token',
+                type: 'address',
+                internalType: 'address',
+              },
+              {
+                name: 'tokenTransferFeeConfig',
+                type: 'tuple',
+                internalType: 'struct FeeQuoter.TokenTransferFeeConfig',
+                components: [
+                  {
+                    name: 'feeUSDCents',
+                    type: 'uint32',
+                    internalType: 'uint32',
+                  },
+                  {
+                    name: 'destGasOverhead',
+                    type: 'uint32',
+                    internalType: 'uint32',
+                  },
+                  {
+                    name: 'destBytesOverhead',
+                    type: 'uint32',
+                    internalType: 'uint32',
+                  },
+                  {
+                    name: 'isEnabled',
+                    type: 'bool',
+                    internalType: 'bool',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        name: 'tokensToUseDefaultFeeConfigs',
+        type: 'tuple[]',
+        internalType: 'struct FeeQuoter.TokenTransferFeeConfigRemoveArgs[]',
+        components: [
+          {
+            name: 'destChainSelector',
+            type: 'uint64',
+            internalType: 'uint64',
+          },
+          { name: 'token', type: 'address', internalType: 'address' },
+        ],
+      },
+    ],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    name: 'convertTokenAmount',
+    inputs: [
+      { name: 'fromToken', type: 'address', internalType: 'address' },
+      {
+        name: 'fromTokenAmount',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+      { name: 'toToken', type: 'address', internalType: 'address' },
+    ],
+    outputs: [{ name: '', type: 'uint256', internalType: 'uint256' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'getAllAuthorizedCallers',
+    inputs: [],
+    outputs: [{ name: '', type: 'address[]', internalType: 'address[]' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'getAllDestChainConfigs',
+    inputs: [],
+    outputs: [
+      { name: '', type: 'uint64[]', internalType: 'uint64[]' },
+      {
+        name: '',
+        type: 'tuple[]',
+        internalType: 'struct FeeQuoter.DestChainConfig[]',
+        components: [
+          { name: 'isEnabled', type: 'bool', internalType: 'bool' },
+          {
+            name: 'maxDataBytes',
+            type: 'uint32',
+            internalType: 'uint32',
+          },
+          {
+            name: 'maxPerMsgGasLimit',
+            type: 'uint32',
+            internalType: 'uint32',
+          },
+          {
+            name: 'destGasOverhead',
+            type: 'uint32',
+            internalType: 'uint32',
+          },
+          {
+            name: 'destGasPerPayloadByteBase',
+            type: 'uint8',
+            internalType: 'uint8',
+          },
+          {
+            name: 'chainFamilySelector',
+            type: 'bytes4',
+            internalType: 'bytes4',
+          },
+          {
+            name: 'defaultTokenFeeUSDCents',
+            type: 'uint16',
+            internalType: 'uint16',
+          },
+          {
+            name: 'defaultTokenDestGasOverhead',
+            type: 'uint32',
+            internalType: 'uint32',
+          },
+          {
+            name: 'defaultTxGasLimit',
+            type: 'uint32',
+            internalType: 'uint32',
+          },
+          {
+            name: 'networkFeeUSDCents',
+            type: 'uint16',
+            internalType: 'uint16',
+          },
+          {
+            name: 'linkFeeMultiplierPercent',
+            type: 'uint8',
+            internalType: 'uint8',
+          },
+        ],
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'getAllTokenTransferFeeConfigs',
+    inputs: [],
+    outputs: [
+      {
+        name: 'destChainSelectors',
+        type: 'uint64[]',
+        internalType: 'uint64[]',
+      },
+      {
+        name: 'transferTokens',
+        type: 'address[][]',
+        internalType: 'address[][]',
+      },
+      {
+        name: 'tokenTransferFeeConfigs',
+        type: 'tuple[][]',
+        internalType: 'struct FeeQuoter.TokenTransferFeeConfig[][]',
+        components: [
+          {
+            name: 'feeUSDCents',
+            type: 'uint32',
+            internalType: 'uint32',
+          },
+          {
+            name: 'destGasOverhead',
+            type: 'uint32',
+            internalType: 'uint32',
+          },
+          {
+            name: 'destBytesOverhead',
+            type: 'uint32',
+            internalType: 'uint32',
+          },
+          { name: 'isEnabled', type: 'bool', internalType: 'bool' },
+        ],
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'getDestChainConfig',
+    inputs: [
+      {
+        name: 'destChainSelector',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
+    ],
+    outputs: [
+      {
+        name: '',
+        type: 'tuple',
+        internalType: 'struct FeeQuoter.DestChainConfig',
+        components: [
+          { name: 'isEnabled', type: 'bool', internalType: 'bool' },
+          {
+            name: 'maxDataBytes',
+            type: 'uint32',
+            internalType: 'uint32',
+          },
+          {
+            name: 'maxPerMsgGasLimit',
+            type: 'uint32',
+            internalType: 'uint32',
+          },
+          {
+            name: 'destGasOverhead',
+            type: 'uint32',
+            internalType: 'uint32',
+          },
+          {
+            name: 'destGasPerPayloadByteBase',
+            type: 'uint8',
+            internalType: 'uint8',
+          },
+          {
+            name: 'chainFamilySelector',
+            type: 'bytes4',
+            internalType: 'bytes4',
+          },
+          {
+            name: 'defaultTokenFeeUSDCents',
+            type: 'uint16',
+            internalType: 'uint16',
+          },
+          {
+            name: 'defaultTokenDestGasOverhead',
+            type: 'uint32',
+            internalType: 'uint32',
+          },
+          {
+            name: 'defaultTxGasLimit',
+            type: 'uint32',
+            internalType: 'uint32',
+          },
+          {
+            name: 'networkFeeUSDCents',
+            type: 'uint16',
+            internalType: 'uint16',
+          },
+          {
+            name: 'linkFeeMultiplierPercent',
+            type: 'uint8',
+            internalType: 'uint8',
+          },
+        ],
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'getDestinationChainGasPrice',
+    inputs: [
+      {
+        name: 'destChainSelector',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
+    ],
+    outputs: [
+      {
+        name: '',
+        type: 'tuple',
+        internalType: 'struct Internal.TimestampedPackedUint224',
+        components: [
+          { name: 'value', type: 'uint224', internalType: 'uint224' },
+          { name: 'timestamp', type: 'uint32', internalType: 'uint32' },
+        ],
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'getFeeTokens',
+    inputs: [],
+    outputs: [{ name: '', type: 'address[]', internalType: 'address[]' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'getStaticConfig',
+    inputs: [],
+    outputs: [
+      {
+        name: '',
+        type: 'tuple',
+        internalType: 'struct FeeQuoter.StaticConfig',
+        components: [
+          {
+            name: 'maxFeeJuelsPerMsg',
+            type: 'uint96',
+            internalType: 'uint96',
+          },
+          {
+            name: 'linkToken',
+            type: 'address',
+            internalType: 'address',
+          },
+        ],
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'getTokenAndGasPrices',
+    inputs: [
+      { name: 'token', type: 'address', internalType: 'address' },
+      {
+        name: 'destChainSelector',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
+    ],
+    outputs: [
+      { name: 'tokenPrice', type: 'uint224', internalType: 'uint224' },
+      {
+        name: 'gasPriceValue',
+        type: 'uint224',
+        internalType: 'uint224',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'getTokenPrice',
+    inputs: [{ name: 'token', type: 'address', internalType: 'address' }],
+    outputs: [
+      {
+        name: '',
+        type: 'tuple',
+        internalType: 'struct Internal.TimestampedPackedUint224',
+        components: [
+          { name: 'value', type: 'uint224', internalType: 'uint224' },
+          { name: 'timestamp', type: 'uint32', internalType: 'uint32' },
+        ],
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'getTokenPrices',
+    inputs: [{ name: 'tokens', type: 'address[]', internalType: 'address[]' }],
+    outputs: [
+      {
+        name: '',
+        type: 'tuple[]',
+        internalType: 'struct Internal.TimestampedPackedUint224[]',
+        components: [
+          { name: 'value', type: 'uint224', internalType: 'uint224' },
+          { name: 'timestamp', type: 'uint32', internalType: 'uint32' },
+        ],
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'getTokenTransferFee',
+    inputs: [
+      {
+        name: 'destChainSelector',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
+      { name: 'token', type: 'address', internalType: 'address' },
+    ],
+    outputs: [
+      { name: 'feeUSDCents', type: 'uint32', internalType: 'uint32' },
+      {
+        name: 'destGasOverhead',
+        type: 'uint32',
+        internalType: 'uint32',
+      },
+      {
+        name: 'destBytesOverhead',
+        type: 'uint32',
+        internalType: 'uint32',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'getTokenTransferFeeConfig',
+    inputs: [
+      {
+        name: 'destChainSelector',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
+      { name: 'token', type: 'address', internalType: 'address' },
+    ],
+    outputs: [
+      {
+        name: 'tokenTransferFeeConfig',
+        type: 'tuple',
+        internalType: 'struct FeeQuoter.TokenTransferFeeConfig',
+        components: [
+          {
+            name: 'feeUSDCents',
+            type: 'uint32',
+            internalType: 'uint32',
+          },
+          {
+            name: 'destGasOverhead',
+            type: 'uint32',
+            internalType: 'uint32',
+          },
+          {
+            name: 'destBytesOverhead',
+            type: 'uint32',
+            internalType: 'uint32',
+          },
+          { name: 'isEnabled', type: 'bool', internalType: 'bool' },
+        ],
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'getValidatedFee',
+    inputs: [
+      {
+        name: 'destChainSelector',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
+      {
+        name: 'message',
+        type: 'tuple',
+        internalType: 'struct Client.EVM2AnyMessage',
+        components: [
+          { name: 'receiver', type: 'bytes', internalType: 'bytes' },
+          { name: 'data', type: 'bytes', internalType: 'bytes' },
+          {
+            name: 'tokenAmounts',
+            type: 'tuple[]',
+            internalType: 'struct Client.EVMTokenAmount[]',
+            components: [
+              {
+                name: 'token',
+                type: 'address',
+                internalType: 'address',
+              },
+              {
+                name: 'amount',
+                type: 'uint256',
+                internalType: 'uint256',
+              },
+            ],
+          },
+          {
+            name: 'feeToken',
+            type: 'address',
+            internalType: 'address',
+          },
+          { name: 'extraArgs', type: 'bytes', internalType: 'bytes' },
+        ],
+      },
+    ],
+    outputs: [
+      {
+        name: 'feeTokenAmount',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'getValidatedTokenPrice',
+    inputs: [{ name: 'token', type: 'address', internalType: 'address' }],
+    outputs: [{ name: '', type: 'uint224', internalType: 'uint224' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'owner',
+    inputs: [],
+    outputs: [{ name: '', type: 'address', internalType: 'address' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'processMessageArgs',
+    inputs: [
+      {
+        name: 'destChainSelector',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
+      { name: 'feeToken', type: 'address', internalType: 'address' },
+      {
+        name: 'feeTokenAmount',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+      { name: 'extraArgs', type: 'bytes', internalType: 'bytes' },
+      { name: 'messageReceiver', type: 'bytes', internalType: 'bytes' },
+    ],
+    outputs: [
+      { name: 'msgFeeJuels', type: 'uint256', internalType: 'uint256' },
+      {
+        name: 'isOutOfOrderExecution',
+        type: 'bool',
+        internalType: 'bool',
+      },
+      {
+        name: 'convertedExtraArgs',
+        type: 'bytes',
+        internalType: 'bytes',
+      },
+      { name: 'tokenReceiver', type: 'bytes', internalType: 'bytes' },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'processPoolReturnData',
+    inputs: [
+      {
+        name: 'destChainSelector',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
+      {
+        name: 'onRampTokenTransfers',
+        type: 'tuple[]',
+        internalType: 'struct Internal.EVM2AnyTokenTransfer[]',
+        components: [
+          {
+            name: 'sourcePoolAddress',
+            type: 'address',
+            internalType: 'address',
+          },
+          {
+            name: 'destTokenAddress',
+            type: 'bytes',
+            internalType: 'bytes',
+          },
+          { name: 'extraData', type: 'bytes', internalType: 'bytes' },
+          { name: 'amount', type: 'uint256', internalType: 'uint256' },
+          {
+            name: 'destExecData',
+            type: 'bytes',
+            internalType: 'bytes',
+          },
+        ],
+      },
+      {
+        name: 'sourceTokenAmounts',
+        type: 'tuple[]',
+        internalType: 'struct Client.EVMTokenAmount[]',
+        components: [
+          { name: 'token', type: 'address', internalType: 'address' },
+          { name: 'amount', type: 'uint256', internalType: 'uint256' },
+        ],
+      },
+    ],
+    outputs: [
+      {
+        name: 'destExecDataPerToken',
+        type: 'bytes[]',
+        internalType: 'bytes[]',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'quoteGasForExec',
+    inputs: [
+      {
+        name: 'destChainSelector',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
+      {
+        name: 'nonCalldataGas',
+        type: 'uint32',
+        internalType: 'uint32',
+      },
+      { name: 'calldataSize', type: 'uint32', internalType: 'uint32' },
+      { name: 'feeToken', type: 'address', internalType: 'address' },
+    ],
+    outputs: [
+      { name: 'totalGas', type: 'uint32', internalType: 'uint32' },
+      {
+        name: 'gasCostInUsdCents',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+      {
+        name: 'feeTokenPrice',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+      {
+        name: 'premiumPercentMultiplier',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'removeFeeTokens',
+    inputs: [
+      {
+        name: 'feeTokensToRemove',
+        type: 'address[]',
+        internalType: 'address[]',
+      },
+    ],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    name: 'resolveLegacyArgs',
+    inputs: [
+      {
+        name: 'destChainSelector',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
+      { name: 'extraArgs', type: 'bytes', internalType: 'bytes' },
+    ],
+    outputs: [
+      { name: 'tokenReceiver', type: 'bytes', internalType: 'bytes' },
+      { name: 'gasLimit', type: 'uint32', internalType: 'uint32' },
+      { name: 'executorArgs', type: 'bytes', internalType: 'bytes' },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'transferOwnership',
+    inputs: [{ name: 'to', type: 'address', internalType: 'address' }],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    name: 'typeAndVersion',
+    inputs: [],
+    outputs: [{ name: '', type: 'string', internalType: 'string' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'updatePrices',
+    inputs: [
+      {
+        name: 'priceUpdates',
+        type: 'tuple',
+        internalType: 'struct Internal.PriceUpdates',
+        components: [
+          {
+            name: 'tokenPriceUpdates',
+            type: 'tuple[]',
+            internalType: 'struct Internal.TokenPriceUpdate[]',
+            components: [
+              {
+                name: 'sourceToken',
+                type: 'address',
+                internalType: 'address',
+              },
+              {
+                name: 'usdPerToken',
+                type: 'uint224',
+                internalType: 'uint224',
+              },
+            ],
+          },
+          {
+            name: 'gasPriceUpdates',
+            type: 'tuple[]',
+            internalType: 'struct Internal.GasPriceUpdate[]',
+            components: [
+              {
+                name: 'destChainSelector',
+                type: 'uint64',
+                internalType: 'uint64',
+              },
+              {
+                name: 'usdPerUnitGas',
+                type: 'uint224',
+                internalType: 'uint224',
+              },
+            ],
+          },
+        ],
+      },
+    ],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'event',
+    name: 'AuthorizedCallerAdded',
+    inputs: [
+      {
+        name: 'caller',
+        type: 'address',
+        indexed: false,
+        internalType: 'address',
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: 'event',
+    name: 'AuthorizedCallerRemoved',
+    inputs: [
+      {
+        name: 'caller',
+        type: 'address',
+        indexed: false,
+        internalType: 'address',
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: 'event',
+    name: 'DestChainAdded',
+    inputs: [
+      {
+        name: 'destChainSelector',
+        type: 'uint64',
+        indexed: true,
+        internalType: 'uint64',
+      },
+      {
+        name: 'destChainConfig',
+        type: 'tuple',
+        indexed: false,
+        internalType: 'struct FeeQuoter.DestChainConfig',
+        components: [
+          { name: 'isEnabled', type: 'bool', internalType: 'bool' },
+          {
+            name: 'maxDataBytes',
+            type: 'uint32',
+            internalType: 'uint32',
+          },
+          {
+            name: 'maxPerMsgGasLimit',
+            type: 'uint32',
+            internalType: 'uint32',
+          },
+          {
+            name: 'destGasOverhead',
+            type: 'uint32',
+            internalType: 'uint32',
+          },
+          {
+            name: 'destGasPerPayloadByteBase',
+            type: 'uint8',
+            internalType: 'uint8',
+          },
+          {
+            name: 'chainFamilySelector',
+            type: 'bytes4',
+            internalType: 'bytes4',
+          },
+          {
+            name: 'defaultTokenFeeUSDCents',
+            type: 'uint16',
+            internalType: 'uint16',
+          },
+          {
+            name: 'defaultTokenDestGasOverhead',
+            type: 'uint32',
+            internalType: 'uint32',
+          },
+          {
+            name: 'defaultTxGasLimit',
+            type: 'uint32',
+            internalType: 'uint32',
+          },
+          {
+            name: 'networkFeeUSDCents',
+            type: 'uint16',
+            internalType: 'uint16',
+          },
+          {
+            name: 'linkFeeMultiplierPercent',
+            type: 'uint8',
+            internalType: 'uint8',
+          },
+        ],
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: 'event',
+    name: 'DestChainConfigUpdated',
+    inputs: [
+      {
+        name: 'destChainSelector',
+        type: 'uint64',
+        indexed: true,
+        internalType: 'uint64',
+      },
+      {
+        name: 'destChainConfig',
+        type: 'tuple',
+        indexed: false,
+        internalType: 'struct FeeQuoter.DestChainConfig',
+        components: [
+          { name: 'isEnabled', type: 'bool', internalType: 'bool' },
+          {
+            name: 'maxDataBytes',
+            type: 'uint32',
+            internalType: 'uint32',
+          },
+          {
+            name: 'maxPerMsgGasLimit',
+            type: 'uint32',
+            internalType: 'uint32',
+          },
+          {
+            name: 'destGasOverhead',
+            type: 'uint32',
+            internalType: 'uint32',
+          },
+          {
+            name: 'destGasPerPayloadByteBase',
+            type: 'uint8',
+            internalType: 'uint8',
+          },
+          {
+            name: 'chainFamilySelector',
+            type: 'bytes4',
+            internalType: 'bytes4',
+          },
+          {
+            name: 'defaultTokenFeeUSDCents',
+            type: 'uint16',
+            internalType: 'uint16',
+          },
+          {
+            name: 'defaultTokenDestGasOverhead',
+            type: 'uint32',
+            internalType: 'uint32',
+          },
+          {
+            name: 'defaultTxGasLimit',
+            type: 'uint32',
+            internalType: 'uint32',
+          },
+          {
+            name: 'networkFeeUSDCents',
+            type: 'uint16',
+            internalType: 'uint16',
+          },
+          {
+            name: 'linkFeeMultiplierPercent',
+            type: 'uint8',
+            internalType: 'uint8',
+          },
+        ],
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: 'event',
+    name: 'FeeTokenAdded',
+    inputs: [
+      {
+        name: 'feeToken',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: 'event',
+    name: 'FeeTokenRemoved',
+    inputs: [
+      {
+        name: 'feeToken',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: 'event',
+    name: 'OwnershipTransferRequested',
+    inputs: [
+      {
+        name: 'from',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
+      },
+      {
+        name: 'to',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: 'event',
+    name: 'OwnershipTransferred',
+    inputs: [
+      {
+        name: 'from',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
+      },
+      {
+        name: 'to',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: 'event',
+    name: 'TokenTransferFeeConfigDeleted',
+    inputs: [
+      {
+        name: 'destChainSelector',
+        type: 'uint64',
+        indexed: true,
+        internalType: 'uint64',
+      },
+      {
+        name: 'token',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: 'event',
+    name: 'TokenTransferFeeConfigUpdated',
+    inputs: [
+      {
+        name: 'destChainSelector',
+        type: 'uint64',
+        indexed: true,
+        internalType: 'uint64',
+      },
+      {
+        name: 'token',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
+      },
+      {
+        name: 'tokenTransferFeeConfig',
+        type: 'tuple',
+        indexed: false,
+        internalType: 'struct FeeQuoter.TokenTransferFeeConfig',
+        components: [
+          {
+            name: 'feeUSDCents',
+            type: 'uint32',
+            internalType: 'uint32',
+          },
+          {
+            name: 'destGasOverhead',
+            type: 'uint32',
+            internalType: 'uint32',
+          },
+          {
+            name: 'destBytesOverhead',
+            type: 'uint32',
+            internalType: 'uint32',
+          },
+          { name: 'isEnabled', type: 'bool', internalType: 'bool' },
+        ],
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: 'event',
+    name: 'UsdPerTokenUpdated',
+    inputs: [
+      {
+        name: 'token',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
+      },
+      {
+        name: 'value',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
+      },
+      {
+        name: 'timestamp',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: 'event',
+    name: 'UsdPerUnitGasUpdated',
+    inputs: [
+      {
+        name: 'destChain',
+        type: 'uint64',
+        indexed: true,
+        internalType: 'uint64',
+      },
+      {
+        name: 'value',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
+      },
+      {
+        name: 'timestamp',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
+      },
+    ],
+    anonymous: false,
+  },
+  { type: 'error', name: 'CannotTransferToSelf', inputs: [] },
+  {
+    type: 'error',
+    name: 'DestinationChainNotEnabled',
+    inputs: [
+      {
+        name: 'destChainSelector',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
+    ],
+  },
+  {
+    type: 'error',
+    name: 'FeeTokenNotSupported',
+    inputs: [{ name: 'token', type: 'address', internalType: 'address' }],
+  },
+  {
+    type: 'error',
+    name: 'Invalid32ByteAddress',
+    inputs: [{ name: 'encodedAddress', type: 'bytes', internalType: 'bytes' }],
+  },
+  {
+    type: 'error',
+    name: 'InvalidChainFamilySelector',
+    inputs: [
+      {
+        name: 'chainFamilySelector',
+        type: 'bytes4',
+        internalType: 'bytes4',
+      },
+    ],
+  },
+  {
+    type: 'error',
+    name: 'InvalidDataLength',
+    inputs: [
+      {
+        name: 'location',
+        type: 'uint8',
+        internalType: 'enum ExtraArgsCodec.EncodingErrorLocation',
+      },
+      { name: 'offset', type: 'uint256', internalType: 'uint256' },
+    ],
+  },
+  {
+    type: 'error',
+    name: 'InvalidDestBytesOverhead',
+    inputs: [
+      { name: 'token', type: 'address', internalType: 'address' },
+      {
+        name: 'destBytesOverhead',
+        type: 'uint32',
+        internalType: 'uint32',
+      },
+    ],
+  },
+  {
+    type: 'error',
+    name: 'InvalidDestChainConfig',
+    inputs: [
+      {
+        name: 'destChainSelector',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
+    ],
+  },
+  {
+    type: 'error',
+    name: 'InvalidEVMAddress',
+    inputs: [{ name: 'encodedAddress', type: 'bytes', internalType: 'bytes' }],
+  },
+  { type: 'error', name: 'InvalidExtraArgsData', inputs: [] },
+  { type: 'error', name: 'InvalidExtraArgsTag', inputs: [] },
+  {
+    type: 'error',
+    name: 'InvalidSVMExtraArgsWritableBitmap',
+    inputs: [
+      {
+        name: 'accountIsWritableBitmap',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
+      { name: 'numAccounts', type: 'uint256', internalType: 'uint256' },
+    ],
+  },
+  { type: 'error', name: 'InvalidStaticConfig', inputs: [] },
+  {
+    type: 'error',
+    name: 'InvalidTVMAddress',
+    inputs: [{ name: 'encodedAddress', type: 'bytes', internalType: 'bytes' }],
+  },
+  { type: 'error', name: 'InvalidTokenReceiver', inputs: [] },
+  { type: 'error', name: 'MessageComputeUnitLimitTooHigh', inputs: [] },
+  {
+    type: 'error',
+    name: 'MessageFeeTooHigh',
+    inputs: [
+      { name: 'msgFeeJuels', type: 'uint256', internalType: 'uint256' },
+      {
+        name: 'maxFeeJuelsPerMsg',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+  },
+  { type: 'error', name: 'MessageGasLimitTooHigh', inputs: [] },
+  {
+    type: 'error',
+    name: 'MessageTooLarge',
+    inputs: [
+      { name: 'maxSize', type: 'uint256', internalType: 'uint256' },
+      { name: 'actualSize', type: 'uint256', internalType: 'uint256' },
+    ],
+  },
+  { type: 'error', name: 'MustBeProposedOwner', inputs: [] },
+  {
+    type: 'error',
+    name: 'NoGasPriceAvailable',
+    inputs: [
+      {
+        name: 'destChainSelector',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
+    ],
+  },
+  { type: 'error', name: 'OnlyCallableByOwner', inputs: [] },
+  { type: 'error', name: 'OwnerCannotBeZero', inputs: [] },
+  {
+    type: 'error',
+    name: 'SourceTokenDataTooLarge',
+    inputs: [{ name: 'token', type: 'address', internalType: 'address' }],
+  },
+  {
+    type: 'error',
+    name: 'TokenNotSupported',
+    inputs: [{ name: 'token', type: 'address', internalType: 'address' }],
+  },
+  {
+    type: 'error',
+    name: 'TokenTransferConfigMustBeEnabled',
+    inputs: [
+      {
+        name: 'destChainSelector',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
+      { name: 'token', type: 'address', internalType: 'address' },
+    ],
+  },
+  {
+    type: 'error',
+    name: 'TooManySVMExtraArgsAccounts',
+    inputs: [
+      { name: 'numAccounts', type: 'uint256', internalType: 'uint256' },
+      { name: 'maxAccounts', type: 'uint256', internalType: 'uint256' },
+    ],
+  },
+  {
+    type: 'error',
+    name: 'TooManySuiExtraArgsReceiverObjectIds',
+    inputs: [
+      {
+        name: 'numReceiverObjectIds',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+      {
+        name: 'maxReceiverObjectIds',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+  },
+  {
+    type: 'error',
+    name: 'UnauthorizedCaller',
+    inputs: [{ name: 'caller', type: 'address', internalType: 'address' }],
+  },
+  {
+    type: 'error',
+    name: 'UnsupportedNumberOfTokens',
+    inputs: [
+      {
+        name: 'numberOfTokens',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+      {
+        name: 'maxNumberOfTokensPerMsg',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+  },
+  { type: 'error', name: 'ZeroAddressNotAllowed', inputs: [] },
+  // generate:end
+] as const

--- a/ccip-sdk/src/evm/const.ts
+++ b/ccip-sdk/src/evm/const.ts
@@ -5,7 +5,8 @@ import Token_ABI from './abi/BurnMintERC677Token.ts'
 import CCTPVerifier_2_0_ABI from './abi/CCTPVerifier_2_0.ts'
 import CommitStore_1_2_ABI from './abi/CommitStore_1_2.ts'
 import CommitStore_1_5_ABI from './abi/CommitStore_1_5.ts'
-import FeeQuoter_ABI from './abi/FeeQuoter_1_6.ts'
+import FeeQuoter_1_6_ABI from './abi/FeeQuoter_1_6.ts'
+import FeeQuoter_2_0_ABI from './abi/FeeQuoter_2_0.ts'
 import TokenPool_1_5_ABI from './abi/LockReleaseTokenPool_1_5.ts'
 import TokenPool_1_5_1_ABI from './abi/LockReleaseTokenPool_1_5_1.ts'
 import TokenPool_1_6_ABI from './abi/LockReleaseTokenPool_1_6_1.ts'
@@ -44,11 +45,12 @@ export const interfaces = {
   Router: new Interface(Router_ABI),
   Token: new Interface(Token_ABI),
   TokenAdminRegistry: new Interface(TokenAdminRegistry_ABI),
-  FeeQuoter: new Interface(FeeQuoter_ABI),
-  TokenPool_v1_5_1: new Interface(TokenPool_1_5_1_ABI),
-  TokenPool_v1_5: new Interface(TokenPool_1_5_ABI),
+  FeeQuoter_v1_6: new Interface(FeeQuoter_1_6_ABI),
+  FeeQuoter_v2_0: new Interface(FeeQuoter_2_0_ABI),
   TokenPool_v2_0: new Interface(TokenPool_2_0_ABI),
   TokenPool_v1_6: new Interface(TokenPool_1_6_ABI),
+  TokenPool_v1_5_1: new Interface(TokenPool_1_5_1_ABI),
+  TokenPool_v1_5: new Interface(TokenPool_1_5_ABI),
   CommitStore_v1_5: new Interface(CommitStore_1_5_ABI),
   CommitStore_v1_2: new Interface(CommitStore_1_2_ABI),
   OffRamp_v2_0: new Interface(OffRamp_2_0_ABI),

--- a/ccip-sdk/src/evm/errors.ts
+++ b/ccip-sdk/src/evm/errors.ts
@@ -63,18 +63,15 @@ export function parseWithFragment(
       parsed?: Result,
     ]
   | undefined {
-  if (!dataLength(data ?? '0x') && isBytesLike(selector)) {
-    const len = dataLength(selector)
-    if (len >= 4 && len !== 32) {
-      data = dataSlice(selector, 4)
-      selector = dataSlice(selector, 0, 4)
-    }
-  }
   let res: readonly [ErrorFragment | FunctionFragment | EventFragment, string] | undefined
   for (const [name, iface] of Object.entries(interfaces)) {
     try {
-      const error = iface.getError(selector)
+      const error = iface.getError(isHexString(selector) ? dataSlice(selector, 0, 4) : selector)
       if (error) {
+        if (!data && isHexString(selector) && dataLength(selector) > 4) {
+          ;[selector, data] = [dataSlice(selector, 0, 4), dataSlice(selector, 4)]
+        }
+
         res = [error, name] as const
         break
       }
@@ -82,8 +79,11 @@ export function parseWithFragment(
       // test all abis
     }
     try {
-      const func = iface.getFunction(selector)
+      const func = iface.getFunction(isHexString(selector) ? dataSlice(selector, 0, 4) : selector)
       if (func) {
+        if (!data && isHexString(selector) && dataLength(selector) > 4) {
+          ;[selector, data] = [dataSlice(selector, 0, 4), dataSlice(selector, 4)]
+        }
         res = [func, name] as const
         break
       }
@@ -91,8 +91,11 @@ export function parseWithFragment(
       // test all abis
     }
     try {
-      const event = iface.getEvent(selector)
+      const event = iface.getEvent(isHexString(selector) ? dataSlice(selector, 0, 32) : selector)
       if (event) {
+        if (!data && isHexString(selector) && dataLength(selector) > 32) {
+          ;[selector, data] = [dataSlice(selector, 0, 32), dataSlice(selector, 32)]
+        }
         res = [event, name] as const
         break
       }

--- a/ccip-sdk/src/evm/index.ts
+++ b/ccip-sdk/src/evm/index.ts
@@ -100,7 +100,8 @@ import type Token_ABI from './abi/BurnMintERC677Token.ts'
 import type CCTPVerifier_2_0_ABI from './abi/CCTPVerifier_2_0.ts'
 import CommitStore_1_2_ABI from './abi/CommitStore_1_2.ts'
 import CommitStore_1_5_ABI from './abi/CommitStore_1_5.ts'
-import type FeeQuoter_ABI from './abi/FeeQuoter_1_6.ts'
+import type FeeQuoter_1_6_ABI from './abi/FeeQuoter_1_6.ts'
+import type FeeQuoter_2_0_ABI from './abi/FeeQuoter_2_0.ts'
 import type TokenPool_1_5_ABI from './abi/LockReleaseTokenPool_1_5.ts'
 import type TokenPool_ABI from './abi/LockReleaseTokenPool_1_6_1.ts'
 import EVM2EVMOffRamp_1_2_ABI from './abi/OffRamp_1_2.ts'
@@ -136,6 +137,7 @@ import type { CCIPMessage_V1_6_EVM, CCIPMessage_V2_0, CleanAddressable } from '.
 import { encodeEVMOffchainTokenData } from './offchain.ts'
 import { type UnsignedEVMTx, resultToObject } from './types.ts'
 import { type NetworkInfo, ChainFamily, NetworkType, networkInfo } from '../networks.ts'
+import type PriceRegistry_1_2 from './abi/PriceRegistry_1_2.ts'
 export type { UnsignedEVMTx }
 
 /** Raw on-chain TokenBucket struct returned by TokenPool rate limiter queries. */
@@ -322,6 +324,12 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
       expires: 60e3,
     })
     this.getOffRampConfig = memoize(this.getOffRampConfig.bind(this), {
+      async: true,
+      maxArgs: 2,
+      maxSize: 10,
+      expires: 60e3,
+    })
+    this._getFeeQuoterDest = memoize(this._getFeeQuoterDest.bind(this), {
       async: true,
       maxArgs: 2,
       maxSize: 10,
@@ -699,6 +707,54 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
     }
   }
 
+  /**
+   * Fetch FeeQuoter dest state for a given contract and remote chainSelector
+   */
+  async _getFeeQuoterDest(feeQuoter: string, destChainSelector: bigint) {
+    const [type, version, typeAndVersion] = await this.typeAndVersion(feeQuoter)
+    if (type !== 'FeeQuoter' && type !== 'PriceRegistry')
+      throw new CCIPContractTypeInvalidError(feeQuoter, type, ['FeeQuoter', 'PriceRegistry'], {
+        context: { type, version, typeAndVersion },
+      })
+    let contract
+    if (type === 'PriceRegistry') {
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+      contract = new Contract(
+        feeQuoter,
+        interfaces.PriceRegistry_v1_2,
+        this.provider,
+      ) as unknown as TypedContract<typeof PriceRegistry_1_2>
+      const [destChainGasPrice, stalenessThreshold] = await Promise.all([
+        contract.getDestinationChainGasPrice(destChainSelector),
+        contract.getStalenessThreshold(),
+      ])
+      return resultToObject({
+        destChainGasPrice,
+        stalenessThreshold,
+        typeAndVersion,
+      })
+    }
+    if (version < CCIPVersion.V2_0) {
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+      contract = new Contract(
+        feeQuoter,
+        interfaces.FeeQuoter_v1_6,
+        this.provider,
+      ) as unknown as TypedContract<typeof FeeQuoter_1_6_ABI>
+    } else {
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+      contract = new Contract(
+        feeQuoter,
+        interfaces.FeeQuoter_v2_0,
+        this.provider,
+      ) as unknown as TypedContract<typeof FeeQuoter_2_0_ABI>
+    }
+    return {
+      ...(await resultToObject(contract.getDestChainConfig(destChainSelector))),
+      typeAndVersion,
+    }
+  }
+
   /** {@inheritDoc Chain.getOnRampConfig} */
   async getOnRampConfig(onRamp: string, destChainSelector: bigint) {
     const [, version, typeAndVersion] = await this.typeAndVersion(onRamp)
@@ -729,6 +785,10 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
           feeQuoter: dynamicConfig.priceRegistry,
           ...staticConfig,
           ...dynamicConfig,
+          priceRegistryConfig: await this._getFeeQuoterDest(
+            dynamicConfig.priceRegistry,
+            destChainSelector,
+          ),
           typeAndVersion,
         }
       }
@@ -745,18 +805,12 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
         ])
         const [_, allowlistEnabled, router] = destChainConfigRaw
         const destChainConfig = { allowlistEnabled, router }
-        const feeQuoter = new Contract(
-          dynamicConfig.feeQuoter,
-          interfaces.FeeQuoter,
-          this.provider,
-        ) as unknown as TypedContract<typeof FeeQuoter_ABI>
-        const feeQuoterState = await resultToObject(feeQuoter.getDestChainConfig(destChainSelector))
         return {
           ...staticConfig,
           destChainSelector,
           ...dynamicConfig,
           ...resultToObject(destChainConfig),
-          feeQuoterState,
+          feeQuoterConfig: await this._getFeeQuoterDest(dynamicConfig.feeQuoter, destChainSelector),
           typeAndVersion,
         }
       }
@@ -776,6 +830,7 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
           ...dynamicConfig,
           destChainSelector,
           ...destChainConfig,
+          feeQuoterConfig: await this._getFeeQuoterDest(dynamicConfig.feeQuoter, destChainSelector),
           typeAndVersion,
         }
       }
@@ -905,6 +960,10 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
           ...csDynamicConfig,
           ...staticConfig,
           ...dynamicConfig,
+          priceRegistryConfig: await this._getFeeQuoterDest(
+            dynamicConfig.priceRegistry,
+            sourceChainSelector,
+          ),
           onRamps: [staticConfig.onRamp],
           typeAndVersion,
         }
@@ -932,6 +991,10 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
           ...dynamicConfig,
           sourceChainSelector,
           ...sourceChainConfig,
+          feeQuoterConfig: await this._getFeeQuoterDest(
+            dynamicConfig.feeQuoter,
+            sourceChainSelector,
+          ),
           onRamps,
           typeAndVersion,
         }
@@ -1286,9 +1349,9 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
     // getTokenPrice(address) → { value: uint224, timestamp: uint32 }
     const contract = new Contract(
       priceContractAddress,
-      interfaces.FeeQuoter,
+      interfaces.FeeQuoter_v1_6,
       this.provider,
-    ) as unknown as TypedContract<typeof FeeQuoter_ABI>
+    ) as unknown as TypedContract<typeof FeeQuoter_1_6_ABI>
 
     // If timestamp provided, resolve to block number for historical query
     let blockTag: number | undefined
@@ -2069,9 +2132,9 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
     const feeQuoter = await this.getFeeQuoterFor(address)
     const contract = new Contract(
       feeQuoter,
-      interfaces.FeeQuoter,
+      interfaces.FeeQuoter_v1_6,
       this.provider,
-    ) as unknown as TypedContract<typeof FeeQuoter_ABI>
+    ) as unknown as TypedContract<typeof FeeQuoter_1_6_ABI>
     const tokens = await contract.getFeeTokens()
 
     return Object.fromEntries(

--- a/ccip-sdk/src/evm/index.ts
+++ b/ccip-sdk/src/evm/index.ts
@@ -32,7 +32,6 @@ import type { PickDeep, SetFieldType, SetRequired } from 'type-fest'
 import {
   type ChainContext,
   type GetBalanceOpts,
-  type LaneFeatures,
   type LogFilter,
   type RateLimiterState,
   type TokenPoolRemote,
@@ -40,7 +39,6 @@ import {
   type TokenTransferFeeOpts,
   type TotalFeesEstimate,
   Chain,
-  LaneFeature,
 } from '../chain.ts'
 import {
   CCIPAddressInvalidError,
@@ -837,49 +835,6 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
       default:
         throw new CCIPVersionUnsupportedError(version)
     }
-  }
-
-  /**
-   * {@inheritDoc Chain.getLaneFeatures}
-   */
-  override async getLaneFeatures(opts: {
-    router: string
-    destChainSelector: bigint
-    token?: string
-  }): Promise<Partial<LaneFeatures>> {
-    const onRamp = await this.getOnRampForRouter(opts.router, opts.destChainSelector)
-    const [, version] = await this.typeAndVersion(onRamp)
-
-    const result: Partial<LaneFeatures> = {}
-
-    // default FTF value for V2_0+ lanes if no token/pool or pool doesn't specify
-    if (version >= CCIPVersion.V2_0) {
-      result[LaneFeature.FINALITY_FAST] = 1
-      result[LaneFeature.FINALITY_SAFE] = true
-    }
-
-    // FINALITY_FAST — V2_0+ only
-    if (opts.token) {
-      const { tokenPool } = await this.getRegistryTokenConfig(
-        await this.getTokenAdminRegistryFor(onRamp),
-        opts.token,
-      )
-      if (tokenPool) {
-        const { finalityDepth, finalitySafe } = await this.getTokenPoolConfig(tokenPool)
-        if (finalityDepth != null) result[LaneFeature.FINALITY_FAST] = finalityDepth
-        else delete result[LaneFeature.FINALITY_FAST]
-        if (finalitySafe) result[LaneFeature.FINALITY_SAFE] = true
-        else delete result[LaneFeature.FINALITY_SAFE]
-
-        const remote = await this.getTokenPoolRemote(tokenPool, opts.destChainSelector)
-        result[LaneFeature.RATE_LIMITS] = remote.outboundRateLimiterState
-        if ((finalityDepth || finalitySafe) && 'fastOutboundRateLimiterState' in remote) {
-          result[LaneFeature.FAST_RATE_LIMITS] = remote.fastOutboundRateLimiterState
-        }
-      }
-    }
-
-    return result
   }
 
   /** {@inheritDoc Chain.getNativeTokenForRouter} */

--- a/ccip-sdk/src/evm/index.ts
+++ b/ccip-sdk/src/evm/index.ts
@@ -745,11 +745,18 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
         ])
         const [_, allowlistEnabled, router] = destChainConfigRaw
         const destChainConfig = { allowlistEnabled, router }
+        const feeQuoter = new Contract(
+          dynamicConfig.feeQuoter,
+          interfaces.FeeQuoter,
+          this.provider,
+        ) as unknown as TypedContract<typeof FeeQuoter_ABI>
+        const feeQuoterState = await resultToObject(feeQuoter.getDestChainConfig(destChainSelector))
         return {
           ...staticConfig,
           destChainSelector,
           ...dynamicConfig,
           ...resultToObject(destChainConfig),
+          feeQuoterState,
           typeAndVersion,
         }
       }

--- a/ccip-sdk/src/offchain.ts
+++ b/ccip-sdk/src/offchain.ts
@@ -170,7 +170,7 @@ export async function getLbtcAttestation(
  * @returns Promise resolving to an OffchainTokenData for each tokenAmount
  */
 export async function getOffchainTokenData(
-  request: PickDeep<CCIPRequest, 'tx.hash' | `message`>,
+  request: PickDeep<CCIPRequest, 'log.transactionHash' | `message`>,
   { logger = console }: WithLogger = {},
 ): Promise<OffchainTokenData[]> {
   const { networkType } = networkInfo(request.message.sourceChainSelector)
@@ -216,7 +216,7 @@ export async function getOffchainTokenData(
       if (usdcOpts) {
         try {
           const usdcAttestation = await getUsdcAttestation(
-            { ...usdcOpts, txHash: request.tx.hash },
+            { ...usdcOpts, txHash: request.log.transactionHash },
             networkType,
           )
           return { _tag: 'usdc', extraData, ...usdcAttestation }

--- a/ccip-sdk/src/requests.ts
+++ b/ccip-sdk/src/requests.ts
@@ -1,3 +1,4 @@
+import type BN from 'bn.js'
 import { type BytesLike, hexlify, isBytesLike, toBigInt } from 'ethers'
 import type { PickDeep } from 'type-fest'
 
@@ -33,6 +34,39 @@ import {
   leToBigInt,
   parseJson,
 } from './utils.ts'
+
+/** Convert recursively a message or config record into normalized values */
+export function normalizeDeep<T extends Record<string, unknown>>(
+  data: T,
+  opts: { sourceFamily?: ChainFamily; destFamily?: ChainFamily } = {},
+): T {
+  return convertKeysToCamelCase(data, (v, k) =>
+    k === 'chainFamilySelector'
+      ? hexlify(getDataBytes(v as number[]))
+      : k?.match(/(selector|amount|nonce|number|limit|bitmap|juels|value)$/i)
+        ? toBigInt(
+            Array.isArray(v) ? getDataBytes(v) : (v as string | number | bigint | BN).toString(),
+          )
+        : k?.match(/(^dest.*address)|(receiver|offramp|accounts)/i)
+          ? v == null && k === 'destAddress'
+            ? v
+            : decodeAddress(
+                (typeof v === 'bigint' ? v.toString() : v) as BytesLike,
+                opts.destFamily,
+              )
+          : k?.match(
+                /((source.*address)|sender|issuer|origin|onramp|(feetoken$)|(token.*address$))/i,
+              )
+            ? decodeAddress(
+                (typeof v === 'bigint' ? v.toString() : v) as BytesLike,
+                opts.sourceFamily,
+              )
+            : v instanceof Uint8Array ||
+                (Array.isArray(v) && v.length >= 4 && v.every((e) => typeof e === 'number'))
+              ? hexlify(getDataBytes(v))
+              : v,
+  ) as T
+}
 
 function decodeJsonMessage(data: Record<string, unknown> | undefined) {
   if (!data || typeof data != 'object') throw new CCIPMessageInvalidError(data)
@@ -86,20 +120,7 @@ function decodeJsonMessage(data: Record<string, unknown> | undefined) {
   if (destChainSelector) data_.destChainSelector ??= destChainSelector
   const destFamily = destChainSelector ? networkInfo(destChainSelector).family : ChainFamily.EVM
   // transform type, normalize keys case, source/dest addresses, and ensure known bigints
-  data_ = convertKeysToCamelCase(data_, (v, k) =>
-    k?.match(/(selector|amount|nonce|number|limit|bitmap|juels)$/i)
-      ? BigInt(v as string | number | bigint)
-      : k?.match(/(^dest.*address)|(receiver|offramp|accounts)/i)
-        ? v == null && k === 'destAddress'
-          ? v
-          : decodeAddress((typeof v === 'bigint' ? v.toString() : v) as BytesLike, destFamily)
-        : k?.match(/((source.*address)|sender|issuer|origin|onramp|(feetoken$)|(token.*address$))/i)
-          ? decodeAddress((typeof v === 'bigint' ? v.toString() : v) as BytesLike, sourceFamily)
-          : v instanceof Uint8Array ||
-              (Array.isArray(v) && v.length >= 4 && v.every((e) => typeof e === 'number'))
-            ? hexlify(getDataBytes(v))
-            : v,
-  ) as typeof data_
+  data_ = normalizeDeep(data_, { sourceFamily, destFamily })
 
   if (data_.tokenTransfer) {
     data_.tokenAmounts = data_.tokenTransfer

--- a/ccip-sdk/src/solana/index.ts
+++ b/ccip-sdk/src/solana/index.ts
@@ -636,15 +636,29 @@ export class SolanaChain extends Chain<typeof ChainFamily.Solana> {
     )
     const {
       config: { onRamp: onRampField, ...sourceConfig },
+      state,
     } = await program.account.sourceChain.fetch(statePda)
     const onRamp = decodeAddress(
       getAddressBytes(onRampField.bytes).subarray(0, onRampField.len),
       networkInfo(sourceChainSelector).family,
     )
 
+    const [feeQuoterDestChainStateAccountAddress] = PublicKey.findProgramAddressSync(
+      [Buffer.from('dest_chain'), toLeArray(sourceChainSelector, 8)],
+      refAddresses.feeQuoter,
+    )
+    const feeQuoter = new Program(FEE_QUOTER_IDL, refAddresses.feeQuoter, {
+      connection: this.connection,
+    })
+    const feeQuoterState = await feeQuoter.account.destChain.fetch(
+      feeQuoterDestChainStateAccountAddress,
+    )
+
     return normalizePda({
       ...refAddresses,
       ...sourceConfig,
+      ...state,
+      feeQuoterState,
       onRamps: [onRamp],
       typeAndVersion,
     })

--- a/ccip-sdk/src/solana/index.ts
+++ b/ccip-sdk/src/solana/index.ts
@@ -129,7 +129,7 @@ import {
   simulateAndSendTxs,
   simulationProvider,
 } from './utils.ts'
-import { buildMessageForDest } from '../requests.ts'
+import { buildMessageForDest, normalizeDeep } from '../requests.ts'
 import { patchBorsh } from './patchBorsh.ts'
 import { DEFAULT_GAS_LIMIT } from '../shared/constants.ts'
 export type { UnsignedSolanaTx }
@@ -650,7 +650,7 @@ export class SolanaChain extends Chain<typeof ChainFamily.Solana> {
     const feeQuoter = new Program(FEE_QUOTER_IDL, refAddresses.feeQuoter, {
       connection: this.connection,
     })
-    const feeQuoterState = await feeQuoter.account.destChain.fetch(
+    const destChainState = await feeQuoter.account.destChain.fetch(
       feeQuoterDestChainStateAccountAddress,
     )
 
@@ -658,7 +658,7 @@ export class SolanaChain extends Chain<typeof ChainFamily.Solana> {
       ...refAddresses,
       ...sourceConfig,
       ...state,
-      feeQuoterState,
+      feeQuoterState: normalizeDeep(destChainState),
       onRamps: [onRamp],
       typeAndVersion,
     })

--- a/ccip-sdk/src/utils.ts
+++ b/ccip-sdk/src/utils.ts
@@ -410,7 +410,11 @@ export function convertKeysToCamelCase(
   }
 
   if (obj == null) return obj
-  if (typeof obj !== 'object') return mapValues ? mapValues(obj, key) : obj
+  if (
+    typeof obj !== 'object' ||
+    !(Object.getPrototypeOf(obj) == null || Object.getPrototypeOf(obj) === Object.prototype)
+  )
+    return mapValues ? mapValues(obj, key) : obj
 
   const record = obj as Record<string, unknown>
   const converted: Record<string, unknown> = {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,27 @@
         "node": ">=20.0.0"
       }
     },
+    "ccip-api-ref/node_modules/react": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
+      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "ccip-api-ref/node_modules/react-dom": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
+      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.6"
+      }
+    },
     "ccip-cli": {
       "name": "@chainlink/ccip-cli",
       "version": "1.7.0",
@@ -98,67 +119,10 @@
         "typescript": "6.0.3"
       }
     },
-    "ccip-cli/node_modules/cliui": {
-      "version": "9.0.1",
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^7.2.0",
-        "strip-ansi": "^7.1.0",
-        "wrap-ansi": "^9.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "ccip-cli/node_modules/string-width": {
-      "version": "7.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "ccip-cli/node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "ccip-cli/node_modules/wrap-ansi": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
-      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.2.1",
-        "string-width": "^7.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
     "ccip-cli/node_modules/yargs": {
       "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
       "license": "MIT",
       "dependencies": {
         "cliui": "^9.0.1",
@@ -174,6 +138,8 @@
     },
     "ccip-cli/node_modules/yargs-parser": {
       "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
       "license": "ISC",
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=23"
@@ -223,6 +189,8 @@
     },
     "ccip-sdk/node_modules/@noble/hashes": {
       "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
       "license": "MIT",
       "engines": {
         "node": ">= 20.19.0"
@@ -689,15 +657,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^3.0.2"
-      }
-    },
     "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -706,12 +665,6 @@
       "bin": {
         "semver": "bin/semver.js"
       }
-    },
-    "node_modules/@babel/helper-compilation-targets/node_modules/yallist": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "license": "ISC"
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
       "version": "7.29.3",
@@ -4312,21 +4265,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@docusaurus/core/node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
     "node_modules/@docusaurus/core/node_modules/type-fest": {
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
@@ -4399,23 +4337,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@docusaurus/core/node_modules/wrap-ansi": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/@docusaurus/cssnano-preset": {
@@ -7263,33 +7184,6 @@
         "react-dom": "19.0.0"
       }
     },
-    "node_modules/@ledgerhq/domain-service/node_modules/react": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
-      "integrity": "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@ledgerhq/domain-service/node_modules/react-dom": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.0.0.tgz",
-      "integrity": "sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==",
-      "license": "MIT",
-      "dependencies": {
-        "scheduler": "^0.25.0"
-      },
-      "peerDependencies": {
-        "react": "^19.0.0"
-      }
-    },
-    "node_modules/@ledgerhq/domain-service/node_modules/scheduler": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
-      "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
-      "license": "MIT"
-    },
     "node_modules/@ledgerhq/errors": {
       "version": "6.34.1",
       "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-6.34.1.tgz",
@@ -7577,30 +7471,6 @@
         "jju": "~1.4.0",
         "resolve": "~1.22.2"
       }
-    },
-    "node_modules/@microsoft/tsdoc-config/node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/@microsoft/tsdoc-config/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@mysten/bcs": {
       "version": "2.0.5",
@@ -8381,6 +8251,19 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/@parcel/watcher/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/@peculiar/asn1-cms": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.7.0.tgz",
@@ -8639,12 +8522,6 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/@redocly/ajv/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
-    },
     "node_modules/@redocly/config": {
       "version": "0.48.1",
       "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.48.1.tgz",
@@ -8676,28 +8553,17 @@
         "npm": ">=10"
       }
     },
-    "node_modules/@redocly/openapi-core/node_modules/ajv": {
-      "name": "@redocly/ajv",
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.18.1.tgz",
-      "integrity": "sha512-Ifm/pP/tul1qmAecpbVxCBluVE32rKfjf8gYXH4xI2gCv9mRWFhJMHzkPDM4TXlxwPQYIFegymlsy8lXz7optA==",
+    "node_modules/@redocly/openapi-core/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
+      "engines": {
+        "node": ">=12"
       },
       "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
-    },
-    "node_modules/@redocly/openapi-core/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
     },
     "node_modules/@reduxjs/toolkit": {
       "version": "2.11.2",
@@ -10366,22 +10232,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@types/update-notifier/node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
     "node_modules/@types/update-notifier/node_modules/type-fest": {
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
@@ -10393,24 +10243,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@types/update-notifier/node_modules/wrap-ansi": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/@types/use-sync-external-store": {
@@ -11281,19 +11113,34 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
-      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "name": "@redocly/ajv",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.18.1.tgz",
+      "integrity": "sha512-Ifm/pP/tul1qmAecpbVxCBluVE32rKfjf8gYXH4xI2gCv9mRWFhJMHzkPDM4TXlxwPQYIFegymlsy8lXz7optA==",
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-draft-04": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^8.5.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/ajv-formats": {
@@ -11313,35 +11160,16 @@
         }
       }
     },
-    "node_modules/ajv-formats/node_modules/ajv": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+    "node_modules/ajv-keywords": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
+        "fast-deep-equal": "^3.1.3"
       },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
-    },
-    "node_modules/ajv-keywords": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "license": "MIT",
       "peerDependencies": {
-        "ajv": "^6.9.1"
+        "ajv": "^8.8.2"
       }
     },
     "node_modules/algoliasearch": {
@@ -11399,6 +11227,47 @@
         "string-width": "^4.1.0"
       }
     },
+    "node_modules/ansi-align/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-align/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/ansi-align/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-align/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-html-community": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ansi-html-community/-/ansi-html-community-0.0.8.tgz",
@@ -11424,12 +11293,15 @@
       }
     },
     "node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
       "engines": {
-        "node": ">=12"
+        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
@@ -11461,18 +11333,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/anymatch/node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/are-docs-informative": {
@@ -11725,9 +11585,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.28",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.28.tgz",
-      "integrity": "sha512-Ic44hnOtFIgravCunj1ifSoQPSUrkNiJuH9Mf6jr2jjoA74icqV8wU0KuadXeOR8zuIJMOoTv0GuQjZ9ZYNMeA==",
+      "version": "2.10.27",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.27.tgz",
+      "integrity": "sha512-zEs/ufmZoUd7WftKpKyXaT6RFxpQ5Qm9xytKRHvJfxFV9DFJkZph9RvJ1LcOUi0Z1ZVijMte65JbILeV+8QQEA==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -11969,21 +11829,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/boxen/node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
     "node_modules/boxen/node_modules/type-fest": {
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
@@ -11994,23 +11839,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/boxen/node_modules/wrap-ansi": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/brace-expansion": {
@@ -12402,21 +12230,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/chalk/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/change-case": {
       "version": "5.4.4",
       "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
@@ -12578,18 +12391,6 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/chokidar/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/chownr": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
@@ -12681,6 +12482,47 @@
         "@colors/colors": "1.5.0"
       }
     },
+    "node_modules/cli-table3/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-table3/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/cli-table3/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-table3/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/cli-width": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
@@ -12691,17 +12533,46 @@
       }
     },
     "node_modules/cliui": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
       "license": "ISC",
       "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
       },
       "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
         "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/clone-deep": {
@@ -13042,6 +12913,18 @@
       },
       "peerDependencies": {
         "webpack": "^5.1.0"
+      }
+    },
+    "node_modules/copy-webpack-plugin/node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/copy-webpack-plugin/node_modules/globby": {
@@ -14746,9 +14629,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.353",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.353.tgz",
-      "integrity": "sha512-kOrWphBi8TOZyiJZqsgqIle0lw+tzmnQK83pV9dZUd01Nm2POECSyFQMAuarzZdYqQW7FH9RaYOuaRo3h+bQ3w==",
+      "version": "1.5.352",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.352.tgz",
+      "integrity": "sha512-9wHk8x6dyuimoe18EdiDPWKExNdxYqo4fn4FwOVVper6RxT3cmpBwBkWWfSOCYJjQdIco/nPhJhNLmn4Ufg1Yg==",
       "license": "ISC"
     },
     "node_modules/elliptic": {
@@ -15454,6 +15337,43 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/eslint/node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/espree": {
       "version": "11.2.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
@@ -15980,18 +15900,6 @@
         "node": ">=8.6.0"
       }
     },
-    "node_modules/fast-glob/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -16104,23 +16012,6 @@
         "node": ">=0.8.0"
       }
     },
-    "node_modules/fdir": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/feed": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/feed/-/feed-4.2.2.tgz",
@@ -16181,6 +16072,37 @@
       "peerDependencies": {
         "webpack": "^4.0.0 || ^5.0.0"
       }
+    },
+    "node_modules/file-loader/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/file-loader/node_modules/ajv-keywords": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^6.9.1"
+      }
+    },
+    "node_modules/file-loader/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "license": "MIT"
     },
     "node_modules/file-loader/node_modules/schema-utils": {
       "version": "3.3.0",
@@ -16652,15 +16574,15 @@
       }
     },
     "node_modules/glob-parent": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "license": "ISC",
       "dependencies": {
-        "is-glob": "^4.0.3"
+        "is-glob": "^4.0.1"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">= 6"
       }
     },
     "node_modules/glob-to-regex.js": {
@@ -17622,9 +17544,9 @@
       "license": "MIT"
     },
     "node_modules/immer": {
-      "version": "11.1.8",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.8.tgz",
-      "integrity": "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==",
+      "version": "11.1.7",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.7.tgz",
+      "integrity": "sha512-LFVFtAROHcDy1er5UI6nodRFnZ2SgdCXhfNSI+DpObO8N7Pur/muBGsjzH5wpnFHCYhYVQxZskCkV4koQ//3/Q==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -18233,6 +18155,20 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "license": "MIT"
     },
+    "node_modules/jayson/node_modules/utf-8-validate": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "extraneous": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
     "node_modules/jayson/node_modules/ws": {
       "version": "7.5.10",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
@@ -18269,18 +18205,6 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-util/node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/jest-worker": {
@@ -18471,9 +18395,9 @@
       }
     },
     "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
@@ -18848,13 +18772,12 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "11.3.6",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
-      "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
       }
     },
     "node_modules/lunr": {
@@ -21274,18 +21197,6 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/micromatch/node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/mime": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
@@ -21764,6 +21675,37 @@
         "webpack": "^4.0.0 || ^5.0.0"
       }
     },
+    "node_modules/null-loader/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/null-loader/node_modules/ajv-keywords": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^6.9.1"
+      }
+    },
+    "node_modules/null-loader/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "license": "MIT"
+    },
     "node_modules/null-loader/node_modules/schema-utils": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
@@ -22074,36 +22016,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/openapi-to-postmanv2/node_modules/ajv": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/openapi-to-postmanv2/node_modules/ajv-draft-04": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
-      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "ajv": "^8.5.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/openapi-to-postmanv2/node_modules/ajv-formats": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
@@ -22125,12 +22037,6 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "license": "MIT"
-    },
-    "node_modules/openapi-to-postmanv2/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
     "node_modules/openapi-to-postmanv2/node_modules/yaml": {
@@ -22621,6 +22527,16 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
+      "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/path-to-regexp": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.9.0.tgz",
@@ -22646,12 +22562,12 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
-        "node": ">=12"
+        "node": ">=8.6"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -24997,25 +24913,31 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
-      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
+      "integrity": "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
-      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.0.0.tgz",
+      "integrity": "sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==",
       "license": "MIT",
       "dependencies": {
-        "scheduler": "^0.27.0"
+        "scheduler": "^0.25.0"
       },
       "peerDependencies": {
-        "react": "^19.2.6"
+        "react": "^19.0.0"
       }
+    },
+    "node_modules/react-dom/node_modules/scheduler": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
+      "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
+      "license": "MIT"
     },
     "node_modules/react-fast-compare": {
       "version": "3.2.2",
@@ -25285,18 +25207,6 @@
       },
       "engines": {
         "node": ">=8.10.0"
-      }
-    },
-    "node_modules/readdirp/node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/rechoir": {
@@ -25667,6 +25577,15 @@
         "strip-ansi": "^6.0.1"
       }
     },
+    "node_modules/renderkid/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/renderkid/node_modules/css-select": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
@@ -25752,6 +25671,18 @@
         "domhandler": "^4.0.0",
         "domutils": "^2.5.2",
         "entities": "^2.0.0"
+      }
+    },
+    "node_modules/renderkid/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/require-directory": {
@@ -26173,22 +26104,6 @@
         "url": "https://opencollective.com/webpack"
       }
     },
-    "node_modules/schema-utils/node_modules/ajv": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
     "node_modules/schema-utils/node_modules/ajv-formats": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
@@ -26205,24 +26120,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/schema-utils/node_modules/ajv-keywords": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
-      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3"
-      },
-      "peerDependencies": {
-        "ajv": "^8.8.2"
-      }
-    },
-    "node_modules/schema-utils/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
     },
     "node_modules/search-insights": {
       "version": "2.17.3",
@@ -26264,9 +26161,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -27113,24 +27010,21 @@
       }
     },
     "node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
       "license": "MIT",
       "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/string-width/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "license": "MIT"
     },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
@@ -27161,24 +27055,18 @@
       }
     },
     "node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
       "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^5.0.1"
+        "ansi-regex": "^6.2.2"
       },
       "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/strip-bom-string": {
@@ -27480,6 +27368,18 @@
         "tailwindcss": ">=3.0.0 || insiders"
       }
     },
+    "node_modules/tailwindcss/node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/tailwindcss/node_modules/lilconfig": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
@@ -27553,6 +27453,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/tar/node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/terser": {
       "version": "5.47.1",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.47.1.tgz",
@@ -27572,9 +27482,9 @@
       }
     },
     "node_modules/terser-webpack-plugin": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.6.0.tgz",
-      "integrity": "sha512-Eum+5ajkaOhf5KbM26osvv21kLD7BaGqQ1UA4Ami4arYwylmGUQTgHFpHDdmJod1q4QXa66p0to/FBKID+J1vA==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.5.0.tgz",
+      "integrity": "sha512-UYhptBwhWvfIjKd/UuFo6D8uq9xpGLDK+z8EDsj/zWhrTaH34cKEbrkMKfV5YWqGBvAYA3tlzZbs2R+qYrbQJA==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
@@ -27593,37 +27503,10 @@
         "webpack": "^5.1.0"
       },
       "peerDependenciesMeta": {
-        "@minify-html/node": {
-          "optional": true
-        },
         "@swc/core": {
           "optional": true
         },
-        "@swc/css": {
-          "optional": true
-        },
-        "@swc/html": {
-          "optional": true
-        },
-        "clean-css": {
-          "optional": true
-        },
-        "cssnano": {
-          "optional": true
-        },
-        "csso": {
-          "optional": true
-        },
         "esbuild": {
-          "optional": true
-        },
-        "html-minifier-terser": {
-          "optional": true
-        },
-        "lightningcss": {
-          "optional": true
-        },
-        "postcss": {
           "optional": true
         },
         "uglify-js": {
@@ -27770,6 +27653,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/tinypool": {
@@ -28412,6 +28324,18 @@
         "url": "https://github.com/yeoman/update-notifier?sponsor=1"
       }
     },
+    "node_modules/update-notifier/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/update-notifier/node_modules/boxen": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-8.0.1.tgz",
@@ -28456,38 +28380,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/update-notifier/node_modules/string-width": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/update-notifier/node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/update-notifier/node_modules/type-fest": {
@@ -28582,6 +28474,37 @@
           "optional": true
         }
       }
+    },
+    "node_modules/url-loader/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/url-loader/node_modules/ajv-keywords": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^6.9.1"
+      }
+    },
+    "node_modules/url-loader/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "license": "MIT"
     },
     "node_modules/url-loader/node_modules/schema-utils": {
       "version": "3.3.0",
@@ -29102,6 +29025,20 @@
         "node": ">= 10"
       }
     },
+    "node_modules/webpack-bundle-analyzer/node_modules/utf-8-validate": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "extraneous": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
     "node_modules/webpack-bundle-analyzer/node_modules/ws": {
       "version": "7.5.10",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
@@ -29522,21 +29459,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/widest-line/node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
     "node_modules/wildcard": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.1.tgz",
@@ -29554,35 +29476,55 @@
       }
     },
     "node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
       "license": "MIT",
       "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/wrap-ansi/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
       "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/wrappy": {
@@ -29715,14 +29657,10 @@
       }
     },
     "node_modules/yallist": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
-      }
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "license": "ISC"
     },
     "node_modules/yaml": {
       "version": "2.8.4",
@@ -29770,6 +29708,78 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/yocto-queue": {


### PR DESCRIPTION
- includes FeeQuoter configs in `lane` command for a few chains (for easier debugging)
- improves `parse` around event's `topic0 || data`
- fix: `getLaneFeatures` available for every chain family (move implementation to Chain base class)
- fix: fetch again `offchainTokenData` if missing from API