### PR TITLE
fix(ton): prevent polling loop from exiting due to unref'd AbortSignal.timeout timers

### DIFF
--- a/ccip-cli/src/index.ts
+++ b/ccip-cli/src/index.ts
@@ -28,7 +28,7 @@ Error.stackTraceLimit = 50 // show more stack frames for better debugging
 
 // generate:nofail
 // `const VERSION = '${require('./package.json').version}-${require('child_process').execSync('git rev-parse --short HEAD').toString().trim()}'`
-const VERSION = '1.7.1-90c0438'
+const VERSION = '1.7.1-2807dab'
 // generate:end
 
 const require = createRequire(import.meta.url)

--- a/ccip-sdk/src/api/index.ts
+++ b/ccip-sdk/src/api/index.ts
@@ -58,7 +58,7 @@ export const DEFAULT_TIMEOUT_MS = 30000
 /** SDK version string for telemetry header */
 // generate:nofail
 // `export const SDK_VERSION = '${require('./package.json').version}-${require('child_process').execSync('git rev-parse --short HEAD').toString().trim()}'`
-export const SDK_VERSION = '1.7.1-90c0438'
+export const SDK_VERSION = '1.7.1-2807dab'
 // generate:end
 
 /** SDK telemetry header name */

--- a/ccip-sdk/src/ton/logs.ts
+++ b/ccip-sdk/src/ton/logs.ts
@@ -61,17 +61,30 @@ async function* fetchTxsForward(
       yield tx
     }
 
-    let delay$ = AbortSignal.timeout(
-      Math.max(
-        Math.ceil((opts.pollInterval || DEFAULT_POLL_INTERVAL) - (performance.now() - lastReq)),
-        1,
-      ),
+    const delay = Math.max(
+      Math.ceil((opts.pollInterval || DEFAULT_POLL_INTERVAL) - (performance.now() - lastReq)),
+      1,
     )
-    if (opts.watch instanceof AbortSignal) {
-      if (opts.watch.aborted) break
-      delay$ = AbortSignal.any([opts.watch, delay$])
+
+    if (opts.watch instanceof AbortSignal && opts.watch.aborted) {
+      break
     }
-    await signalToPromise(delay$).catch(() => false)
+
+    // NOTE:
+    // We intentionally avoid `AbortSignal.timeout()` here because Node.js
+    // implements it using an unref'd timer internally. Unref'd timers do not
+    // keep the event loop alive, which caused the process to exit while this
+    // polling loop was awaiting the delay between requests.
+    //
+    // Using a normal `setTimeout()` keeps the polling loop alive correctly,
+    // while `signalToPromise(opts.watch)` still allows immediate cancellation
+    // when the external AbortSignal is aborted.
+    await Promise.race([
+      new Promise((resolve) => setTimeout(resolve, delay)),
+      opts.watch instanceof AbortSignal
+        ? signalToPromise(opts.watch).catch(() => false)
+        : undefined,
+    ])
   }
 }
 


### PR DESCRIPTION
AbortSignal.timeout() uses unref'd timers internally in Node.js, which do not keep the event loop alive. This caused the TON transaction polling loop to exit prematurely while awaiting the next poll interval.

This change replaces timeout-based polling delays with a standard setTimeout() wrapped in Promise.race(), preserving AbortSignal cancellation semantics while ensuring the polling loop correctly keeps the process alive until completion or cancellation.`