### PR TITLE
refactor: waitFinalized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.0] - 2026-05-25
+
 - SDK: Add `getMessagesInRange()` to the abstract Chain class — range-based CCIP message discovery using `getLogs` + `decodeMessage`, returns `AsyncIterableIterator<CCIPRequest>`
 - SDK: add `getOnRampConfig`/`getOffRampConfig` to fetch chain-specific onramp/offramp address and config for a given lane
+- SDK: replace `getBlockTimestamp` with `getBlockInfo`, fine-tune `Chain.waitFinalized` implementation
 - CLI: expose `lane --source <chain> --router <or_onramp> --dest <chain>` command to print lane config and ramps addresses
 
 ## [1.6.0] - 2026-05-06

--- a/ccip-cli/src/commands/e2e-helpers.test.ts
+++ b/ccip-cli/src/commands/e2e-helpers.test.ts
@@ -1,0 +1,44 @@
+import { spawn } from 'child_process'
+import { fileURLToPath } from 'node:url'
+import path from 'path'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+export const CLI_PATH = path.join(__dirname, '..', 'index.ts')
+
+export const RPCS = [
+  process.env['RPC_SEPOLIA'] || 'https://ethereum-sepolia-rpc.publicnode.com',
+  process.env['RPC_AVAX'] || 'https://avalanche-fuji-c-chain-rpc.publicnode.com',
+  process.env['RPC_APTOS'] || 'testnet',
+  process.env['RPC_SOLANA'] || 'https://api.devnet.solana.com',
+  process.env['RPC_TON'] || 'https://testnet.toncenter.com/api/v2',
+]
+
+export async function spawnCLI(
+  args: string[],
+  timeout = 60000,
+): Promise<{ stdout: string; stderr: string; exitCode: number | null }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn('node', [CLI_PATH, ...args], { env: { ...process.env } })
+
+    let stdout = ''
+    let stderr = ''
+
+    child.stdout.on('data', (data) => (stdout += data.toString()))
+    child.stderr.on('data', (data) => (stderr += data.toString()))
+
+    const timeoutId = setTimeout(() => {
+      child.kill('SIGTERM')
+      reject(new Error(`CLI command timed out after ${timeout / 1e3}s`))
+    }, timeout)
+
+    child.on('close', (code) => {
+      clearTimeout(timeoutId)
+      resolve({ stdout, stderr, exitCode: code })
+    })
+
+    child.on('error', (err) => {
+      clearTimeout(timeoutId)
+      reject(err)
+    })
+  })
+}

--- a/ccip-cli/src/commands/lane.test.ts
+++ b/ccip-cli/src/commands/lane.test.ts
@@ -1,49 +1,7 @@
-import { spawn } from 'child_process'
 import assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
