### PR TITLE
[Solana] Add fork test for 1.6.2 version parsing mismatch

### DIFF
--- a/ccip-sdk/src/evm/fork.test.data.ts
+++ b/ccip-sdk/src/evm/fork.test.data.ts
@@ -423,10 +423,10 @@ export const SOLANA_DEVNET_TO_SEPOLIA: ForkTestMessage[] = [
   // codepath to mishandle the lane version in ccip-sdk versions prior to 1.7.1.
   {
     messageId: '0xacb7f265a4d02eb1b902c6f171655aabd4b6c7c1d5b4519bee0b261fc2a88c5f',
-    txHash: 'ZHKdh1vcqUVedGtF38feWhKq46kB3d8j3SNTZYXUBDF51bArDVmhDuSSod9oBvwYKEjrm2PqtjDDXpsBvbfbA85',
+    txHash:
+      'ZHKdh1vcqUVedGtF38feWhKq46kB3d8j3SNTZYXUBDF51bArDVmhDuSSod9oBvwYKEjrm2PqtjDDXpsBvbfbA85',
     status: MessageStatus.Failed,
     version: '1.6',
-    description:
-      'failed from Solana Devnet, ready for manual exec — API reports version "1.6.2"',
+    description: 'failed from Solana Devnet, ready for manual exec — API reports version "1.6.2"',
   },
 ]

--- a/ccip-sdk/src/evm/fork.test.data.ts
+++ b/ccip-sdk/src/evm/fork.test.data.ts
@@ -414,3 +414,19 @@ export const TON_TO_SEPOLIA: ForkTestMessage[] = [
       'failed data-only (gasLimit=1) from TON, ready for manual exec — problematic API path',
   },
 ]
+
+// ── Solana Devnet → Sepolia (SVM → EVM) ──
+
+export const SOLANA_DEVNET_TO_SEPOLIA: ForkTestMessage[] = [
+  // FAILED — ready for manual exec; API reports version "1.6.2" which does not match
+  // the CCIPVersion enum values ("1.6.0" etc.), causing the API-driven manual-exec
+  // codepath to mishandle the lane version in ccip-sdk versions prior to 1.7.1.
+  {
+    messageId: '0xacb7f265a4d02eb1b902c6f171655aabd4b6c7c1d5b4519bee0b261fc2a88c5f',
+    txHash: 'ZHKdh1vcqUVedGtF38feWhKq46kB3d8j3SNTZYXUBDF51bArDVmhDuSSod9oBvwYKEjrm2PqtjDDXpsBvbfbA85',
+    status: MessageStatus.Failed,
+    version: '1.6',
+    description:
+      'failed from Solana Devnet, ready for manual exec — API reports version "1.6.2"',
+  },
+]

--- a/ccip-sdk/src/evm/fork.test.ts
+++ b/ccip-sdk/src/evm/fork.test.ts
@@ -8,6 +8,7 @@ import { Instance } from 'prool'
 import { createPublicClient, http } from 'viem'
 
 import '../aptos/index.ts' // register Aptos chain family for cross-family message decoding
+import '../solana/index.ts' // register Solana chain family for cross-family message decoding
 import '../ton/index.ts' // register TON chain family for cross-family message decoding
 import { CCIPAPIClient } from '../api/index.ts'
 import { LaneFeature } from '../chain.ts'
@@ -16,7 +17,12 @@ import { NetworkType } from '../networks.ts'
 import { CCTP_FINALITY_FAST, getUsdcBurnFees } from '../offchain.ts'
 import { type ExecutionInput, ExecutionState, MessageStatus } from '../types.ts'
 import { interfaces } from './const.ts'
-import { FUJI_TO_SEPOLIA, SEPOLIA_TO_FUJI, TON_TO_SEPOLIA } from './fork.test.data.ts'
+import {
+  FUJI_TO_SEPOLIA,
+  SEPOLIA_TO_FUJI,
+  SOLANA_DEVNET_TO_SEPOLIA,
+  TON_TO_SEPOLIA,
+} from './fork.test.data.ts'
 import { EVMChain } from './index.ts'
 import { ViemTransportProvider } from './viem/client-adapter.ts'
 
@@ -1502,6 +1508,42 @@ describe('EVM Fork Tests', { skip, timeout: 180_000 }, () => {
 
       console.log(
         `  executed ${msg.messageId.slice(0, 10)}… via API (TON source, gasLimit=1) → state=${execution.receipt.state}`,
+      )
+      assert.equal(execution.receipt.messageId, msg.messageId, 'receipt messageId should match')
+      assert.ok(execution.log.transactionHash, 'should have tx hash')
+      assert.ok(execution.log.blockTimestamp > 0, 'should have timestamp')
+      assert.equal(execution.receipt.state, ExecutionState.Success)
+
+      sepoliaWithApi.provider.destroy()
+    })
+
+    // Solana Devnet → Sepolia message whose lane.version reported by the API is "1.6.2".
+    // The CCIPVersion enum only knows "1.6.0", so the API-driven manual-exec codepath
+    // must normalize patch-level versions to avoid breaking downstream handling
+    // (e.g. leaf hasher selection in calculateManualExecProof).
+    it('should execute a Solana-source message via API-driven path (Solana Devnet -> Sepolia)', async () => {
+      assert.ok(sepoliaInstance, 'sepolia anvil should be running')
+
+      const msg = SOLANA_DEVNET_TO_SEPOLIA[0]!
+
+      const stagingApi = new CCIPAPIClient('https://api.ccip.cldev.cloud', { logger: testLogger })
+      const sepoliaProvider = new JsonRpcProvider(
+        `http://${sepoliaInstance.host}:${sepoliaInstance.port}`,
+      )
+      const sepoliaWithApi = await EVMChain.fromProvider(sepoliaProvider, {
+        apiClient: stagingApi,
+        logger: testLogger,
+      })
+      const w = new Wallet(ANVIL_PRIVATE_KEY, sepoliaProvider)
+
+      const execution = await sepoliaWithApi.execute({
+        messageId: msg.messageId,
+        wallet: w,
+        gasLimit: 500_000,
+      })
+
+      console.log(
+        `  executed ${msg.messageId.slice(0, 10)}… via API (Solana source) → state=${execution.receipt.state}`,
       )
       assert.equal(execution.receipt.messageId, msg.messageId, 'receipt messageId should match')
       assert.ok(execution.log.transactionHash, 'should have tx hash')


### PR DESCRIPTION
Adds a fork test validating the fix in #265.

For reference, this test, when run on top of 1.7.0 without the hotfix, reproduces the chain version parsing issue:

```
test at src/evm/fork.test.ts:1524:5
✖ should execute a Solana-source message via API-driven path (Solana Devnet -> Sepolia) (982.333ms)
     // ...
      at async Test.run (node:internal/test_runner/test:1113:7) {
    _isCCIPError: true,
    code: 'HASHER_VERSION_UNSUPPORTED',
    context: { chain: 'EVM', version: '1.6.2' },
    isTransient: false,
    retryAfterMs: undefined,
    recovery: 'Use a supported CCIP version for this chain. Check the lane configuration for compatible versions.',
    [cause]: undefined
  }
 ```