-import { fileURLToPath } from 'node:url'
-import path from 'path'
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url))
-const CLI_PATH = path.join(__dirname, '..', 'index.ts')
-
-const RPCS = [
-  process.env['RPC_SEPOLIA'] || 'https://ethereum-sepolia-rpc.publicnode.com',
-  process.env['RPC_AVAX'] || 'https://avalanche-fuji-c-chain-rpc.publicnode.com',
-  process.env['RPC_APTOS'] || 'testnet',
-  process.env['RPC_SOLANA'] || 'https://api.devnet.solana.com',
-  process.env['RPC_TON'] || 'https://testnet.toncenter.com/api/v2',
-]
-
-async function spawnCLI(
-  args: string[],
-  timeout = 60000,
-): Promise<{ stdout: string; stderr: string; exitCode: number | null }> {
-  return new Promise((resolve, reject) => {
-    const child = spawn('node', [CLI_PATH, ...args], { env: { ...process.env } })
-
-    let stdout = ''
-    let stderr = ''
-
-    child.stdout.on('data', (data) => (stdout += data.toString()))
-    child.stderr.on('data', (data) => (stderr += data.toString()))
-
-    const timeoutId = setTimeout(() => {
-      child.kill('SIGTERM')
-      reject(new Error(`CLI command timed out after ${timeout / 1e3}s`))
-    }, timeout)
-
-    child.on('close', (code) => {
-      clearTimeout(timeoutId)
-      resolve({ stdout, stderr, exitCode: code })
-    })
-
-    child.on('error', (err) => {
-      clearTimeout(timeoutId)
-      reject(err)
-    })
-  })
-}
+import { RPCS, spawnCLI } from './e2e-helpers.test.ts'
 
 function buildLaneArgs(
   source: string,
@@ -138,6 +96,11 @@ describe('e2e command lane EVM v2.0', () => {
     assert.match(envelope.onRamp, new RegExp(ONRAMP, 'i'))
     assert.match(envelope.onRampConfig.typeAndVersion, /OnRamp 2\.0\.0/)
     assert.ok(envelope.onRampConfig.router, 'onRampConfig should have router')
+    assert.ok(envelope.onRampConfig.feeQuoterConfig, 'onRampConfig should have feeQuoterConfig')
+    assert.ok(
+      envelope.onRampConfig.feeQuoterConfig.typeAndVersion,
+      'feeQuoterConfig should have typeAndVersion',
+    )
     assert.ok(envelope.offRamp, 'offRamp should be discovered')
     assert.match(envelope.offRampConfig.typeAndVersion, /OffRamp 2\.0\.0/)
     assert.ok(envelope.offRampConfig.router, 'offRampConfig should have router')
@@ -173,6 +136,11 @@ describe('e2e command lane EVM <-> Aptos (v1.6)', () => {
     assert.match(envelope.onRamp, new RegExp(EVM_ONRAMP, 'i'))
     assert.match(envelope.onRampConfig.typeAndVersion, /OnRamp 1\.6\.0/)
     assert.ok(envelope.onRampConfig.router, 'onRampConfig should have router')
+    assert.ok(envelope.onRampConfig.feeQuoterConfig, 'onRampConfig should have feeQuoterConfig')
+    assert.ok(
+      envelope.onRampConfig.feeQuoterConfig.typeAndVersion,
+      'feeQuoterConfig should have typeAndVersion',
+    )
     assert.match(envelope.offRamp, new RegExp(APTOS_PACKAGE, 'i'))
     assert.match(envelope.offRampConfig.typeAndVersion, /1\.6\.0/)
     assert.ok(envelope.offRampConfig.router, 'offRampConfig should have router')
@@ -204,6 +172,10 @@ describe('e2e command lane EVM <-> Aptos (v1.6)', () => {
     assert.match(envelope.onRamp, new RegExp(APTOS_PACKAGE, 'i'))
     assert.match(envelope.onRampConfig.typeAndVersion, /1\.6\.0/)
     assert.ok(envelope.onRampConfig.router, 'onRampConfig should have router')
+    assert.ok(
+      envelope.onRampConfig.feeQuoterConfig,
+      'onRampConfig (Aptos) should have feeQuoterConfig',
+    )
     assert.match(envelope.offRamp, new RegExp(EVM_OFFRAMP, 'i'))
     assert.match(envelope.offRampConfig.typeAndVersion, /OffRamp 1\.6\.0/)
     assert.ok(envelope.offRampConfig.router, 'offRampConfig should have router')
@@ -242,6 +214,11 @@ describe('e2e command lane EVM <-> Solana (v1.6)', () => {
     assert.match(envelope.onRamp, new RegExp(EVM_ONRAMP, 'i'))
     assert.match(envelope.onRampConfig.typeAndVersion, /OnRamp 1\.6\.0/)
     assert.ok(envelope.onRampConfig.router, 'onRampConfig should have router')
+    assert.ok(envelope.onRampConfig.feeQuoterConfig, 'onRampConfig should have feeQuoterConfig')
+    assert.ok(
+      envelope.onRampConfig.feeQuoterConfig.typeAndVersion,
+      'feeQuoterConfig should have typeAndVersion',
+    )
     assert.match(envelope.offRamp, new RegExp(SOLANA_OFFRAMP))
     assert.match(envelope.offRampConfig.typeAndVersion, /1\.6\./)
     assert.ok(envelope.offRampConfig.router, 'offRampConfig should have router')
@@ -273,6 +250,10 @@ describe('e2e command lane EVM <-> Solana (v1.6)', () => {
     assert.match(envelope.onRamp, new RegExp(SOLANA_ONRAMP))
     assert.match(envelope.onRampConfig.typeAndVersion, /1\.6\./)
     assert.ok(envelope.onRampConfig.router, 'onRampConfig should have router')
+    assert.ok(
+      envelope.onRampConfig.feeQuoterConfig,
+      'onRampConfig (Solana) should have feeQuoterConfig',
+    )
     assert.match(envelope.offRamp, new RegExp(EVM_OFFRAMP, 'i'))
     assert.match(envelope.offRampConfig.typeAndVersion, /OffRamp 1\.6\.0/)
     assert.ok(envelope.offRampConfig.router, 'offRampConfig should have router')
@@ -307,6 +288,26 @@ describe('e2e command lane EVM <-> TON (v1.6)', () => {
     assert.match(envelope.onRamp, new RegExp(TON_ONRAMP.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')))
     assert.match(envelope.onRampConfig.typeAndVersion, /1\.6\.0/)
     assert.ok(envelope.onRampConfig.router, 'onRampConfig should have router')
+    assert.ok(
+      envelope.onRampConfig.feeQuoterConfig,
+      'onRampConfig (TON) should have feeQuoterConfig',
+    )
+    assert.ok(
+      envelope.onRampConfig.feeQuoterConfig.maxFeeJuelsPerMsg !== undefined,
+      'feeQuoterConfig should have maxFeeJuelsPerMsg',
+    )
+    assert.ok(
+      envelope.onRampConfig.feeQuoterConfig.linkToken,
+      'feeQuoterConfig should have linkToken',
+    )
+    assert.ok(
+      envelope.onRampConfig.feeQuoterConfig.usdPerUnitGas,
+      'feeQuoterConfig should have usdPerUnitGas',
+    )
+    assert.ok(
+      envelope.onRampConfig.feeQuoterConfig.defaultTxGasLimit !== undefined,
+      'feeQuoterConfig should have defaultTxGasLimit',
+    )
     assert.match(envelope.offRamp, /^0x[0-9a-fA-F]{40}$/, 'offRamp should be an EVM address')
     assert.match(envelope.offRampConfig.typeAndVersion, /OffRamp 1\.6\.0/)
     assert.ok(envelope.offRampConfig.router, 'offRampConfig should have router')
@@ -329,6 +330,11 @@ describe('e2e command lane EVM <-> TON (v1.6)', () => {
     assert.match(envelope.onRamp, new RegExp(EVM_ONRAMP_TON, 'i'))
     assert.match(envelope.onRampConfig.typeAndVersion, /OnRamp 1\.6\.0/)
     assert.ok(envelope.onRampConfig.router, 'onRampConfig should have router')
+    assert.ok(envelope.onRampConfig.feeQuoterConfig, 'onRampConfig should have feeQuoterConfig')
+    assert.ok(
+      envelope.onRampConfig.feeQuoterConfig.typeAndVersion,
+      'feeQuoterConfig should have typeAndVersion',
+    )
     assert.match(envelope.offRamp, /^0:[0-9a-fA-F]+$/, 'offRamp should be a raw TON address')
     assert.match(envelope.offRampConfig.typeAndVersion, /1\.6\.0/)
     assert.ok(envelope.offRampConfig.router, 'offRampConfig should have router')

--- a/ccip-cli/src/commands/lane.ts
+++ b/ccip-cli/src/commands/lane.ts
@@ -97,7 +97,7 @@ async function getLane(ctx: Ctx, argv: Parameters<typeof handler>[0]) {
       output.write('onRampConfig =', onRampConfig)
       break
     case Format.pretty:
-      output.write(`OnRamp (${sourceNetwork.name}):`)
+      output.write(`OnRamp (${sourceNetwork.name}) [${sourceNetwork.family}]:`)
       prettyTable.call(ctx, { onRamp, ...onRampConfig })
       break
     default:
@@ -142,7 +142,7 @@ async function getLane(ctx: Ctx, argv: Parameters<typeof handler>[0]) {
       output.write('offRampConfig =', offRampConfig)
       break
     case Format.pretty:
-      output.write(`OffRamp (${destNetwork.name}):`)
+      output.write(`OffRamp (${destNetwork.name}) [${destNetwork.family}]:`)
       prettyTable.call(ctx, { offRamp, ...offRampConfig })
       break
     default:

--- a/ccip-cli/src/commands/show.test.ts
+++ b/ccip-cli/src/commands/show.test.ts
@@ -1,75 +1,8 @@
-import { spawn } from 'child_process'
 import assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
-import { fileURLToPath } from 'node:url'
-import path from 'path'
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url))
-const CLI_PATH = path.join(__dirname, '..', 'index.ts')
+import { RPCS, spawnCLI } from './e2e-helpers.test.ts'
 
-// Public RPCs for testing
-const RPCS = [
-  process.env['RPC_SEPOLIA'] || 'https://ethereum-sepolia-rpc.publicnode.com',
-  process.env['RPC_AVAX'] || 'https://avalanche-fuji-c-chain-rpc.publicnode.com',
-  process.env['RPC_APTOS'] || 'testnet',
-  process.env['RPC_SOLANA'] || 'https://api.devnet.solana.com',
-  process.env['RPC_TON'] || 'https://testnet.toncenter.com/api/v2',
-]
-
-/**
- * Spawns the CLI as a subprocess and returns stdout/stderr/exitCode
- *
- * Sets NODE_V8_COVERAGE to collect coverage from the subprocess.
- * This coverage is automatically merged with Jest's coverage by c8.
- */
-async function spawnCLI(
-  args: string[],
-  timeout = 60000,
-): Promise<{
-  stdout: string
-  stderr: string
-  exitCode: number | null
-}> {
-  return new Promise((resolve, reject) => {
-    const child = spawn('node', [CLI_PATH, ...args], {
-      env: { ...process.env },
-    })
-
-    let stdout = ''
-    let stderr = ''
-
-    child.stdout.on('data', (data) => {
-      stdout += data.toString()
-    })
-
-    child.stderr.on('data', (data) => {
-      stderr += data.toString()
-    })
-
-    const timeoutId = setTimeout(() => {
-      child.kill('SIGTERM')
-      reject(new Error(`CLI command timed out after ${timeout / 1e3}s`))
-    }, timeout)
-
-    child.on('close', (code) => {
-      clearTimeout(timeoutId)
-      resolve({
-        stdout,
-        stderr,
-        exitCode: code,
-      })
-    })
-
-    child.on('error', (err) => {
-      clearTimeout(timeoutId)
-      reject(err)
-    })
-  })
-}
-
-/**
- * Helper to build common CLI arguments for show command
- */
 function buildShowArgs(txHash: string, ...additionalArgs: string[]): string[] {
   return [
     'show',

--- a/ccip-sdk/src/aptos/index.ts
+++ b/ccip-sdk/src/aptos/index.ts
@@ -11,6 +11,7 @@ import { type BytesLike, concat, isBytesLike, isHexString } from 'ethers'
 import { memoize } from 'micro-memoize'
 
 import {
+  type BlockInfo,
   type ChainContext,
   type GetBalanceOpts,
   type LogFilter,
@@ -207,9 +208,12 @@ export class AptosChain extends Chain<typeof ChainFamily.Aptos> {
     return this.fromAptosConfig(config, ctx)
   }
 
-  /** {@inheritDoc Chain.getBlockTimestamp} */
-  async getBlockTimestamp(version: number | 'finalized'): Promise<number> {
-    return getVersionTimestamp(this.provider, version)
+  /** {@inheritDoc Chain.getBlockInfo} */
+  async getBlockInfo(version: number | 'finalized' | 'latest'): Promise<BlockInfo> {
+    let version_ = typeof version !== 'number' ? 0 : version
+    if (version_ <= 0) version_ = +(await this.provider.getLedgerInfo()).ledger_version + version_
+    const timestamp = await getVersionTimestamp(this.provider, version_)
+    return { number: version_, timestamp }
   }
 
   /**

--- a/ccip-sdk/src/aptos/index.ts
+++ b/ccip-sdk/src/aptos/index.ts
@@ -77,7 +77,7 @@ import {
 } from '../utils.ts'
 import { getTokenInfo } from './token.ts'
 import type { CCIPMessage_V1_6_EVM } from '../evm/messages.ts'
-import { buildMessageForDest, decodeMessage } from '../requests.ts'
+import { buildMessageForDest, decodeMessage, normalizeDeep } from '../requests.ts'
 export type { UnsignedAptosTx }
 
 /**
@@ -280,8 +280,8 @@ export class AptosChain extends Chain<typeof ChainFamily.Aptos> {
   /** {@inheritDoc Chain.getOnRampConfig} */
   async getOnRampConfig(onRamp: string, destChainSelector: bigint) {
     const pkg = onRamp.split('::')[0]!
-    const onRampModule = `${pkg}::onramp`
     const feeQuoter = `${pkg}::fee_quoter`
+    const onRampModule = `${pkg}::onramp`
     const [, , typeAndVersion] = await this.typeAndVersion(onRampModule)
     const [sequenceNumber, allowlistEnabled, router, routerStateAddress] = await this.provider.view<
       [
@@ -297,15 +297,28 @@ export class AptosChain extends Chain<typeof ChainFamily.Aptos> {
         functionArguments: [destChainSelector],
       },
     })
-    return {
+    const [feeQuoterConfig] = await this.provider.view<[Record<string, unknown>]>({
+      payload: {
+        function: `${feeQuoter}::get_static_config` as `${string}::${string}::get_static_config`,
+      },
+    })
+    const [feeQuoterDestConfig] = await this.provider.view<[Record<string, unknown>]>({
+      payload: {
+        function:
+          `${feeQuoter}::get_dest_chain_config` as `${string}::${string}::get_dest_chain_config`,
+        functionArguments: [destChainSelector],
+      },
+    })
+    return normalizeDeep({
       feeQuoter,
       destChainSelector,
       sequenceNumber: +sequenceNumber,
       allowlistEnabled,
       router: router.includes('::') ? router : `${router}::router`,
       routerStateAddress,
+      feeQuoterConfig: { ...feeQuoterConfig, ...feeQuoterDestConfig },
       typeAndVersion,
-    }
+    })
   }
 
   /** {@inheritDoc Chain.getOffRampConfig} */
@@ -324,13 +337,19 @@ export class AptosChain extends Chain<typeof ChainFamily.Aptos> {
       },
     })
     const onRamp = decodeAddress(sourceChainConfig.on_ramp, networkInfo(sourceChainSelector).family)
-    return {
-      sourceChainSelector,
-      ...sourceChainConfig,
-      onRamps: [onRamp],
-      router,
-      typeAndVersion,
-    }
+    return normalizeDeep(
+      {
+        sourceChainSelector,
+        ...sourceChainConfig,
+        onRamps: [onRamp],
+        router,
+        typeAndVersion,
+      },
+      {
+        sourceFamily: networkInfo(sourceChainSelector).family,
+        destFamily: (this.constructor as typeof AptosChain).family,
+      },
+    )
   }
 
   /** {@inheritDoc Chain.getNativeTokenForRouter} */

--- a/ccip-sdk/src/canton/index.ts
+++ b/ccip-sdk/src/canton/index.ts
@@ -1,6 +1,7 @@
 import { type BytesLike, hexlify, id as keccak256Utf8 } from 'ethers'
 
 import {
+  type BlockInfo,
   type ChainContext,
   type ChainStatic,
   type GetBalanceOpts,
@@ -296,12 +297,12 @@ export class CantonChain extends Chain<typeof ChainFamily.Canton> {
   }
 
   /**
-   * {@inheritDoc Chain.getBlockTimestamp}
-   * @throws {@link CCIPNotImplementedError} for numeric blocks (Canton ledger uses offsets, not block numbers)
+   * {@inheritDoc Chain.getBlockInfo}
+   * @throws {@link CCIPNotImplementedError} Canton ledger uses offsets, not block numbers
    */
-  getBlockTimestamp(block: number | 'finalized'): Promise<number> {
+  getBlockInfo(block: number | 'finalized' | 'latest'): Promise<BlockInfo> {
     throw new CCIPNotImplementedError(
-      `CantonChain.getBlockTimestamp: block ${block} — Canton uses ledger offsets, not block numbers`,
+      `CantonChain.getBlockInfo: block ${block} — Canton uses ledger offsets, not block numbers`,
     )
   }
 

--- a/ccip-sdk/src/chain.ts
+++ b/ccip-sdk/src/chain.ts
@@ -13,7 +13,6 @@ import {
   CCIPLogsRequiresStartError,
   CCIPNotImplementedError,
   CCIPTokenPoolChainConfigNotFoundError,
-  CCIPTransactionNotFinalizedError,
 } from './errors/index.ts'
 import type { UnsignedEVMTx } from './evm/types.ts'
 import { calculateManualExecProof } from './execution.ts'
@@ -32,7 +31,12 @@ import type { LeafHasher } from './hasher/common.ts'
 import { decodeMessageV1 } from './messages.ts'
 import { type ChainFamily, type NetworkInfo, networkInfo } from './networks.ts'
 import { getOffchainTokenData } from './offchain.ts'
-import { getMessagesInBatch, getMessagesInRange, getMessagesInTx } from './requests.ts'
+import {
+  getMessagesInBatch,
+  getMessagesInRange,
+  getMessagesInTx,
+  waitFinalized,
+} from './requests.ts'
 import { DEFAULT_GAS_LIMIT } from './shared/constants.ts'
 import type { UnsignedSolanaTx } from './solana/types.ts'
 import type { UnsignedSuiTx } from './sui/types.ts'
@@ -56,7 +60,7 @@ import {
   CCIPVersion,
   ExecutionState,
 } from './types.ts'
-import { signalToPromise, util, withRetry } from './utils.ts'
+import { util, withRetry } from './utils.ts'
 
 /** All valid field names for GenericExtraArgsV2. */
 const V2_FIELDS = new Set(['gasLimit', 'allowOutOfOrderExecution'])
@@ -727,7 +731,7 @@ export abstract class Chain<F extends ChainFamily = ChainFamily> {
    * Confirm a log tx is finalized or wait for it to be finalized.
    *
    * @param opts - Options containing the request, finality level, and optional cancel promise
-   * @returns true when the transaction is finalized
+   * @returns Some block info at or after tx finalization
    *
    * @throws {@link CCIPTransactionNotFinalizedError} if the transaction is not included (e.g., due to a reorg)
    *
@@ -744,94 +748,20 @@ export abstract class Chain<F extends ChainFamily = ChainFamily> {
    * }
    * ```
    */
-  async waitFinalized({
-    request: { log },
-    finality = 'finalized',
-    abort,
-    reorgSafetyBlocks = 10,
-    pollIntervalMs = 5_000,
-  }: {
+  async waitFinalized(opts: {
     request: PickDeep<
       CCIPRequest,
       `log.${'address' | 'blockNumber' | 'transactionHash' | 'topics' | 'blockTimestamp'}`
     >
-    finality?: number | 'finalized' | 'latest'
+    finality?: Parameters<Chain['getBlockInfo']>[0]
     abort?: AbortSignal
     /** How many blocks past the original tx blockNumber must be finalized
      *  without the tx reappearing before we declare it reorged out. Default: 10 */
     reorgSafetyBlocks?: number
     /** Delay in ms between block-height poller iterations. Default: 5000 */
     pollIntervalMs?: number
-  }): Promise<true> {
-    // Fast-path: if the log is old enough, check tx timestamp vs finalized timestamp
-    if (!log.blockTimestamp || Date.now() / 1e3 - log.blockTimestamp > 60) {
-      const [trans, finalizedInfo] = await Promise.all([
-        this.getTransaction(log.transactionHash),
-        this.getBlockInfo(finality),
-      ])
-      if (trans.timestamp <= finalizedInfo.timestamp) return true
-    }
-    const watch = abort ? AbortSignal.any([this.abort, abort]) : this.abort
-
-    // Block-height deadline: poll finalized block height and abort if tx is gone
-    const deadlineAc = new AbortController()
-    const deadline = deadlineAc.signal
-    let txBlockNumber = log.blockNumber
-    const blockHeightPoller = (async () => {
-      while (!watch.aborted && !deadline.aborted) {
-        try {
-          const info = await this.getBlockInfo(finality)
-          if (info.number >= txBlockNumber + reorgSafetyBlocks) {
-            // Deadline reached — but the tx may have been reorged to a later block.
-            // Re-fetch the tx: if it's still present, update blockNumber and keep going.
-            try {
-              const tx = await this.getTransaction(log.transactionHash)
-              if (tx.blockNumber !== txBlockNumber) {
-                txBlockNumber = tx.blockNumber
-              }
-              // tx still present — fall through to the delay and re-evaluate;
-              // if it's genuinely finalized, the concurrent getLogs loop will match it
-            } catch {
-              // tx not found — definitively reorged out
-              deadlineAc.abort(new CCIPTransactionNotFinalizedError(log.transactionHash))
-              return
-            }
-          }
-        } catch {
-          // transient RPC error — retry on next poll
-        }
-        // wait before re-checking; exit early on watch abort
-        await signalToPromise(
-          AbortSignal.any([watch, deadline, AbortSignal.timeout(pollIntervalMs)]),
-        ).catch(() => {})
-      }
-    })()
-
-    // Race: getLogs watch vs block height deadline
-    try {
-      const combinedWatch = AbortSignal.any([watch, deadline])
-      for await (const l of this.getLogs({
-        address: log.address,
-        startBlock: log.blockNumber - 10,
-        endBlock: finality,
-        topics: [log.topics[0]!],
-        watch: combinedWatch,
-      })) {
-        if (l.transactionHash === log.transactionHash) {
-          return true
-        } else if (l.blockNumber > log.blockNumber) {
-          break
-        }
-      }
-    } catch (err) {
-      // If the deadline signal fired, its reason is already the right error
-      if (deadline.aborted) throw deadline.reason
-      throw err
-    } finally {
-      deadlineAc.abort() // stop the poller if getLogs resolved first
-      await blockHeightPoller // clean up
-    }
-    throw new CCIPTransactionNotFinalizedError(log.transactionHash)
+  }): ReturnType<Chain['getBlockInfo']> {
+    return waitFinalized(this, opts)
   }
   /**
    * An async generator that yields logs based on the provided options.

--- a/ccip-sdk/src/chain.ts
+++ b/ccip-sdk/src/chain.ts
@@ -56,7 +56,7 @@ import {
   CCIPVersion,
   ExecutionState,
 } from './types.ts'
-import { util, withRetry } from './utils.ts'
+import { signalToPromise, util, withRetry } from './utils.ts'
 
 /** All valid field names for GenericExtraArgsV2. */
 const V2_FIELDS = new Set(['gasLimit', 'allowOutOfOrderExecution'])
@@ -241,6 +241,16 @@ export type TokenInfo = {
   readonly decimals: number
   /** Optional human-readable token name. */
   readonly name?: string
+}
+
+/**
+ * Block metadata returned by {@link Chain.getBlockInfo}.
+ */
+export type BlockInfo = {
+  /** Block number (or slot, version, etc. depending on chain family). */
+  readonly number: number
+  /** Unix timestamp of the block in seconds. */
+  readonly timestamp: number
 }
 
 /**
@@ -667,21 +677,30 @@ export abstract class Chain<F extends ChainFamily = ChainFamily> {
   }
 
   /**
-   * Fetch the timestamp of a given block.
-   *
-   * @param block - Positive block number, negative finality depth, or 'finalized' tag
-   * @returns Promise resolving to timestamp of the block, in seconds
+   * Fetch info (number and timestamp) for a given block or finality tag.
+   * @param block - Block number, or tag like `'finalized'` or `'latest'`
+   * @returns Block info with number and timestamp
    *
    * @throws {@link CCIPBlockNotFoundError} if block does not exist
    *
-   * @example Get finalized block timestamp
+   * @example Get finalized block info
    * ```typescript
    * const chain = await EVMChain.fromUrl('https://eth-mainnet.example.com')
-   * const timestamp = await chain.getBlockTimestamp('finalized')
-   * console.log(`Finalized at: ${new Date(timestamp * 1000).toISOString()}`)
+   * const info = await chain.getBlockInfo('finalized')
+   * console.log(`Finalized block ${info.number} at ${new Date(info.timestamp * 1000).toISOString()}`)
    * ```
    */
-  abstract getBlockTimestamp(block: number | 'finalized'): Promise<number>
+  abstract getBlockInfo(block: number | 'finalized' | 'latest'): Promise<BlockInfo>
+
+  /**
+   * Fetch the timestamp of a given block.
+   * @param block - Block number or finality tag
+   * @returns Unix timestamp in seconds
+   * @deprecated Use {@link Chain.getBlockInfo} instead.
+   */
+  async getBlockTimestamp(block: number | 'finalized' | 'latest'): Promise<number> {
+    return (await this.getBlockInfo(block)).timestamp
+  }
   /**
    * Fetch a transaction by its hash.
    *
@@ -729,35 +748,88 @@ export abstract class Chain<F extends ChainFamily = ChainFamily> {
     request: { log },
     finality = 'finalized',
     abort,
+    reorgSafetyBlocks = 10,
+    pollIntervalMs = 5_000,
   }: {
     request: PickDeep<
       CCIPRequest,
       `log.${'address' | 'blockNumber' | 'transactionHash' | 'topics' | 'blockTimestamp'}`
     >
-    finality?: number | 'finalized'
+    finality?: number | 'finalized' | 'latest'
     abort?: AbortSignal
+    /** How many blocks past the original tx blockNumber must be finalized
+     *  without the tx reappearing before we declare it reorged out. Default: 10 */
+    reorgSafetyBlocks?: number
+    /** Delay in ms between block-height poller iterations. Default: 5000 */
+    pollIntervalMs?: number
   }): Promise<true> {
+    // Fast-path: if the log is old enough, check tx timestamp vs finalized timestamp
     if (!log.blockTimestamp || Date.now() / 1e3 - log.blockTimestamp > 60) {
-      // only try to fetch tx if request is old enough (>60s)
-      const [trans, finalizedTs] = await Promise.all([
+      const [trans, finalizedInfo] = await Promise.all([
         this.getTransaction(log.transactionHash),
-        this.getBlockTimestamp(finality),
+        this.getBlockInfo(finality),
       ])
-      if (trans.timestamp <= finalizedTs) return true
+      if (trans.timestamp <= finalizedInfo.timestamp) return true
     }
     const watch = abort ? AbortSignal.any([this.abort, abort]) : this.abort
-    for await (const l of this.getLogs({
-      address: log.address,
-      startBlock: log.blockNumber - 10,
-      endBlock: finality,
-      topics: [log.topics[0]!],
-      watch,
-    })) {
-      if (l.transactionHash === log.transactionHash) {
-        return true
-      } else if (l.blockNumber > log.blockNumber) {
-        break
+
+    // Block-height deadline: poll finalized block height and abort if tx is gone
+    const deadlineAc = new AbortController()
+    const deadline = deadlineAc.signal
+    let txBlockNumber = log.blockNumber
+    const blockHeightPoller = (async () => {
+      while (!watch.aborted && !deadline.aborted) {
+        try {
+          const info = await this.getBlockInfo(finality)
+          if (info.number >= txBlockNumber + reorgSafetyBlocks) {
+            // Deadline reached — but the tx may have been reorged to a later block.
+            // Re-fetch the tx: if it's still present, update blockNumber and keep going.
+            try {
+              const tx = await this.getTransaction(log.transactionHash)
+              if (tx.blockNumber !== txBlockNumber) {
+                txBlockNumber = tx.blockNumber
+              }
+              // tx still present — fall through to the delay and re-evaluate;
+              // if it's genuinely finalized, the concurrent getLogs loop will match it
+            } catch {
+              // tx not found — definitively reorged out
+              deadlineAc.abort(new CCIPTransactionNotFinalizedError(log.transactionHash))
+              return
+            }
+          }
+        } catch {
+          // transient RPC error — retry on next poll
+        }
+        // wait before re-checking; exit early on watch abort
+        await signalToPromise(
+          AbortSignal.any([watch, deadline, AbortSignal.timeout(pollIntervalMs)]),
+        ).catch(() => {})
       }
+    })()
+
+    // Race: getLogs watch vs block height deadline
+    try {
+      const combinedWatch = AbortSignal.any([watch, deadline])
+      for await (const l of this.getLogs({
+        address: log.address,
+        startBlock: log.blockNumber - 10,
+        endBlock: finality,
+        topics: [log.topics[0]!],
+        watch: combinedWatch,
+      })) {
+        if (l.transactionHash === log.transactionHash) {
+          return true
+        } else if (l.blockNumber > log.blockNumber) {
+          break
+        }
+      }
+    } catch (err) {
+      // If the deadline signal fired, its reason is already the right error
+      if (deadline.aborted) throw deadline.reason
+      throw err
+    } finally {
+      deadlineAc.abort() // stop the poller if getLogs resolved first
+      await blockHeightPoller // clean up
     }
     throw new CCIPTransactionNotFinalizedError(log.transactionHash)
   }

--- a/ccip-sdk/src/commits.test.ts
+++ b/ccip-sdk/src/commits.test.ts
@@ -37,8 +37,10 @@ class MockChain extends Chain {
     this.mockLogs = logs
   }
 
-  async getBlockTimestamp(_block: number | 'finalized'): Promise<number> {
-    return this.mockBlockTimestamp
+  async getBlockInfo(
+    _block: number | 'finalized' | 'latest',
+  ): Promise<{ number: number; timestamp: number }> {
+    return { number: 1000, timestamp: this.mockBlockTimestamp }
   }
 
   async getTransaction(_hash: string): Promise<ChainTransaction> {

--- a/ccip-sdk/src/evm/index.ts
+++ b/ccip-sdk/src/evm/index.ts
@@ -30,6 +30,7 @@ import { memoize } from 'micro-memoize'
 import type { PickDeep, SetFieldType, SetRequired } from 'type-fest'
 
 import {
+  type BlockInfo,
   type ChainContext,
   type GetBalanceOpts,
   type LogFilter,
@@ -234,17 +235,17 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
     this.provider = provider
     this.abort.addEventListener('abort', () => this.provider.destroy(), { once: true })
 
-    const getBlockTimestamp = memoize(this.getBlockTimestamp.bind(this), {
+    const getBlockInfo = memoize(this.getBlockInfo.bind(this), {
       async: true,
       maxArgs: 1,
       maxSize: 1024,
     })
-    this.getBlockTimestamp = getBlockTimestamp
+    this.getBlockInfo = getBlockInfo
 
     /** ethers doesn't support logs' new `blockTimestamp` property; to workaround having to do
      * another roundtrip for it, we hook in these Provider methods, which have access to the 'raw'
      * payloads of getTransactionReceipts and getLogs, cache the timestamps, and populate from
-     * cached this.getBlockTimestamp inside getTransaction and getEvmLogs */
+     * cached this.getBlockInfo inside getTransaction and getEvmLogs */
     type RawLog = { blockNumber: number | string; blockTimestamp?: string | number }
     this.provider._wrapTransactionReceipt = (
       value: TransactionReceiptParams,
@@ -252,9 +253,12 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
     ): TransactionReceipt => {
       // on provider.getTransactionReceipt, cache logs block timestamp, hidden by ethers
       if (value.logs.length && (value.logs[0] as RawLog).blockTimestamp)
-        getBlockTimestamp.cache.set(
+        getBlockInfo.cache.set(
           [getNumber(value.logs[0]!.blockNumber)],
-          Promise.resolve(getNumber((value.logs[0]! as RawLog).blockTimestamp!)),
+          Promise.resolve({
+            number: getNumber(value.logs[0]!.blockNumber),
+            timestamp: getNumber((value.logs[0]! as RawLog).blockTimestamp!),
+          }),
         )
       return (
         this.provider.constructor as typeof JsonRpcApiProvider
@@ -263,9 +267,12 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
     this.provider._wrapLog = (value: LogParams, network: Network): Log => {
       // on provider.getLogs, cache logs block timestamp, hidden by ethers
       if ((value as RawLog).blockTimestamp)
-        getBlockTimestamp.cache.set(
+        getBlockInfo.cache.set(
           [getNumber(value.blockNumber)],
-          Promise.resolve(getNumber((value as RawLog).blockTimestamp!)),
+          Promise.resolve({
+            number: getNumber(value.blockNumber),
+            timestamp: getNumber((value as RawLog).blockTimestamp!),
+          }),
         )
       return (this.provider.constructor as typeof JsonRpcApiProvider).prototype._wrapLog.call(
         this.provider,
@@ -421,11 +428,11 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
     return this.fromProvider(await this._getProvider(url, ctx?.abort), ctx)
   }
 
-  /** {@inheritDoc Chain.getBlockTimestamp} */
-  async getBlockTimestamp(block: EVMEndBlockTag): Promise<number> {
+  /** {@inheritDoc Chain.getBlockInfo} */
+  async getBlockInfo(block: EVMEndBlockTag): Promise<BlockInfo> {
     const res = await this.provider.getBlock(block) // cached
     if (!res) throw new CCIPBlockNotFoundError(block)
-    return res.timestamp
+    return { number: res.number, timestamp: res.timestamp }
   }
 
   /** {@inheritDoc Chain.getTransaction} */
@@ -435,7 +442,7 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
       throw new CCIPTransactionNotFoundError(hash as string, {
         context: { network: this.network.name },
       })
-    const timestamp = await this.getBlockTimestamp(tx.blockNumber)
+    const { timestamp } = await this.getBlockInfo(tx.blockNumber)
     const chainTx = {
       ...tx,
       timestamp,

--- a/ccip-sdk/src/evm/index.ts
+++ b/ccip-sdk/src/evm/index.ts
@@ -755,6 +755,7 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
       ) as unknown as TypedContract<typeof FeeQuoter_2_0_ABI>
     }
     return {
+      ...(await resultToObject(contract.getStaticConfig())),
       ...(await resultToObject(contract.getDestChainConfig(destChainSelector))),
       typeAndVersion,
     }
@@ -922,10 +923,6 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
           ...csDynamicConfig,
           ...staticConfig,
           ...dynamicConfig,
-          priceRegistryConfig: await this._getFeeQuoterDest(
-            dynamicConfig.priceRegistry,
-            sourceChainSelector,
-          ),
           onRamps: [staticConfig.onRamp],
           typeAndVersion,
         }
@@ -937,26 +934,22 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
           offRampABI,
           this.provider,
         ) as unknown as TypedContract<typeof OffRamp_1_6_ABI>
-        const [staticConfig, dynamicConfig, sourceChainConfig] = await Promise.all([
+        const [staticConfig, dynamicConfig, { onRamp, ...sourceChainConfig }] = await Promise.all([
           resultToObject(contract.getStaticConfig()),
           resultToObject(contract.getDynamicConfig()),
           resultToObject(contract.getSourceChainConfig(sourceChainSelector)),
         ])
         const onRamps = []
         try {
-          onRamps.push(decodeOnRampAddress(sourceChainConfig.onRamp, sourceFamily))
+          onRamps.push(decodeOnRampAddress(onRamp, sourceFamily))
         } catch {
           // ignore
         }
         return {
+          sourceChainSelector,
           ...staticConfig,
           ...dynamicConfig,
-          sourceChainSelector,
           ...sourceChainConfig,
-          feeQuoterConfig: await this._getFeeQuoterDest(
-            dynamicConfig.feeQuoter,
-            sourceChainSelector,
-          ),
           onRamps,
           typeAndVersion,
         }

--- a/ccip-sdk/src/evm/logs.ts
+++ b/ccip-sdk/src/evm/logs.ts
@@ -42,7 +42,7 @@ export async function* getEvmLogs(
   filter: SetFieldType<LogFilter, 'endBlock', EVMEndBlockTag>,
   ctx: {
     provider: JsonRpcApiProvider
-    getBlockTimestamp: (block: EVMEndBlockTag) => Promise<number>
+    getBlockInfo: (block: EVMEndBlockTag) => Promise<{ number: number; timestamp: number }>
     abort?: AbortSignal
   } & WithLogger,
 ): AsyncIterableIterator<Log & { blockTimestamp: number }> {
@@ -72,7 +72,7 @@ export async function* getEvmLogs(
   filter.endBlock ||= 'latest'
   const { number: endBlock } = (await provider.getBlock(filter.endBlock))!
   filter.startBlock ??= await getSomeBlockNumberBefore(
-    (block: number) => ctx.getBlockTimestamp(block), // cached
+    async (block: number) => (await ctx.getBlockInfo(block)).timestamp,
     endBlock,
     filter.startTime!,
     ctx,
@@ -95,7 +95,7 @@ export async function* getEvmLogs(
       latestLogBlockNumber = Math.max(latestLogBlockNumber, logs[logs.length - 1]!.blockNumber)
     const logs_ = await Promise.all(
       logs.map(async (l) =>
-        Object.assign(l, { blockTimestamp: await ctx.getBlockTimestamp(l.blockNumber) }),
+        Object.assign(l, { blockTimestamp: (await ctx.getBlockInfo(l.blockNumber)).timestamp }),
       ),
     )
     yield* logs_
@@ -120,7 +120,7 @@ export async function* getEvmLogs(
       latestLogBlockNumber = Math.max(latestLogBlockNumber, logs[logs.length - 1]!.blockNumber)
     const logs_ = await Promise.all(
       logs.map(async (l) =>
-        Object.assign(l, { blockTimestamp: await ctx.getBlockTimestamp(l.blockNumber) }),
+        Object.assign(l, { blockTimestamp: (await ctx.getBlockInfo(l.blockNumber)).timestamp }),
       ),
     )
     yield* logs_

--- a/ccip-sdk/src/execution.test.ts
+++ b/ccip-sdk/src/execution.test.ts
@@ -54,8 +54,14 @@ class MockChain extends Chain {
     this.mockOnRampForOffRamp.set(offRamp, onRamp)
   }
 
-  async getBlockTimestamp(_block: number | 'finalized'): Promise<number> {
-    return this.mockBlockTimestamp
+  override async getBlockTimestamp(block: number | 'finalized'): Promise<number> {
+    return (await this.getBlockInfo(block)).timestamp
+  }
+
+  async getBlockInfo(
+    _block: number | 'finalized' | 'latest',
+  ): Promise<{ number: number; timestamp: number }> {
+    return { number: 1000, timestamp: this.mockBlockTimestamp }
   }
 
   async getTransaction(_hash: string): Promise<ChainTransaction> {

--- a/ccip-sdk/src/logs.test.ts
+++ b/ccip-sdk/src/logs.test.ts
@@ -36,7 +36,10 @@ describe('logs start position validation', () => {
             {},
             {
               provider: {} as JsonRpcApiProvider,
-              getBlockTimestamp: async () => Math.floor(Date.now() / 1000),
+              getBlockInfo: async () => ({
+                number: 1000,
+                timestamp: Math.floor(Date.now() / 1000),
+              }),
             },
           ),
         ),
@@ -114,7 +117,7 @@ describe('EVM logs block tags', () => {
         {
           provider,
           logger: silentLogger,
-          getBlockTimestamp: async (block) => (await getBlock(block)).timestamp,
+          getBlockInfo: (block) => getBlock(block),
         },
       ),
     )

--- a/ccip-sdk/src/requests.ts
+++ b/ccip-sdk/src/requests.ts
@@ -1,5 +1,6 @@
+import type { PublicKey } from '@solana/web3.js'
 import type BN from 'bn.js'
-import { type BytesLike, hexlify, isBytesLike, toBigInt } from 'ethers'
+import { type Addressable, type BytesLike, hexlify, isBytesLike, toBigInt } from 'ethers'
 import type { PickDeep } from 'type-fest'
 
 import type { Chain, ChainStatic, LogFilter } from './chain.ts'
@@ -35,37 +36,51 @@ import {
   parseJson,
 } from './utils.ts'
 
+type Normalized<T> = T extends PublicKey | Addressable
+  ? string
+  : T extends BN
+    ? bigint
+    : T extends Array<infer U>
+      ? Array<Normalized<U>>
+      : T extends ReadonlyArray<infer U>
+        ? ReadonlyArray<Normalized<U>>
+        : T extends Record<string, unknown>
+          ? { [K in keyof T]: Normalized<T[K]> }
+          : T extends Readonly<Record<string, unknown>>
+            ? { readonly [K in keyof T]: Normalized<T[K]> }
+            : T
+
 /** Convert recursively a message or config record into normalized values */
 export function normalizeDeep<T extends Record<string, unknown>>(
   data: T,
   opts: { sourceFamily?: ChainFamily; destFamily?: ChainFamily } = {},
-): T {
-  return convertKeysToCamelCase(data, (v, k) =>
-    k === 'chainFamilySelector'
-      ? hexlify(getDataBytes(v as number[]))
-      : k?.match(/(selector|amount|nonce|number|limit|bitmap|juels|value)$/i)
-        ? toBigInt(
-            Array.isArray(v) ? getDataBytes(v) : (v as string | number | bigint | BN).toString(),
-          )
-        : k?.match(/(^dest.*address)|(receiver|offramp|accounts)/i)
-          ? v == null && k === 'destAddress'
-            ? v
-            : decodeAddress(
-                (typeof v === 'bigint' ? v.toString() : v) as BytesLike,
-                opts.destFamily,
-              )
-          : k?.match(
-                /((source.*address)|sender|issuer|origin|onramp|(feetoken$)|(token.*address$))/i,
-              )
-            ? decodeAddress(
-                (typeof v === 'bigint' ? v.toString() : v) as BytesLike,
-                opts.sourceFamily,
-              )
-            : v instanceof Uint8Array ||
-                (Array.isArray(v) && v.length >= 4 && v.every((e) => typeof e === 'number'))
-              ? hexlify(getDataBytes(v))
-              : v,
-  ) as T
+): Normalized<T> {
+  return convertKeysToCamelCase(data, (v, k) => {
+    if (k === 'chainFamilySelector') return hexlify(getDataBytes(v as number[]))
+    if ((v as { _bn?: unknown } | undefined)?._bn) return (v as PublicKey).toString()
+    if (
+      k?.match(/(selector|amount|nonce|number|limit|bitmap|juels|value)$/i) ||
+      (v as { words?: unknown } | undefined)?.words
+    )
+      return toBigInt(
+        Array.isArray(v) ? getDataBytes(v) : (v as string | number | bigint | BN).toString(),
+      )
+    if (k?.match(/(^dest.*address)|(receiver|offramp|accounts)/i))
+      return (
+        v && decodeAddress((typeof v === 'bigint' ? v.toString() : v) as BytesLike, opts.destFamily)
+      )
+    if (k?.match(/((source.*address)|sender|issuer|origin|onramp|(feetoken$)|(token.*address$))/i))
+      return decodeAddress(
+        (typeof v === 'bigint' ? v.toString() : v) as BytesLike,
+        opts.sourceFamily,
+      )
+    if (
+      v instanceof Uint8Array ||
+      (Array.isArray(v) && v.length >= 4 && v.every((e) => typeof e === 'number'))
+    )
+      return hexlify(getDataBytes(v))
+    return v
+  }) as Normalized<T>
 }
 
 function decodeJsonMessage(data: Record<string, unknown> | undefined) {

--- a/ccip-sdk/src/requests.ts
+++ b/ccip-sdk/src/requests.ts
@@ -13,6 +13,7 @@ import {
   CCIPMessageInvalidError,
   CCIPMessageNotFoundInTxError,
   CCIPTokenNotInRegistryError,
+  CCIPTransactionNotFinalizedError,
 } from './errors/index.ts'
 import type { EVMChain } from './evm/index.ts'
 import { decodeExtraArgs, decodeFinalityRequested } from './extra-args.ts'
@@ -34,6 +35,7 @@ import {
   getDataBytes,
   leToBigInt,
   parseJson,
+  signalToPromise,
 } from './utils.ts'
 
 type Normalized<T> = T extends PublicKey | Addressable
@@ -591,4 +593,120 @@ export async function sourceToDestTokenAddresses<S extends { token: string }>({
     sourceTokenAddress,
     destTokenAddress: remotes[networkInfo(destChainSelector).name]!.remoteToken,
   }
+}
+
+/**
+ * Confirm a log tx is finalized or wait for it to be finalized.
+ *
+ * @param chain - Chain instance to check finality on
+ * @param opts - Options containing the request, finality level, and optional cancel promise
+ * @returns Some block info at or after tx finalization
+ *
+ * @throws {@link CCIPTransactionNotFinalizedError} if the transaction is not included (e.g., due to a reorg)
+ *
+ * @example Wait for message finality
+ * ```typescript
+ * const request = await source.getMessagesInTx(txHash)
+ * try {
+ *   await waitFinalized(chain, { request: request[0] })
+ *   console.log('Transaction finalized')
+ * } catch (err) {
+ *   if (err instanceof CCIPTransactionNotFinalizedError) {
+ *     console.log('Transaction not yet finalized')
+ *   }
+ * }
+ * ```
+ */
+export async function waitFinalized<C extends Chain>(
+  chain: C,
+  {
+    request: { log },
+    finality = 'finalized',
+    abort,
+    reorgSafetyBlocks = 10,
+    pollIntervalMs = 5_000,
+  }: {
+    request: PickDeep<
+      CCIPRequest,
+      `log.${'address' | 'blockNumber' | 'transactionHash' | 'topics' | 'blockTimestamp'}`
+    >
+    finality?: Parameters<Chain['getBlockInfo']>[0]
+    abort?: AbortSignal
+    /** How many blocks past the original tx blockNumber must be finalized
+     *  without the tx reappearing before we declare it reorged out. Default: 10 */
+    reorgSafetyBlocks?: number
+    /** Delay in ms between block-height poller iterations. Default: 5000 */
+    pollIntervalMs?: number
+  },
+): ReturnType<Chain['getBlockInfo']> {
+  // Fast-path: if the log is old enough, check tx timestamp vs finalized timestamp
+  if (!log.blockTimestamp || Date.now() / 1e3 - log.blockTimestamp > 60) {
+    const [tx, finalized, latest] = await Promise.all([
+      chain.getTransaction(log.transactionHash),
+      chain.getBlockInfo(finality),
+      chain.getBlockInfo('latest'),
+    ])
+    if (tx.timestamp <= finalized.timestamp) return latest
+  }
+  const watch = abort ? AbortSignal.any([chain.abort, abort]) : chain.abort
+
+  // Block-height deadline: poll finalized block height and abort if tx is gone
+  const deadlineAc = new AbortController()
+  const deadline = deadlineAc.signal
+  let txBlockNumber = log.blockNumber
+  const blockHeightPoller = (async () => {
+    while (!watch.aborted && !deadline.aborted) {
+      try {
+        const info = await chain.getBlockInfo(finality)
+        if (info.number >= txBlockNumber + reorgSafetyBlocks) {
+          // Deadline reached — but the tx may have been reorged to a later block.
+          // Re-fetch the tx: if it's still present, update blockNumber and keep going.
+          try {
+            const tx = await chain.getTransaction(log.transactionHash)
+            if (tx.blockNumber !== txBlockNumber) {
+              txBlockNumber = tx.blockNumber
+            }
+            // tx still present — fall through to the delay and re-evaluate;
+            // if it's genuinely finalized, the concurrent getLogs loop will match it
+          } catch {
+            // tx not found — definitively reorged out
+            deadlineAc.abort(new CCIPTransactionNotFinalizedError(log.transactionHash))
+            return
+          }
+        }
+      } catch {
+        // transient RPC error — retry on next poll
+      }
+      // wait before re-checking; exit early on watch abort
+      await signalToPromise(
+        AbortSignal.any([watch, deadline, AbortSignal.timeout(pollIntervalMs)]),
+      ).catch(() => {})
+    }
+  })()
+
+  // Race: getLogs watch vs block height deadline
+  const combinedWatch = AbortSignal.any([watch, deadline])
+  try {
+    for await (const l of chain.getLogs({
+      address: log.address,
+      startBlock: log.blockNumber - 10,
+      endBlock: finality,
+      topics: [log.topics[0]!],
+      watch: combinedWatch,
+    })) {
+      if (l.transactionHash === log.transactionHash) {
+        return chain.getBlockInfo('latest')
+      } else if (l.blockNumber > txBlockNumber) {
+        break
+      }
+    }
+  } catch (err) {
+    // If the deadline signal fired, its reason is already the right error
+    if (deadline.aborted) throw deadline.reason
+    throw err
+  } finally {
+    deadlineAc.abort() // stop the poller if getLogs resolved first
+    await blockHeightPoller // clean up
+  }
+  throw new CCIPTransactionNotFinalizedError(log.transactionHash)
 }

--- a/ccip-sdk/src/requests.ts
+++ b/ccip-sdk/src/requests.ts
@@ -655,25 +655,34 @@ export async function waitFinalized<C extends Chain>(
   const deadline = deadlineAc.signal
   let txBlockNumber = log.blockNumber
   const blockHeightPoller = (async () => {
+    let firstFinalized
     while (!watch.aborted && !deadline.aborted) {
       try {
         const info = await chain.getBlockInfo(finality)
         if (info.number >= txBlockNumber) {
-          // Deadline reached — but the tx may have been reorged to a later block.
+          firstFinalized ??= info.number
+          // OG txBlock finalized — but the tx may have been reorged to a later block.
           // Re-fetch the tx: if it's still present, update blockNumber and keep going.
           try {
             const tx = await chain.getTransaction(log.transactionHash)
-            if (tx.blockNumber !== txBlockNumber) {
-              txBlockNumber = tx.blockNumber
-            }
+            if (tx.blockNumber !== txBlockNumber) txBlockNumber = tx.blockNumber
             // tx still present — fall through to the delay and re-evaluate;
             // if it's genuinely finalized, the concurrent getLogs loop will match it
           } catch {
-            if (info.number >= txBlockNumber + reorgSafetyBlocks) {
-              // tx not found — definitively reorged out
+            if (info.number > Math.max(firstFinalized, txBlockNumber + reorgSafetyBlocks - 1)) {
+              // some block after the original tx block has been finalized without the tx reappearing — very likely reorged out
               deadlineAc.abort(new CCIPTransactionNotFinalizedError(log.transactionHash))
               return
             }
+            chain.logger.debug(`waitFinalized: tx not found`, {
+              network: chain.network.name,
+              txHash: log.transactionHash,
+              finality,
+              finalizedBlock: info,
+              firstFinalized,
+              txBlockNumber,
+              reorgSafetyBlocks,
+            })
           }
         }
       } catch {

--- a/ccip-sdk/src/requests.ts
+++ b/ccip-sdk/src/requests.ts
@@ -658,7 +658,7 @@ export async function waitFinalized<C extends Chain>(
     while (!watch.aborted && !deadline.aborted) {
       try {
         const info = await chain.getBlockInfo(finality)
-        if (info.number >= txBlockNumber + reorgSafetyBlocks) {
+        if (info.number >= txBlockNumber) {
           // Deadline reached — but the tx may have been reorged to a later block.
           // Re-fetch the tx: if it's still present, update blockNumber and keep going.
           try {
@@ -669,9 +669,11 @@ export async function waitFinalized<C extends Chain>(
             // tx still present — fall through to the delay and re-evaluate;
             // if it's genuinely finalized, the concurrent getLogs loop will match it
           } catch {
-            // tx not found — definitively reorged out
-            deadlineAc.abort(new CCIPTransactionNotFinalizedError(log.transactionHash))
-            return
+            if (info.number >= txBlockNumber + reorgSafetyBlocks) {
+              // tx not found — definitively reorged out
+              deadlineAc.abort(new CCIPTransactionNotFinalizedError(log.transactionHash))
+              return
+            }
           }
         }
       } catch {

--- a/ccip-sdk/src/solana/index.ts
+++ b/ccip-sdk/src/solana/index.ts
@@ -32,6 +32,7 @@ import { type Memoized, memoize } from 'micro-memoize'
 import type { PickDeep } from 'type-fest'
 
 import {
+  type BlockInfo,
   type ChainContext,
   type ChainStatic,
   type GetBalanceOpts,
@@ -261,7 +262,7 @@ export class SolanaChain extends Chain<typeof ChainFamily.Solana> {
       maxArgs: 1,
       maxSize: 100,
     })
-    this.getBlockTimestamp = memoize(this.getBlockTimestamp.bind(this), {
+    this.getBlockInfo = memoize(this.getBlockInfo.bind(this), {
       async: true,
       maxSize: 1024,
       forceUpdate: ([k]) => typeof k !== 'number' || k <= 0,
@@ -393,17 +394,17 @@ export class SolanaChain extends Chain<typeof ChainFamily.Solana> {
 
   // cached
   /**
-   * {@inheritDoc Chain.getBlockTimestamp}
+   * {@inheritDoc Chain.getBlockInfo}
    * @throws {@link CCIPBlockTimeNotFoundError} if block time cannot be retrieved
    */
-  async getBlockTimestamp(block: number | 'latest' | 'finalized'): Promise<number> {
+  async getBlockInfo(block: number | 'latest' | 'finalized'): Promise<BlockInfo> {
     if (typeof block !== 'number') {
       const slot = await this.connection.getSlot(block === 'latest' ? 'confirmed' : block)
       const blockTime = await this.connection.getBlockTime(slot)
       if (blockTime === null) {
         throw new CCIPBlockTimeNotFoundError(`finalized slot ${slot}`)
       }
-      return blockTime
+      return { number: slot, timestamp: blockTime }
     } else if (block <= 0) {
       block = (await this.connection.getSlot('confirmed')) + block
     }
@@ -412,7 +413,7 @@ export class SolanaChain extends Chain<typeof ChainFamily.Solana> {
     if (blockTime === null) {
       throw new CCIPBlockTimeNotFoundError(block)
     }
-    return blockTime
+    return { number: block, timestamp: blockTime }
   }
 
   /**
@@ -426,11 +427,12 @@ export class SolanaChain extends Chain<typeof ChainFamily.Solana> {
     })
     if (!tx) throw new CCIPTransactionNotFoundError(hash)
     if (tx.blockTime) {
-      ;(
-        this.getBlockTimestamp as Memoized<typeof this.getBlockTimestamp, { async: true }>
-      ).cache.set([tx.slot], Promise.resolve(tx.blockTime))
+      ;(this.getBlockInfo as Memoized<typeof this.getBlockInfo, { async: true }>).cache.set(
+        [tx.slot],
+        Promise.resolve({ number: tx.slot, timestamp: tx.blockTime }),
+      )
     } else {
-      tx.blockTime = await this.getBlockTimestamp(tx.slot)
+      tx.blockTime = (await this.getBlockInfo(tx.slot)).timestamp
     }
 
     // Parse logs from transaction using helper function

--- a/ccip-sdk/src/solana/index.ts
+++ b/ccip-sdk/src/solana/index.ts
@@ -13,7 +13,6 @@ import {
   SYSVAR_CLOCK_PUBKEY,
   SystemProgram,
 } from '@solana/web3.js'
-import BN from 'bn.js'
 import bs58 from 'bs58'
 import {
   type BytesLike,
@@ -143,6 +142,7 @@ const TOKEN_POOL_IDL = {
   events: BASE_TOKEN_POOL.events,
   errors: [...BASE_TOKEN_POOL.errors, ...BURN_MINT_TOKEN_POOL.errors],
 }
+
 const tokenPoolCoder = new BorshCoder(TOKEN_POOL_IDL)
 const CCTP_TOKEN_POOL_IDL = {
   ...CCIP_CCTP_TOKEN_POOL,
@@ -174,40 +174,6 @@ export type SolanaTransaction = MergeArrayElements<
     logs: readonly SolanaLog[]
   }
 >
-
-type NormalizedPda<T> = T extends PublicKey
-  ? string
-  : T extends BN
-    ? bigint
-    : T extends Array<infer U>
-      ? Array<NormalizedPda<U>>
-      : T extends Record<string, unknown>
-        ? { [K in keyof T]: NormalizedPda<T[K]> }
-        : T
-
-function normalizePda<O extends Record<string, unknown>>(obj: O): NormalizedPda<O> {
-  const result: Record<string, unknown> = {}
-  for (const [k, v] of Object.entries(obj)) {
-    if (v instanceof PublicKey) {
-      result[k] = v.toString()
-    } else if (BN.isBN(v)) {
-      result[k] = BigInt(v.toString())
-    } else if (Array.isArray(v)) {
-      result[k] = v.map((item) =>
-        item instanceof PublicKey
-          ? item.toString()
-          : item !== null && typeof item === 'object'
-            ? normalizePda(item as Record<string, unknown>)
-            : (item as O),
-      )
-    } else if (v !== null && typeof v === 'object') {
-      result[k] = normalizePda(v as Record<string, unknown>)
-    } else {
-      result[k] = v
-    }
-  }
-  return result as NormalizedPda<O>
-}
 
 /**
  * Solana chain implementation supporting Solana networks.
@@ -608,12 +574,34 @@ export class SolanaChain extends Chain<typeof ChainFamily.Solana> {
     )
     const destChainState = await program.account.destChain.fetch(destChainStatePda)
 
-    return normalizePda({
-      ...routerConfig,
-      ...destChainState.config,
-      router: onRamp,
-      typeAndVersion,
+    const feeQuoter = new Program(FEE_QUOTER_IDL, routerConfig.feeQuoter, {
+      connection: this.connection,
     })
+    const [feeQuoterConfigAddress] = PublicKey.findProgramAddressSync(
+      [Buffer.from('config')],
+      routerConfig.feeQuoter,
+    )
+    const [feeQuoterDestAddress] = PublicKey.findProgramAddressSync(
+      [Buffer.from('dest_chain'), toLeArray(destChainSelector, 8)],
+      routerConfig.feeQuoter,
+    )
+    const [feeQuoterConfig, feeQuoterDestConfig] = await Promise.all([
+      feeQuoter.account.config.fetch(feeQuoterConfigAddress),
+      feeQuoter.account.destChain.fetch(feeQuoterDestAddress),
+    ])
+    return normalizeDeep(
+      {
+        ...routerConfig,
+        ...destChainState.config,
+        feeQuoterConfig: { ...feeQuoterConfig, ...feeQuoterDestConfig },
+        router: onRamp,
+        typeAndVersion,
+      },
+      {
+        sourceFamily: (this.constructor as typeof SolanaChain).family,
+        destFamily: networkInfo(destChainSelector).family,
+      },
+    )
   }
 
   /**
@@ -645,25 +633,19 @@ export class SolanaChain extends Chain<typeof ChainFamily.Solana> {
       networkInfo(sourceChainSelector).family,
     )
 
-    const [feeQuoterDestChainStateAccountAddress] = PublicKey.findProgramAddressSync(
-      [Buffer.from('dest_chain'), toLeArray(sourceChainSelector, 8)],
-      refAddresses.feeQuoter,
+    return normalizeDeep(
+      {
+        ...refAddresses,
+        ...sourceConfig,
+        ...state,
+        onRamps: [onRamp],
+        typeAndVersion,
+      },
+      {
+        sourceFamily: networkInfo(sourceChainSelector).family,
+        destFamily: (this.constructor as typeof SolanaChain).family,
+      },
     )
-    const feeQuoter = new Program(FEE_QUOTER_IDL, refAddresses.feeQuoter, {
-      connection: this.connection,
-    })
-    const destChainState = await feeQuoter.account.destChain.fetch(
-      feeQuoterDestChainStateAccountAddress,
-    )
-
-    return normalizePda({
-      ...refAddresses,
-      ...sourceConfig,
-      ...state,
-      feeQuoterState: normalizeDeep(destChainState),
-      onRamps: [onRamp],
-      typeAndVersion,
-    })
   }
 
   /** {@inheritDoc Chain.getNativeTokenForRouter} */
@@ -689,6 +671,7 @@ export class SolanaChain extends Chain<typeof ChainFamily.Solana> {
       programs: true,
       address: feeQuoterDestChainStateAccountAddress.toBase58(),
       startBlock: 0, // use getLogs special-case to do a single getSignaturesForAddress pass
+      endBlock: 'finalized',
       topics: ['ExecutionStateChanged', 'CommitReportAccepted', 'Transmitted'],
     })) {
       return [log.address] // assume single offramp per router/deployment on Solana
@@ -1111,7 +1094,8 @@ export class SolanaChain extends Chain<typeof ChainFamily.Solana> {
    * @param bytes - Bytes to convert.
    * @returns Base58-encoded Solana address.
    */
-  static getAddress(bytes: BytesLike): string {
+  static getAddress(bytes: BytesLike | PublicKey): string {
+    if (bytes instanceof PublicKey) return bytes.toBase58()
     try {
       if (typeof bytes === 'string' && bs58.decode(bytes).length === 32) return bytes
     } catch (_) {

--- a/ccip-sdk/src/sui/index.ts
+++ b/ccip-sdk/src/sui/index.ts
@@ -8,6 +8,7 @@ import { type BytesLike, dataLength, hexlify, isBytesLike, isHexString } from 'e
 import type { SetOptional } from 'type-fest'
 
 import {
+  type BlockInfo,
   type ChainContext,
   type ChainStatic,
   type GetBalanceOpts,
@@ -158,13 +159,19 @@ export class SuiChain extends Chain<typeof ChainFamily.Sui> {
     return Object.assign(chain, { url })
   }
 
-  /** {@inheritDoc Chain.getBlockTimestamp} */
-  async getBlockTimestamp(block: number | 'finalized'): Promise<number> {
-    if (typeof block !== 'number' || block <= 0) return Math.floor(Date.now() / 1000)
+  /** {@inheritDoc Chain.getBlockInfo} */
+  async getBlockInfo(block: number | 'finalized' | 'latest'): Promise<BlockInfo> {
+    if (typeof block !== 'number' || block <= 0) {
+      const now = Math.floor(Date.now() / 1000)
+      return { number: now, timestamp: now }
+    }
     const checkpoint = await this.client.getCheckpoint({
       id: String(block),
     })
-    return Number(checkpoint.timestampMs) / 1000
+    return {
+      number: Number(checkpoint.sequenceNumber),
+      timestamp: Number(checkpoint.timestampMs) / 1000,
+    }
   }
 
   /** {@inheritDoc Chain.getTransaction} */

--- a/ccip-sdk/src/ton/index.ts
+++ b/ccip-sdk/src/ton/index.ts
@@ -9,6 +9,7 @@ import { type Memoized, memoize } from 'micro-memoize'
 import { streamTransactionsForAddress } from './logs.ts'
 import { generateUnsignedCcipSend, getFee as getFeeImpl } from './send.ts'
 import {
+  type BlockInfo,
   type ChainContext,
   type ChainStatic,
   type GetBalanceOpts,
@@ -157,7 +158,7 @@ export class TONChain extends Chain<typeof ChainFamily.TON> {
       maxSize: 100,
     })
 
-    this.getBlockTimestamp = memoize(this.getBlockTimestamp.bind(this), {
+    this.getBlockInfo = memoize(this.getBlockInfo.bind(this), {
       async: true,
       maxArgs: 1,
       maxSize: 100,
@@ -216,6 +217,10 @@ export class TONChain extends Chain<typeof ChainFamily.TON> {
 
     let fetchFn: typeof fetch | undefined
     let httpAdapter: AxiosAdapter | undefined
+    // For known public providers, detect network from URL to avoid an API call during init
+    // (free-tier endpoints are rate-limited and return transient 5xx errors).
+    let isMainnetHint: boolean | undefined
+
     if (['toncenter.com', 'tonapi.io'].some((d) => url.includes(d))) {
       logger.warn(
         'Public TONCenter API calls are rate-limited to ~1 req/sec, some commands may be slow',
@@ -224,6 +229,8 @@ export class TONChain extends Chain<typeof ChainFamily.TON> {
       httpAdapter = (getAdapter as (name: string, config: object) => AxiosAdapter)('fetch', {
         env: { fetch: fetchFn },
       })
+      // testnet.toncenter.com / testnet.tonapi.io → testnet; bare domain → mainnet
+      isMainnetHint = !url.includes('testnet.')
     }
 
     // Wrap the adapter (or the default 'http' adapter) so that every TonClient axios
@@ -242,10 +249,13 @@ export class TONChain extends Chain<typeof ChainFamily.TON> {
 
     const client = new TonClient({ endpoint: url, httpAdapter })
     try {
-      const chain = await this.fromClient(client, {
-        ...ctx,
-        fetchFn,
-      })
+      const chain =
+        isMainnetHint !== undefined
+          ? new TONChain(client, networkInfo(isMainnetHint ? 'ton-mainnet' : 'ton-testnet'), {
+              ...ctx,
+              fetchFn,
+            })
+          : await this.fromClient(client, { ...ctx, fetchFn })
       logger.debug(`Connected to TON V2 endpoint: ${url}`)
       return chain
     } catch (error) {
@@ -265,15 +275,16 @@ export class TONChain extends Chain<typeof ChainFamily.TON> {
    * @returns Unix timestamp in seconds
    * @throws {@link CCIPNotImplementedError} if lt is not in cache
    */
-  async getBlockTimestamp(block: number | 'finalized'): Promise<number> {
+  async getBlockInfo(block: number | 'finalized' | 'latest'): Promise<BlockInfo> {
     if (typeof block != 'number') {
-      return Promise.resolve(Math.floor(Date.now() / 1000))
+      const now = Math.floor(Date.now() / 1000)
+      return { number: now, timestamp: now }
     }
 
     // For TON, we cannot look up timestamp by lt alone without the account address.
     // The lt must have been cached during a previous getLogs or getTransaction call.
     throw new CCIPNotImplementedError(
-      `getBlockTimestamp: lt ${block} not in cache. ` +
+      `getBlockInfo: lt ${block} not in cache. ` +
         `TON requires lt to be cached from getLogs or getTransaction calls first.`,
     )
   }
@@ -336,10 +347,10 @@ export class TONChain extends Chain<typeof ChainFamily.TON> {
       address = new Address(0, Buffer.from(toBeArray(tx.address, 32)))
     }
 
-    // Cache lt → timestamp for later getBlockTimestamp lookups
-    ;(this.getBlockTimestamp as Memoized<typeof this.getBlockTimestamp, { async: true }>).cache.set(
+    // Cache lt → timestamp for later getBlockInfo lookups
+    ;(this.getBlockInfo as Memoized<typeof this.getBlockInfo, { async: true }>).cache.set(
       [Number(tx.lt)],
-      Promise.resolve(tx.now),
+      Promise.resolve({ number: Number(tx.lt), timestamp: tx.now }),
     )
 
     // Extract logs from outgoing external messages
@@ -479,6 +490,50 @@ export class TONChain extends Chain<typeof ChainFamily.TON> {
     const sequenceNumber = BigInt(destStack.readBigNumber().toString())
     const allowlistEnabled = destStack.readBoolean()
 
+    const feeQuoterAddress = Address.parse(feeQuoter)
+    const [{ stack: fqStaticStack }, { stack: fqDestStack }] = await Promise.all([
+      this.provider.runMethod(feeQuoterAddress, 'staticConfig', []),
+      this.provider.runMethod(feeQuoterAddress, 'destChainConfig', [
+        { type: 'int', value: destChainSelector },
+      ]),
+    ])
+
+    // FeeQuoter staticConfig() -> maxFeeJuelsPerMsg: uint96, linkToken: address, tokenPriceStalenessThreshold: uint32
+    const maxFeeJuelsPerMsg = fqStaticStack.readBigNumber()
+    const linkToken = fqStaticStack.readAddress().toString()
+    const tokenPriceStalenessThreshold = fqStaticStack.readNumber()
+
+    // FeeQuoter destChainConfig() -> 18 FeeQuoterDestChainConfig scalar fields, then usdPerUnitGas cell
+    const destChainConfig = {
+      isEnabled: fqDestStack.readBoolean(),
+      maxNumberOfTokensPerMsg: fqDestStack.readNumber(),
+      maxDataBytes: fqDestStack.readNumber(),
+      maxPerMsgGasLimit: fqDestStack.readNumber(),
+      destGasOverhead: fqDestStack.readNumber(),
+      destGasPerPayloadByteBase: fqDestStack.readNumber(),
+      destGasPerPayloadByteHigh: fqDestStack.readNumber(),
+      destGasPerPayloadByteThreshold: fqDestStack.readNumber(),
+      destDataAvailabilityOverheadGas: fqDestStack.readNumber(),
+      destGasPerDataAvailabilityByte: fqDestStack.readNumber(),
+      destDataAvailabilityMultiplierBps: fqDestStack.readNumber(),
+      chainFamilySelector: fqDestStack.readNumber(),
+      defaultTokenFeeUsdCents: fqDestStack.readNumber(),
+      defaultTokenDestGasOverhead: fqDestStack.readNumber(),
+      defaultTxGasLimit: fqDestStack.readNumber(),
+      gasMultiplierWeiPerEth: fqDestStack.readBigNumber(),
+      gasPriceStalenessThreshold: fqDestStack.readNumber(),
+      networkFeeUsdCents: fqDestStack.readNumber(),
+    }
+
+    // usdPerUnitGas is a cell ref following the 18 scalar fields (GasPrice struct)
+    const usdPerUnitGasCell = fqDestStack.readCell()
+    const gasSlice = usdPerUnitGasCell.beginParse()
+    const usdPerUnitGas = {
+      executionGasPrice: gasSlice.loadUintBig(112),
+      dataAvailabilityGasPrice: gasSlice.loadUintBig(112),
+      timestamp: gasSlice.loadUintBig(64),
+    }
+
     return {
       chainSelector,
       feeQuoter,
@@ -489,6 +544,13 @@ export class TONChain extends Chain<typeof ChainFamily.TON> {
       sequenceNumber,
       allowlistEnabled,
       typeAndVersion,
+      feeQuoterConfig: {
+        maxFeeJuelsPerMsg,
+        linkToken,
+        tokenPriceStalenessThreshold,
+        usdPerUnitGas,
+        ...destChainConfig,
+      },
     }
   }
 

--- a/ccip-sdk/src/utils.ts
+++ b/ccip-sdk/src/utils.ts
@@ -23,7 +23,7 @@ import {
   CCIPHttpError,
   CCIPTimeoutError,
   CCIPTypeVersionInvalidError,
-  HttpStatus,
+  isTransientHttpStatus,
 } from './errors/index.ts'
 import { getRetryDelay, shouldRetry } from './errors/utils.ts'
 import { ChainFamily } from './networks.ts'
@@ -693,10 +693,9 @@ export function createRateLimitedFetch(
     return input.hostname
   }
 
-  const isRateLimitError = (error: unknown): boolean => {
-    if (error instanceof Error) {
-      return !!error.message.match(/\b(429\b|rate.?limit)/i)
-    }
+  const isRetryableError = (error: unknown): boolean => {
+    if (error instanceof CCIPHttpError) return error.isTransient === true
+    if (error instanceof Error) return !!error.message.match(/\b(429\b|rate.?limit)/i)
     return false
   }
 
@@ -739,8 +738,8 @@ export function createRateLimitedFetch(
           return response
         }
 
-        // For rate limit responses, throw an error to trigger retry
-        if (response.status === HttpStatus.TOO_MANY_REQUESTS) {
+        // For transient responses (429, 5xx), throw to trigger retry
+        if (isTransientHttpStatus(response.status)) {
           throw new CCIPHttpError(response.status, response.statusText)
         }
 
@@ -751,8 +750,8 @@ export function createRateLimitedFetch(
         logger.debug('fetch errored', attempt, error, input, init?.body)
         lastError = error instanceof Error ? error : CCIPError.from(error, 'HTTP_ERROR')
 
-        // Only retry on rate limit errors
-        if (!isRateLimitError(lastError)) {
+        // Only retry on transient errors (429, 5xx, network errors matching rate-limit pattern)
+        if (!isRetryableError(lastError)) {
           throw lastError
         }
 

--- a/ccip-sdk/src/waitFinalized.test.ts
+++ b/ccip-sdk/src/waitFinalized.test.ts
@@ -1,0 +1,421 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import type { PickDeep } from 'type-fest'
+
+import { type BlockInfo, type LogFilter, Chain } from './chain.ts'
+import { CCIPTransactionNotFinalizedError, CCIPTransactionNotFoundError } from './errors/index.ts'
+import { ChainFamily, networkInfo } from './networks.ts'
+import type { CCIPRequest, ChainLog, ChainTransaction } from './types.ts'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Minimal log fixture for waitFinalized */
+function makeLog(overrides: Partial<ChainLog> = {}): ChainLog {
+  return {
+    address: '0xOnRamp',
+    blockNumber: 100,
+    blockTimestamp: Math.floor(Date.now() / 1e3), // "just happened"
+    transactionHash: '0xTxHash',
+    topics: ['0xTopic0'],
+    index: 0,
+    data: '0x',
+    ...overrides,
+  }
+}
+
+/** Wrap a log into the shape expected by waitFinalized */
+function makeRequest(
+  log: ChainLog,
+): PickDeep<
+  CCIPRequest,
+  `log.${'address' | 'blockNumber' | 'transactionHash' | 'topics' | 'blockTimestamp'}`
+> {
+  return { log }
+}
+
+// ---------------------------------------------------------------------------
+// Mock chain with controllable getBlockInfo / getTransaction / getLogs
+// ---------------------------------------------------------------------------
+
+class WaitFinalizedMockChain extends Chain {
+  static family = ChainFamily.EVM
+  static decimals = 18 as const
+
+  /** Sequence of { number, timestamp } values returned by successive getBlockInfo calls */
+  blockInfoQueue: BlockInfo[] = []
+  /** Default block info when queue is empty */
+  defaultBlockInfo: BlockInfo = { number: 100, timestamp: 1_700_000_000 }
+
+  /** If set, getTransaction returns this; if a function, it's called each time */
+  txResult: ChainTransaction | ((hash: string) => ChainTransaction) | null = null
+  /** If set, getTransaction throws this error */
+  txError: Error | null = null
+
+  /** Logs yielded by getLogs (watch mode will keep looping after these until aborted) */
+  logsToYield: ChainLog[] = []
+
+  constructor() {
+    super(networkInfo(1))
+  }
+
+  async getBlockInfo(_block: number | 'finalized' | 'latest'): Promise<BlockInfo> {
+    if (this.blockInfoQueue.length > 0) return this.blockInfoQueue.shift()!
+    return this.defaultBlockInfo
+  }
+
+  async getTransaction(hash: string): Promise<ChainTransaction> {
+    if (this.txError) throw this.txError
+    if (typeof this.txResult === 'function') return this.txResult(hash)
+    return (
+      this.txResult ?? {
+        hash,
+        logs: [],
+        blockNumber: 100,
+        timestamp: 1_700_000_000,
+        from: '0xSender',
+      }
+    )
+  }
+
+  async *getLogs(opts: LogFilter): AsyncIterableIterator<ChainLog> {
+    for (const log of this.logsToYield) {
+      yield log
+    }
+    // In watch mode, hang until the watch signal aborts
+    if (opts.watch) {
+      const signal =
+        opts.watch instanceof AbortSignal ? opts.watch : this.abort
+      await new Promise<void>((_resolve, reject) => {
+        if (signal.aborted) return reject(signal.reason as Error)
+        signal.addEventListener(
+          'abort',
+          () => reject(signal.reason as Error),
+          { once: true },
+        )
+      }).catch(() => {})
+    }
+  }
+
+  // -- stubs for remaining abstract methods (unused by waitFinalized) --
+  async typeAndVersion(_a: string) {
+    return ['Test', '1.0', 'Test 1.0'] as [string, string, string]
+  }
+  async getOnRampConfig(_a: string, _b: bigint): Promise<any> {
+    return {}
+  }
+  async getOffRampConfig(_a: string, _b: bigint): Promise<any> {
+    return {}
+  }
+  async getNativeTokenForRouter(_a: string) {
+    return '0x0'
+  }
+  async getOffRampsForRouter(_a: string, _b: bigint) {
+    return [] as string[]
+  }
+  async getOnRampForRouter(_a: string, _b: bigint) {
+    return '0x0'
+  }
+  async getSupportedTokens() {
+    return [] as string[]
+  }
+  async getRegistryTokenConfig(): Promise<any> {
+    return {}
+  }
+  async getTokenPoolConfig(): Promise<any> {
+    return { token: '0x', router: '0x' }
+  }
+  async getTokenPoolRemotes(): Promise<any> {
+    return {}
+  }
+  async getTokenForTokenPool() {
+    return '0x'
+  }
+  async getTokenInfo() {
+    return { symbol: 'T', decimals: 18 }
+  }
+  async getBalance() {
+    return 0n
+  }
+  async getTokenAdminRegistryFor() {
+    return '0x'
+  }
+  async getFee() {
+    return 0n
+  }
+  async getFeeTokens() {
+    return {}
+  }
+  async generateUnsignedSendMessage(): Promise<never> {
+    throw new Error('not implemented')
+  }
+  async sendMessage(): Promise<never> {
+    throw new Error('not implemented')
+  }
+  async generateUnsignedExecute(): Promise<never> {
+    throw new Error('not implemented')
+  }
+  async execute(): Promise<never> {
+    throw new Error('not implemented')
+  }
+  static decodeMessage() {
+    return undefined
+  }
+  static decodeExtraArgs() {
+    return undefined
+  }
+  static encodeExtraArgs() {
+    return ''
+  }
+  static decodeCommits() {
+    return undefined
+  }
+  static decodeReceipt() {
+    return undefined
+  }
+  static getAddress(b: any) {
+    return String(b)
+  }
+  static isTxHash() {
+    return true
+  }
+  static getDestLeafHasher(): any {
+    return () => ''
+  }
+  override async getMessagesInBatch(): Promise<any[]> {
+    return []
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('waitFinalized', () => {
+  it('fast-path: returns true when tx timestamp <= finalized timestamp (old log)', async () => {
+    const chain = new WaitFinalizedMockChain()
+    const log = makeLog({
+      blockTimestamp: Math.floor(Date.now() / 1e3) - 120, // 2 min ago, >60s
+    })
+    // tx.timestamp (1_700_000_000) <= finalized.timestamp (1_700_000_000)
+    chain.defaultBlockInfo = { number: 200, timestamp: 1_700_000_000 }
+    chain.txResult = {
+      hash: log.transactionHash,
+      logs: [],
+      blockNumber: 100,
+      timestamp: 1_700_000_000,
+      from: '0xSender',
+    }
+
+    const result = await chain.waitFinalized({ request: makeRequest(log) })
+    assert.equal(result, true)
+    chain.destroy()
+  })
+
+  it('fast-path: skipped when log is recent (<60s)', async () => {
+    const chain = new WaitFinalizedMockChain()
+    const log = makeLog({
+      blockTimestamp: Math.floor(Date.now() / 1e3) - 10, // 10s ago
+    })
+    // getLogs will yield the matching tx, so it still succeeds
+    chain.logsToYield = [log]
+
+    const result = await chain.waitFinalized({ request: makeRequest(log) })
+    assert.equal(result, true)
+    chain.destroy()
+  })
+
+  it('getLogs watch: returns true when matching log appears', async () => {
+    const chain = new WaitFinalizedMockChain()
+    const log = makeLog()
+    // Keep finalized behind so fast-path doesn't trigger and poller doesn't fire
+    chain.defaultBlockInfo = { number: 100, timestamp: 1_700_000_000 }
+    chain.txResult = {
+      hash: log.transactionHash,
+      logs: [],
+      blockNumber: 100,
+      timestamp: 1_700_000_100, // newer than finalized
+      from: '0xSender',
+    }
+    chain.logsToYield = [log] // getLogs yields the matching log
+
+    const result = await chain.waitFinalized({ request: makeRequest(log) })
+    assert.equal(result, true)
+    chain.destroy()
+  })
+
+  it('throws when getLogs yields a log at a later block without matching tx', async () => {
+    const chain = new WaitFinalizedMockChain()
+    const log = makeLog({ blockNumber: 100 })
+    chain.defaultBlockInfo = { number: 100, timestamp: 1_700_000_000 }
+    chain.txResult = {
+      hash: log.transactionHash,
+      logs: [],
+      blockNumber: 100,
+      timestamp: 1_700_000_100,
+      from: '0xSender',
+    }
+    // getLogs yields a different log at a later block
+    chain.logsToYield = [
+      makeLog({
+        transactionHash: '0xOtherTx',
+        blockNumber: 101,
+      }),
+    ]
+
+    await assert.rejects(
+      () => chain.waitFinalized({ request: makeRequest(log) }),
+      CCIPTransactionNotFinalizedError,
+    )
+    chain.destroy()
+  })
+
+  it('block-height poller throws when tx eventually disappears after deadline', async () => {
+    const chain = new WaitFinalizedMockChain()
+    const log = makeLog({ blockNumber: 100 })
+    // Finalized block is already way past the deadline (100 + 3 = 103)
+    chain.defaultBlockInfo = { number: 200, timestamp: 1_700_000_000 }
+    // getTransaction returns tx at same blockNumber once, then throws
+    let txCallCount = 0
+    chain.txResult = (hash: string) => {
+      txCallCount++
+      if (txCallCount >= 2) throw new CCIPTransactionNotFoundError(hash)
+      return {
+        hash,
+        logs: [],
+        blockNumber: 100,
+        timestamp: 1_700_000_100,
+        from: '0xSender',
+      }
+    }
+    // no matching logs — getLogs will hang in watch mode until poller aborts
+    chain.logsToYield = []
+
+    await assert.rejects(
+      () =>
+        chain.waitFinalized({
+          request: makeRequest(log),
+          reorgSafetyBlocks: 3,
+          pollIntervalMs: 10,
+        }),
+      CCIPTransactionNotFinalizedError,
+    )
+    assert.ok(txCallCount >= 2, 'getTransaction should have been called multiple times')
+    chain.destroy()
+  })
+
+  it('block-height poller throws when tx is not found (reorged out)', async () => {
+    const chain = new WaitFinalizedMockChain()
+    const log = makeLog({ blockNumber: 100 })
+    chain.defaultBlockInfo = { number: 200, timestamp: 1_700_000_000 }
+    // getTransaction throws — tx gone
+    chain.txError = new CCIPTransactionNotFoundError(log.transactionHash)
+    chain.logsToYield = []
+
+    await assert.rejects(
+      () =>
+        chain.waitFinalized({
+          request: makeRequest(log),
+          reorgSafetyBlocks: 3,
+        }),
+      CCIPTransactionNotFinalizedError,
+    )
+    chain.destroy()
+  })
+
+  it('block-height poller extends deadline when tx moves to a later block', async () => {
+    const chain = new WaitFinalizedMockChain()
+    const log = makeLog({ blockNumber: 100 })
+
+    // First poll: finalized=113 → deadline reached (100+3=103).
+    // getTransaction returns tx at block 200 → deadline slides to 200+3=203.
+    // Second poll: finalized=150 → still under 203, so wait.
+    // getLogs yields the matching log on second iteration → success
+    chain.blockInfoQueue = [
+      { number: 113, timestamp: 1_700_000_100 }, // triggers deadline check
+      { number: 150, timestamp: 1_700_000_200 }, // under new deadline (203)
+    ]
+    // Keep returning a high default so poller doesn't re-trigger before getLogs wins
+    chain.defaultBlockInfo = { number: 150, timestamp: 1_700_000_200 }
+
+    let txCallCount = 0
+    chain.txResult = (hash: string) => {
+      txCallCount++
+      // First call from deadline check: tx reorged to block 200
+      return {
+        hash,
+        logs: [],
+        blockNumber: 200,
+        timestamp: 1_700_000_100,
+        from: '0xSender',
+      }
+    }
+
+    // getLogs yields the matching log (simulating it appearing in finalized set)
+    chain.logsToYield = [log]
+
+    const result = await chain.waitFinalized({
+      request: makeRequest(log),
+      reorgSafetyBlocks: 3,
+    })
+    assert.equal(result, true)
+    assert.ok(txCallCount >= 1, 'getTransaction should have been called for reorg check')
+    chain.destroy()
+  })
+
+  it('respects abort signal', async () => {
+    const chain = new WaitFinalizedMockChain()
+    const log = makeLog({ blockNumber: 100 })
+    // Keep finalized behind so poller never fires
+    chain.defaultBlockInfo = { number: 100, timestamp: 1_700_000_000 }
+    chain.txResult = {
+      hash: log.transactionHash,
+      logs: [],
+      blockNumber: 100,
+      timestamp: 1_700_000_100,
+      from: '0xSender',
+    }
+    // No matching logs — will hang in watch mode
+    chain.logsToYield = []
+
+    const ac = new AbortController()
+    // Abort after a short delay
+    setTimeout(() => ac.abort(), 50)
+
+    // Should exit without hanging; the abort causes the watch loop to end,
+    // and since no match was found, it throws NotFinalized
+    await assert.rejects(
+      () =>
+        chain.waitFinalized({
+          request: makeRequest(log),
+          abort: ac.signal,
+        }),
+      CCIPTransactionNotFinalizedError,
+    )
+    chain.destroy()
+  })
+
+  it('fast-path: does not return true when tx is newer than finalized', async () => {
+    const chain = new WaitFinalizedMockChain()
+    const log = makeLog({
+      blockTimestamp: Math.floor(Date.now() / 1e3) - 120, // old enough for fast-path
+    })
+    // tx is newer than finalized → fast-path should not short-circuit
+    chain.defaultBlockInfo = { number: 200, timestamp: 1_699_999_000 }
+    chain.txResult = {
+      hash: log.transactionHash,
+      logs: [],
+      blockNumber: 100,
+      timestamp: 1_700_000_000, // > finalized.timestamp
+      from: '0xSender',
+    }
+    // getLogs yields matching log so it eventually succeeds
+    chain.logsToYield = [log]
+
+    const result = await chain.waitFinalized({ request: makeRequest(log) })
+    assert.equal(result, true)
+    chain.destroy()
+  })
+})

--- a/ccip-sdk/src/waitFinalized.test.ts
+++ b/ccip-sdk/src/waitFinalized.test.ts
@@ -272,8 +272,13 @@ describe('waitFinalized', () => {
   it('block-height poller throws when tx eventually disappears after deadline', async () => {
     const chain = new WaitFinalizedMockChain()
     const log = makeLog({ blockNumber: 100 })
-    // Finalized block is already way past the deadline (100 + 3 = 103)
-    chain.defaultBlockInfo = { number: 200, timestamp: 1_700_000_000 }
+    // Poll 1: finalized=200 → firstFinalized=200, tx found (txCallCount=1)
+    // Poll 2: finalized=201 → tx throws, 201 > max(200,102) → true → abort
+    chain.blockInfoQueue = [
+      { number: 200, timestamp: 1_700_000_000 },
+      { number: 201, timestamp: 1_700_000_001 },
+    ]
+    chain.defaultBlockInfo = { number: 201, timestamp: 1_700_000_001 }
     // getTransaction returns tx at same blockNumber once, then throws
     let txCallCount = 0
     chain.txResult = (hash: string) => {
@@ -306,7 +311,13 @@ describe('waitFinalized', () => {
   it('block-height poller throws when tx is not found (reorged out)', async () => {
     const chain = new WaitFinalizedMockChain()
     const log = makeLog({ blockNumber: 100 })
-    chain.defaultBlockInfo = { number: 200, timestamp: 1_700_000_000 }
+    // Poll 1: finalized=200 → firstFinalized=200, tx throws, 200 > max(200,102) → false (need NEW block)
+    // Poll 2: finalized=201 → tx throws, 201 > max(200,102) → true → abort
+    chain.blockInfoQueue = [
+      { number: 200, timestamp: 1_700_000_000 },
+      { number: 201, timestamp: 1_700_000_001 },
+    ]
+    chain.defaultBlockInfo = { number: 201, timestamp: 1_700_000_001 }
     // getTransaction throws — tx gone
     chain.txError = new CCIPTransactionNotFoundError(log.transactionHash)
     chain.logsToYield = []
@@ -316,6 +327,7 @@ describe('waitFinalized', () => {
         chain.waitFinalized({
           request: makeRequest(log),
           reorgSafetyBlocks: 3,
+          pollIntervalMs: 10,
         }),
       CCIPTransactionNotFinalizedError,
     )

--- a/ccip-sdk/src/waitFinalized.test.ts
+++ b/ccip-sdk/src/waitFinalized.test.ts
@@ -6,6 +6,7 @@ import type { PickDeep } from 'type-fest'
 import { type BlockInfo, type LogFilter, Chain } from './chain.ts'
 import { CCIPTransactionNotFinalizedError, CCIPTransactionNotFoundError } from './errors/index.ts'
 import { ChainFamily, networkInfo } from './networks.ts'
+import { waitFinalized } from './requests.ts'
 import type { CCIPRequest, ChainLog, ChainTransaction } from './types.ts'
 
 // ---------------------------------------------------------------------------
@@ -44,7 +45,7 @@ class WaitFinalizedMockChain extends Chain {
   static family = ChainFamily.EVM
   static decimals = 18 as const
 
-  /** Sequence of { number, timestamp } values returned by successive getBlockInfo calls */
+  /** Sequence of values returned by successive getBlockInfo calls */
   blockInfoQueue: BlockInfo[] = []
   /** Default block info when queue is empty */
   defaultBlockInfo: BlockInfo = { number: 100, timestamp: 1_700_000_000 }
@@ -86,15 +87,10 @@ class WaitFinalizedMockChain extends Chain {
     }
     // In watch mode, hang until the watch signal aborts
     if (opts.watch) {
-      const signal =
-        opts.watch instanceof AbortSignal ? opts.watch : this.abort
+      const signal = opts.watch instanceof AbortSignal ? opts.watch : this.abort
       await new Promise<void>((_resolve, reject) => {
         if (signal.aborted) return reject(signal.reason as Error)
-        signal.addEventListener(
-          'abort',
-          () => reject(signal.reason as Error),
-          { once: true },
-        )
+        signal.addEventListener('abort', () => reject(signal.reason as Error), { once: true })
       }).catch(() => {})
     }
   }
@@ -210,7 +206,8 @@ describe('waitFinalized', () => {
     }
 
     const result = await chain.waitFinalized({ request: makeRequest(log) })
-    assert.equal(result, true)
+    assert.equal(typeof result.number, 'number')
+    assert.equal(typeof result.timestamp, 'number')
     chain.destroy()
   })
 
@@ -223,11 +220,11 @@ describe('waitFinalized', () => {
     chain.logsToYield = [log]
 
     const result = await chain.waitFinalized({ request: makeRequest(log) })
-    assert.equal(result, true)
+    assert.equal(typeof result.number, 'number')
     chain.destroy()
   })
 
-  it('getLogs watch: returns true when matching log appears', async () => {
+  it('getLogs watch: returns BlockInfo when matching log appears', async () => {
     const chain = new WaitFinalizedMockChain()
     const log = makeLog()
     // Keep finalized behind so fast-path doesn't trigger and poller doesn't fire
@@ -242,7 +239,7 @@ describe('waitFinalized', () => {
     chain.logsToYield = [log] // getLogs yields the matching log
 
     const result = await chain.waitFinalized({ request: makeRequest(log) })
-    assert.equal(result, true)
+    assert.equal(typeof result.number, 'number')
     chain.destroy()
   })
 
@@ -360,7 +357,7 @@ describe('waitFinalized', () => {
       request: makeRequest(log),
       reorgSafetyBlocks: 3,
     })
-    assert.equal(result, true)
+    assert.equal(typeof result.number, 'number')
     assert.ok(txCallCount >= 1, 'getTransaction should have been called for reorg check')
     chain.destroy()
   })
@@ -415,7 +412,27 @@ describe('waitFinalized', () => {
     chain.logsToYield = [log]
 
     const result = await chain.waitFinalized({ request: makeRequest(log) })
-    assert.equal(result, true)
+    assert.equal(typeof result.number, 'number')
+    chain.destroy()
+  })
+
+  it('standalone function returns BlockInfo directly', async () => {
+    const chain = new WaitFinalizedMockChain()
+    const log = makeLog({
+      blockTimestamp: Math.floor(Date.now() / 1e3) - 120,
+    })
+    chain.defaultBlockInfo = { number: 200, timestamp: 1_700_000_000 }
+    chain.txResult = {
+      hash: log.transactionHash,
+      logs: [],
+      blockNumber: 100,
+      timestamp: 1_700_000_000,
+      from: '0xSender',
+    }
+
+    const result = await waitFinalized(chain, { request: makeRequest(log) })
+    assert.equal(result.number, 200)
+    assert.equal(result.timestamp, 1_700_000_000)
     chain.destroy()
   })
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -18155,20 +18155,6 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "license": "MIT"
     },
-    "node_modules/jayson/node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "extraneous": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
-    },
     "node_modules/jayson/node_modules/ws": {
       "version": "7.5.10",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
@@ -29023,20 +29009,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10"
-      }
-    },
-    "node_modules/webpack-bundle-analyzer/node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "extraneous": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
       }
     },
     "node_modules/webpack-bundle-analyzer/node_modules/ws": {


### PR DESCRIPTION
- Expand `getBlockTimestamp` to `getBlockInfo`, returning `{ number, timestamp }`, accepting `finality` tags
  - `getBlockTimestamp` becomes simple concrete implementation in `Chain` (for backwards compatibility), offloads to `getBlockInfo`
- Overhaul `Chain.waitFinalized`
  - Move to its own file
  - Races `getLogs` with polling `finalized` `getBlockInfo`, to fail faster when tx/log gets reorged
    - Before, it had to wait for next similar event to be finalized, which could take a long time
    - Now, it rejects as soon as a new finalized block AFTER OG block got finalized, and after some threshold (default=10) blocks came on top of the OG block, but tx disappeared from `getTransaction`