### PR TITLE
Fix native transfers checks

### DIFF
--- a/ccip-api-ref/package.json
+++ b/ccip-api-ref/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/ccip-api-ref",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "private": true,
   "description": "API Reference documentation for CCIP SDK and CLI",
   "scripts": {

--- a/ccip-api-ref/tsconfig.json
+++ b/ccip-api-ref/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
-    "target": "ES2025",
+    "target": "ESNext",
     "module": "preserve",
+    "lib": ["ESNext", "DOM"],
     "moduleResolution": "bundler",
-    "lib": ["ES2025", "DOM"],
     "allowImportingTsExtensions": true,
     "jsx": "react-jsx",
     "strict": true,

--- a/ccip-cli/package.json
+++ b/ccip-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/ccip-cli",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "CCIP Command Line Interface, based on @chainlink/ccip-sdk",
   "author": "Chainlink devs",
   "license": "MIT",
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "@aptos-labs/ts-sdk": "^6.3.1",
-    "@chainlink/ccip-sdk": "^1.9.0",
+    "@chainlink/ccip-sdk": "^1.9.1",
     "@coral-xyz/anchor": "^0.29.0",
     "@ethers-ext/signer-ledger": "^6.0.0-beta.1",
     "@inquirer/prompts": "8.5.2",

--- a/ccip-cli/package.json
+++ b/ccip-cli/package.json
@@ -42,7 +42,7 @@
     "!**/__mocks__"
   ],
   "devDependencies": {
-    "@types/node": "25.9.1",
+    "@types/node": "25.9.2",
     "@types/update-notifier": "^6.0.8",
     "@types/yargs": "17.0.35",
     "tsx": "4.22.4",

--- a/ccip-cli/src/commands/e2e-helpers.test.ts
+++ b/ccip-cli/src/commands/e2e-helpers.test.ts
@@ -6,8 +6,8 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url))
 export const CLI_PATH = path.join(__dirname, '..', 'index.ts')
 
 export const RPCS = [
-  process.env['RPC_SEPOLIA'] || 'https://ethereum-sepolia-rpc.publicnode.com',
-  process.env['RPC_AVAX'] || 'https://avalanche-fuji-c-chain-rpc.publicnode.com',
+  process.env['RPC_SEPOLIA'] || 'https://sepolia.gateway.tenderly.co',
+  process.env['RPC_AVAX'] || 'https://api.avax-test.network/ext/bc/C/rpc',
   process.env['RPC_APTOS'] || 'testnet',
   process.env['RPC_SOLANA'] || 'https://api.devnet.solana.com',
   process.env['RPC_TON'] || 'https://testnet.toncenter.com/api/v2',

--- a/ccip-cli/tsconfig.json
+++ b/ccip-cli/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "ES2025",
+    "target": "ESNext",
     "module": "NodeNext",
-    "lib": ["ES2025"],
+    "lib": ["ESNext"],
     "types": ["node"],
     "strict": true,
     "skipLibCheck": true,

--- a/ccip-sdk/package.json
+++ b/ccip-sdk/package.json
@@ -57,11 +57,11 @@
   },
   "devDependencies": {
     "@types/bn.js": "^5.2.0",
-    "@types/node": "25.9.1",
+    "@types/node": "25.9.2",
     "ethers-abitype": "1.0.3",
     "prool": "^0.2.4",
     "typescript": "6.0.3",
-    "viem": "^2.52.0"
+    "viem": "^2.52.2"
   },
   "dependencies": {
     "@aptos-labs/ts-sdk": "^6.3.1",

--- a/ccip-sdk/package.json
+++ b/ccip-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/ccip-sdk",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "SDK/Library to interact with CCIP",
   "author": "Chainlink devs",
   "license": "MIT",

--- a/ccip-sdk/src/chain.ts
+++ b/ccip-sdk/src/chain.ts
@@ -1286,6 +1286,10 @@ export abstract class Chain<F extends ChainFamily = ChainFamily> {
   >): Promise<true> {
     let registry
     for (const { token, amount } of message.tokenAmounts ?? []) {
+      // Native value transfers aren't pool-managed (no registry entry / rate limiter),
+      // and `router` may be a sender helper (e.g. EtherSenderReceiver) rather than a
+      // Router/Ramp — skip the token-pool preflight for them.
+      if (!token || token.match(/^(0x)?0*$/i)) continue
       registry ??= await this.getTokenAdminRegistryFor(router)
       const { tokenPool } = await this.getRegistryTokenConfig(registry, token)
       const remote = await this.getTokenPoolRemote(tokenPool!, destChainSelector)
@@ -1324,6 +1328,8 @@ export abstract class Chain<F extends ChainFamily = ChainFamily> {
     for (const ta of message.tokenAmounts ?? []) {
       const amount = ta.amount
       const token = 'destTokenAddress' in ta ? ta.destTokenAddress : ta.token
+      // Native value transfers aren't pool-managed — skip the token-pool preflight.
+      if (!token || token.match(/^(0x)?0*$/i)) continue
       registry ??= await this.getTokenAdminRegistryFor(offRamp)
       const { tokenPool } = await this.getRegistryTokenConfig(registry, token)
       const { typeAndVersion, lockBox } = await this.getTokenPoolConfig(tokenPool!)

--- a/ccip-sdk/src/evm/fork.test.ts
+++ b/ccip-sdk/src/evm/fork.test.ts
@@ -26,10 +26,10 @@ const SEPOLIA_CHAIN_ID = 11155111
 const SEPOLIA_SELECTOR = 16015286601757825753n
 const SEPOLIA_ROUTER = '0x0BF3dE8c5D3e8A2B34D2BEeB17ABfCeBaf363A59'
 
-const FUJI_RPC = process.env['RPC_FUJI'] || 'https://avalanche-fuji-c-chain-rpc.publicnode.com'
+const FUJI_RPC = process.env['RPC_FUJI'] || 'https://api.avax-test.network/ext/bc/C/rpc'
 const FUJI_CHAIN_ID = 43113
 
-const ARB_SEP_RPC = process.env['RPC_ARB_SEPOLIA'] || 'https://arbitrum-sepolia-rpc.publicnode.com'
+const ARB_SEP_RPC = process.env['RPC_ARB_SEPOLIA'] || 'https://sepolia-rollup.arbitrum.io/rpc'
 const ARB_SEP_CHAIN_ID = 421614
 
 const ANVIL_PRIVATE_KEY = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'

--- a/ccip-sdk/src/evm/index.ts
+++ b/ccip-sdk/src/evm/index.ts
@@ -1022,11 +1022,9 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
       interfaces.Token,
       this.provider,
     ) as unknown as TypedContract<typeof Token_ABI>
-    const [symbol, decimals, name] = await Promise.all([
-      contract.symbol(),
-      contract.decimals(),
-      contract.name(),
-    ])
+    const symbol = await contract.symbol()
+    const decimals = await contract.decimals()
+    const name = await contract.name()
     return { symbol, decimals: Number(decimals), name }
   }
 
@@ -1274,10 +1272,8 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
         interfaces.CCTPVerifier_v2_0,
         this.provider,
       ) as unknown as TypedContract<typeof CCTPVerifier_2_0_ABI>
-      const [staticConfig, domainResult] = await Promise.all([
-        verifier.getStaticConfig(),
-        verifier.getDomain(destChainSelector),
-      ])
+      const staticConfig = await verifier.getStaticConfig()
+      const domainResult = await verifier.getDomain(destChainSelector)
       return {
         sourceDomain: Number(staticConfig[3]), // localDomainIdentifier
         destDomain: Number(domainResult.domainIdentifier),
@@ -1348,12 +1344,11 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
       )
     }
 
-    const [result, { decimals }] = await Promise.all([
+    const result =
       blockTag != null
-        ? contract.getTokenPrice.staticCall(token, { blockTag })
-        : contract.getTokenPrice(token),
-      this.getTokenInfo(token),
-    ])
+        ? await contract.getTokenPrice.staticCall(token, { blockTag })
+        : await contract.getTokenPrice(token)
+    const { decimals } = await this.getTokenInfo(token)
 
     const rawPrice = BigInt(result.value)
     return { price: Number(rawPrice) * 10 ** (decimals - 36) }
@@ -1364,10 +1359,9 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
     opts: Parameters<Chain['getTotalFeesEstimate']>[0],
   ): Promise<TotalFeesEstimate> {
     const tokenAmounts = opts.message.tokenAmounts
-    const ccipFee$ = this.getFee(opts)
 
     if (!tokenAmounts?.length) {
-      return { ccipFee: await ccipFee$ }
+      return { ccipFee: await this.getFee(opts) }
     }
 
     const { token, amount } = tokenAmounts[0]!
@@ -1385,7 +1379,7 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
     const onRamp = await this.getOnRampForRouter(opts.router, opts.destChainSelector)
     const [, version] = await this.typeAndVersion(onRamp)
     if (version < CCIPVersion.V2_0) {
-      return { ccipFee: await ccipFee$ }
+      return { ccipFee: await this.getFee(opts) }
     }
 
     const onRampContract = new Contract(
@@ -1399,19 +1393,17 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
       token,
     )) as string
 
-    const [ccipFee, { tokenTransferFeeConfig }, usdcDomains] = await Promise.all([
-      ccipFee$,
-      this.getTokenPoolConfig(poolAddress, {
-        destChainSelector: opts.destChainSelector,
-        finality,
-        tokenArgs,
-      }),
-      this.detectUsdcDomains(
-        poolAddress,
-        opts.destChainSelector,
-        extraArgs && 'ccvs' in extraArgs ? extraArgs.ccvs : [],
-      ),
-    ])
+    const ccipFee = await this.getFee(opts)
+    const { tokenTransferFeeConfig } = await this.getTokenPoolConfig(poolAddress, {
+      destChainSelector: opts.destChainSelector,
+      finality,
+      tokenArgs,
+    })
+    const usdcDomains = await this.detectUsdcDomains(
+      poolAddress,
+      opts.destChainSelector,
+      extraArgs && 'ccvs' in extraArgs ? extraArgs.ccvs : [],
+    )
 
     // USDC path: use Circle CCTP burn fees
     if (usdcDomains) {
@@ -2138,13 +2130,13 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
     ) as unknown as TypedContract<typeof FeeQuoter_1_6_ABI>
     const tokens = await contract.getFeeTokens()
 
-    return Object.fromEntries(
-      await Promise.all(
-        tokens.map(
-          async (token) => [token as string, await this.getTokenInfo(token as string)] as const,
-        ),
-      ),
-    )
+    const entries: Array<readonly [string, Awaited<ReturnType<typeof this.getTokenInfo>>]> = []
+    for (const token of tokens) {
+      const address = token as string
+      entries.push([address, await this.getTokenInfo(address)] as const)
+    }
+
+    return Object.fromEntries(entries)
   }
 
   /** {@inheritDoc Chain.getVerifications} */

--- a/ccip-sdk/src/evm/integration.test.ts
+++ b/ccip-sdk/src/evm/integration.test.ts
@@ -22,13 +22,13 @@ import { EVMChain } from './index.ts'
 // Integration tests issue many live RPC calls (no anvil fork to absorb them), so the
 // defaults point at reliable public endpoints. Free gateways (tenderly, avax public)
 // rate-limit/stall under this load and time out the suite. Override via RPC_* env vars.
-const SEPOLIA_RPC = process.env['RPC_SEPOLIA'] || 'https://ethereum-sepolia-rpc.publicnode.com'
+const SEPOLIA_RPC = process.env['RPC_SEPOLIA'] || 'https://sepolia.gateway.tenderly.co'
 const SEPOLIA_SELECTOR = 16015286601757825753n
 const SEPOLIA_ROUTER = '0x0BF3dE8c5D3e8A2B34D2BEeB17ABfCeBaf363A59'
 
-const FUJI_RPC = process.env['RPC_FUJI'] || 'https://avalanche-fuji-c-chain-rpc.publicnode.com'
+const FUJI_RPC = process.env['RPC_FUJI'] || 'https://api.avax-test.network/ext/bc/C/rpc'
 
-const ARB_SEP_RPC = process.env['RPC_ARB_SEPOLIA'] || 'https://arbitrum-sepolia-rpc.publicnode.com'
+const ARB_SEP_RPC = process.env['RPC_ARB_SEPOLIA'] || 'https://sepolia-rollup.arbitrum.io/rpc'
 const ARB_SEP_SELECTOR = 3478487238524512106n
 const ARB_SEP_V2_0_ROUTER = '0x8F95FA37c55eF7beFdf05f6abDeC551773E17Fb4'
 

--- a/ccip-sdk/src/selectors.ts
+++ b/ccip-sdk/src/selectors.ts
@@ -461,6 +461,7 @@ const SELECTORS: Selectors = {
     selector: 4348158687435793198n,
     name: 'ethereum-mainnet-polygon-zkevm-1',
     network_type: 'MAINNET',
+    deprecated: true,
     family: 'EVM',
   },
   '1111': {
@@ -751,6 +752,7 @@ const SELECTORS: Selectors = {
     selector: 4560701533377838164n,
     name: 'bitcoin-mainnet-botanix',
     network_type: 'MAINNET',
+    deprecated: true,
     family: 'EVM',
   },
   '3776': {

--- a/ccip-sdk/src/solana/index.ts
+++ b/ccip-sdk/src/solana/index.ts
@@ -157,6 +157,10 @@ interface ParsedTokenInfo {
   name?: string
   symbol?: string
   decimals: number
+  extensions?: Array<{
+    extension: string
+    state: { name?: string; symbol?: string; [key: string]: unknown }
+  }>
 }
 
 // hardcoded symbols for tokens without metadata
@@ -741,15 +745,20 @@ export class SolanaChain extends Chain<typeof ChainFamily.Solana> {
     if (typeof mintInfo.value.data === 'object' && 'parsed' in mintInfo.value.data) {
       const parsed = mintInfo.value.data.parsed as { info: ParsedTokenInfo }
       const data = parsed.info
-      let symbol = data.symbol || unknownTokens[token] || 'UNKNOWN'
-      let name = data.name
+
+      // Token-2022 tokens may embed metadata in extensions
+      const tokenMetadataExt = data.extensions?.find((e) => e.extension === 'tokenMetadata')
+
+      let symbol =
+        data.symbol || tokenMetadataExt?.state.symbol || unknownTokens[token] || 'UNKNOWN'
+      let name = data.name || tokenMetadataExt?.state.name
 
       // If symbol or name is missing, try to fetch from Metaplex metadata
-      if (!data.symbol || symbol === 'UNKNOWN' || !data.name) {
+      if (!symbol || symbol === 'UNKNOWN' || !name) {
         try {
           const metadata = await this._fetchTokenMetadata(mint)
           if (metadata) {
-            if (metadata.symbol && (!data.symbol || symbol === 'UNKNOWN')) {
+            if (metadata.symbol && symbol === 'UNKNOWN') {
               symbol = metadata.symbol
             }
             if (metadata.name && !name) {

--- a/ccip-sdk/src/solana/index.ts
+++ b/ccip-sdk/src/solana/index.ts
@@ -748,17 +748,24 @@ export class SolanaChain extends Chain<typeof ChainFamily.Solana> {
 
       // Token-2022 tokens may embed metadata in extensions
       const tokenMetadataExt = data.extensions?.find((e) => e.extension === 'tokenMetadata')
+      const extSymbol = tokenMetadataExt?.state.symbol
+      const extName = tokenMetadataExt?.state.name
+      const rawSymbol = data.symbol || extSymbol
 
-      let symbol =
-        data.symbol || tokenMetadataExt?.state.symbol || unknownTokens[token] || 'UNKNOWN'
-      let name = data.name || tokenMetadataExt?.state.name
+      // Track whether we have an on-chain authoritative symbol/name (parsed fields or T-2022 extension).
+      // unknownTokens / 'UNKNOWN' are fallbacks — Metaplex can still override them.
+      let symbol = rawSymbol || unknownTokens[token] || 'UNKNOWN'
+      let name = data.name || extName
+
+      const hasAuthoritativeSymbol = !!rawSymbol && rawSymbol !== 'UNKNOWN'
+      const hasAuthoritativeName = !!name
 
       // If symbol or name is missing, try to fetch from Metaplex metadata
-      if (!symbol || symbol === 'UNKNOWN' || !name) {
+      if (!hasAuthoritativeSymbol || !hasAuthoritativeName) {
         try {
           const metadata = await this._fetchTokenMetadata(mint)
           if (metadata) {
-            if (metadata.symbol && symbol === 'UNKNOWN') {
+            if (metadata.symbol && !hasAuthoritativeSymbol) {
               symbol = metadata.symbol
             }
             if (metadata.name && !name) {

--- a/ccip-sdk/tsconfig.json
+++ b/ccip-sdk/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "ES2025",
+    "target": "ESNext",
     "module": "NodeNext",
-    "lib": ["ES2025"],
+    "lib": ["ESNext"],
     "types": ["node"],
     "strict": true,
     "skipLibCheck": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chainlink/ccip-tools-ts",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chainlink/ccip-tools-ts",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "license": "MIT",
       "workspaces": [
         "ccip-sdk",
@@ -32,7 +32,7 @@
     },
     "ccip-api-ref": {
       "name": "@chainlink/ccip-api-ref",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "dependencies": {
         "@chainlink/ccip-sdk": "*",
         "@chainlink/design-system": "^0.2.8",
@@ -65,11 +65,11 @@
     },
     "ccip-cli": {
       "name": "@chainlink/ccip-cli",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "license": "MIT",
       "dependencies": {
         "@aptos-labs/ts-sdk": "^6.3.1",
-        "@chainlink/ccip-sdk": "^1.9.0",
+        "@chainlink/ccip-sdk": "^1.9.1",
         "@coral-xyz/anchor": "^0.29.0",
         "@ethers-ext/signer-ledger": "^6.0.0-beta.1",
         "@inquirer/prompts": "8.5.2",
@@ -201,7 +201,7 @@
     },
     "ccip-sdk": {
       "name": "@chainlink/ccip-sdk",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "license": "MIT",
       "dependencies": {
         "@aptos-labs/ts-sdk": "^6.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,18 +15,18 @@
       ],
       "devDependencies": {
         "@eslint/js": "^10.0.1",
-        "@types/node": "25.9.1",
+        "@types/node": "25.9.2",
         "c8": "^11.0.0",
         "eslint": "^10.4.1",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-import-x": "^4.16.2",
-        "eslint-plugin-jsdoc": "^63.0.1",
+        "eslint-plugin-jsdoc": "^63.0.2",
         "eslint-plugin-prettier": "^5.5.6",
         "eslint-plugin-tsdoc": "^0.5.2",
         "glob": "13.0.6",
         "prettier": "3.8.3",
         "typescript": "6.0.3",
-        "typescript-eslint": "8.60.1",
+        "typescript-eslint": "8.61.0",
         "yaml": "2.9.0"
       }
     },
@@ -91,7 +91,7 @@
         "ccip-cli": "dist/index.js"
       },
       "devDependencies": {
-        "@types/node": "25.9.1",
+        "@types/node": "25.9.2",
         "@types/update-notifier": "^6.0.8",
         "@types/yargs": "17.0.35",
         "tsx": "4.22.4",
@@ -226,11 +226,11 @@
       },
       "devDependencies": {
         "@types/bn.js": "^5.2.0",
-        "@types/node": "25.9.1",
+        "@types/node": "25.9.2",
         "ethers-abitype": "1.0.3",
         "prool": "^0.2.4",
         "typescript": "6.0.3",
-        "viem": "^2.52.0"
+        "viem": "^2.52.2"
       },
       "peerDependencies": {
         "viem": "^2.0.0"
@@ -10143,9 +10143,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
-      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "version": "25.9.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.2.tgz",
+      "integrity": "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
@@ -10506,17 +10506,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.60.1.tgz",
-      "integrity": "sha512-JQ4S5GB0tfjO8BuJ4fcX+HodkzJjYBV+7OJ+wLygaX7OGQ7FudyHL4NSCA6ob+w3Yn+5MkKIozOwQhXeM7opVg==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.61.0.tgz",
+      "integrity": "sha512-bFNvl9ZczlVb+wR2Akszf3gHfKVj/8WanXaGJ3UstTA7brNKg0cNdk6X1Psu5V7MZ2oQtzZKOEzIUehaoxbDGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.60.1",
-        "@typescript-eslint/type-utils": "8.60.1",
-        "@typescript-eslint/utils": "8.60.1",
-        "@typescript-eslint/visitor-keys": "8.60.1",
+        "@typescript-eslint/scope-manager": "8.61.0",
+        "@typescript-eslint/type-utils": "8.61.0",
+        "@typescript-eslint/utils": "8.61.0",
+        "@typescript-eslint/visitor-keys": "8.61.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -10529,7 +10529,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.60.1",
+        "@typescript-eslint/parser": "^8.61.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
@@ -10545,16 +10545,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.60.1.tgz",
-      "integrity": "sha512-A0M6ua6H252bVjPvvtSgl2QA4+ET9S5Mtkb2GDyTxIhH/C4qDItT7RQNO5PhMC6NXGYXOR9dIalcDDgBKT7oFA==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.61.0.tgz",
+      "integrity": "sha512-5B7PfA2e1NQGCnDHd/0lW7W3gvp3d59Ryw54FYO8Uswxo9f6ikw3AZV+Xj/TvpImmpsiYyUqAfhC6kJID1jF6w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.60.1",
-        "@typescript-eslint/types": "8.60.1",
-        "@typescript-eslint/typescript-estree": "8.60.1",
-        "@typescript-eslint/visitor-keys": "8.60.1",
+        "@typescript-eslint/scope-manager": "8.61.0",
+        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/typescript-estree": "8.61.0",
+        "@typescript-eslint/visitor-keys": "8.61.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -10570,9 +10570,9 @@
       }
     },
     "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.60.1.tgz",
-      "integrity": "sha512-4h0tY8ppCkdCzcrl2YM5M3my0xsE1Tf8om3owEu5oPWmXwkKRmk0j0LGDzYBGUcAlesEbxBhazqu/K4cu3Ug7w==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.61.0.tgz",
+      "integrity": "sha512-9QTQpZ5Iin4CdIodfbDQFSeiSJKidgYJYug1P9CC2xWgUTvlmixViqDZNciMjwLBZyJnG4tGmPl97rVAFb1AJg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10584,14 +10584,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.60.1.tgz",
-      "integrity": "sha512-eXkTH2bxmXlqD1RnOPmLZ9ZM9D3VwSx04JOwBnP9RQ+yUA5a2Mu7SfW8uaV2Aon53NJzZlZYuX7tn91Izf+xaw==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.61.0.tgz",
+      "integrity": "sha512-DV42F7MLJO6Rax7SK1yg43tcnEfGUrurSpSxKuVX+a3RCTzBlH3fuxprrOJXKCJGAaw82xXocikJ0uQaqwXgGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.60.1",
-        "@typescript-eslint/types": "^8.60.1",
+        "@typescript-eslint/tsconfig-utils": "^8.61.0",
+        "@typescript-eslint/types": "^8.61.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -10606,14 +10606,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.60.1.tgz",
-      "integrity": "sha512-gvI5OQoptnxQnchOirukCuQ55svJSTuD/4k5+pC267xyBtYry748R9/c3tYUzb/iE6RZfllRz2lVulLCHkTm4w==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.61.0.tgz",
+      "integrity": "sha512-IWdXFHFSb6mlC3HPc7QsLDm5zYEbUla6trDEHf32D3/dnuUyXd87plScSNXSbm0/RxMvObpI17sv/EDTGrGZkA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.60.1",
-        "@typescript-eslint/visitor-keys": "8.60.1"
+        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/visitor-keys": "8.61.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -10624,9 +10624,9 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager/node_modules/@typescript-eslint/types": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.60.1.tgz",
-      "integrity": "sha512-4h0tY8ppCkdCzcrl2YM5M3my0xsE1Tf8om3owEu5oPWmXwkKRmk0j0LGDzYBGUcAlesEbxBhazqu/K4cu3Ug7w==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.61.0.tgz",
+      "integrity": "sha512-9QTQpZ5Iin4CdIodfbDQFSeiSJKidgYJYug1P9CC2xWgUTvlmixViqDZNciMjwLBZyJnG4tGmPl97rVAFb1AJg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10638,9 +10638,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.60.1.tgz",
-      "integrity": "sha512-nh8w4qAteiKuZu3pSSzG/yGKpw0OlkrKnzFmbVRenKaD4qc+7i1GrmZaLVkr8rk4uipiPGMOW4YsM6WmKZ5CvA==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.61.0.tgz",
+      "integrity": "sha512-O5Amvdv9ztMpxpf+vmFULGG78IE6Qwdr3bCGvqwG4nwc9H2qXkOYJJnRbRHyMkQTjv1d03olqwwwzHLMqpFePQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10655,15 +10655,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.60.1.tgz",
-      "integrity": "sha512-sdwTrpjosW7ANQYJ39ZBF1ZyEMEGVB2UsikrserVM/30a/F1dTLnu9bGxEdosugyu5caigjLrR2qiD11asjI1A==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.61.0.tgz",
+      "integrity": "sha512-TuBiQYIkd97yBfInHCTKVYMbX4kvEmpOEuixIuzCU9p8BGT1SfyyO0d0IfDMbPIHcjn/hWnusUX5e8v5Xg+X8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.60.1",
-        "@typescript-eslint/typescript-estree": "8.60.1",
-        "@typescript-eslint/utils": "8.60.1",
+        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/typescript-estree": "8.61.0",
+        "@typescript-eslint/utils": "8.61.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -10680,9 +10680,9 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/types": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.60.1.tgz",
-      "integrity": "sha512-4h0tY8ppCkdCzcrl2YM5M3my0xsE1Tf8om3owEu5oPWmXwkKRmk0j0LGDzYBGUcAlesEbxBhazqu/K4cu3Ug7w==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.61.0.tgz",
+      "integrity": "sha512-9QTQpZ5Iin4CdIodfbDQFSeiSJKidgYJYug1P9CC2xWgUTvlmixViqDZNciMjwLBZyJnG4tGmPl97rVAFb1AJg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10708,16 +10708,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.60.1.tgz",
-      "integrity": "sha512-alpRkfG8hlVE5kdJW2GkfgDgXxold3e8e4l6EnmhRmRLbekgAPCCGDVD++sABy9FcgPFroq+uFcCSM1vR57Cew==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.61.0.tgz",
+      "integrity": "sha512-42zatd5qSvvcV1JdDBCLxYRznvP4eIHpPoZXdkPFnAmanA4FuZ5dibSnCBggY8hQnqajPpoGjXFdZ7fIJKQnlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.60.1",
-        "@typescript-eslint/tsconfig-utils": "8.60.1",
-        "@typescript-eslint/types": "8.60.1",
-        "@typescript-eslint/visitor-keys": "8.60.1",
+        "@typescript-eslint/project-service": "8.61.0",
+        "@typescript-eslint/tsconfig-utils": "8.61.0",
+        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/visitor-keys": "8.61.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -10736,9 +10736,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/@typescript-eslint/types": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.60.1.tgz",
-      "integrity": "sha512-4h0tY8ppCkdCzcrl2YM5M3my0xsE1Tf8om3owEu5oPWmXwkKRmk0j0LGDzYBGUcAlesEbxBhazqu/K4cu3Ug7w==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.61.0.tgz",
+      "integrity": "sha512-9QTQpZ5Iin4CdIodfbDQFSeiSJKidgYJYug1P9CC2xWgUTvlmixViqDZNciMjwLBZyJnG4tGmPl97rVAFb1AJg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10750,16 +10750,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.60.1.tgz",
-      "integrity": "sha512-h2MPBLoNtjc3qZWfY3Tl51yPorQ2McHn8pJfcMNTcIvrrZrr90Ykffit0yjrPFWQcRcUxzH20+6OcVdW4yHtUg==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.61.0.tgz",
+      "integrity": "sha512-3bzFt7ImFMW/jVYwJamDoe/dMOdFLSC6pom6rRjdh4SZJEYupyMzem8e7vKZLclLfpHjlwSAXOUxtKxGXUiLqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.60.1",
-        "@typescript-eslint/types": "8.60.1",
-        "@typescript-eslint/typescript-estree": "8.60.1"
+        "@typescript-eslint/scope-manager": "8.61.0",
+        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/typescript-estree": "8.61.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -10774,9 +10774,9 @@
       }
     },
     "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/types": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.60.1.tgz",
-      "integrity": "sha512-4h0tY8ppCkdCzcrl2YM5M3my0xsE1Tf8om3owEu5oPWmXwkKRmk0j0LGDzYBGUcAlesEbxBhazqu/K4cu3Ug7w==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.61.0.tgz",
+      "integrity": "sha512-9QTQpZ5Iin4CdIodfbDQFSeiSJKidgYJYug1P9CC2xWgUTvlmixViqDZNciMjwLBZyJnG4tGmPl97rVAFb1AJg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10788,13 +10788,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.60.1.tgz",
-      "integrity": "sha512-EbGRQg4FhrmwLodl+t3JNAnXHWVr9Vp+Zl1QBZVPY4ByfkzIT8cX3K6QWODHtkIZqqJVEWvhHSx3v5PDHsaQag==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.61.0.tgz",
+      "integrity": "sha512-QVLZu3ZPQEE+HICQyAMZ2yLQhxf0meY/wx6Hx14YcTNj13JB3qHlX3lJ02L3fLGHgERRH71kvYDwiXIguT3AjQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.60.1",
+        "@typescript-eslint/types": "8.61.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -10806,9 +10806,9 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys/node_modules/@typescript-eslint/types": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.60.1.tgz",
-      "integrity": "sha512-4h0tY8ppCkdCzcrl2YM5M3my0xsE1Tf8om3owEu5oPWmXwkKRmk0j0LGDzYBGUcAlesEbxBhazqu/K4cu3Ug7w==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.61.0.tgz",
+      "integrity": "sha512-9QTQpZ5Iin4CdIodfbDQFSeiSJKidgYJYug1P9CC2xWgUTvlmixViqDZNciMjwLBZyJnG4tGmPl97rVAFb1AJg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -28255,16 +28255,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.60.1.tgz",
-      "integrity": "sha512-6m5hkkRAp8lKvhVpcprAIn5KkehQEh+47oHH2VGnExEh7dhNxXlg6GPAOIu6TxbVQxhebrJDvjl3020ooiWCMA==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.61.0.tgz",
+      "integrity": "sha512-8y31Rd0eGTrDKqhy6vT0HtzhN+YLjQizwX3aA3hPXP/ynSfnrBXcQY5IzsP9/DM7+klX4IUncZZjkchP0z+rUw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.60.1",
-        "@typescript-eslint/parser": "8.60.1",
-        "@typescript-eslint/typescript-estree": "8.60.1",
-        "@typescript-eslint/utils": "8.60.1"
+        "@typescript-eslint/eslint-plugin": "8.61.0",
+        "@typescript-eslint/parser": "8.61.0",
+        "@typescript-eslint/typescript-estree": "8.61.0",
+        "@typescript-eslint/utils": "8.61.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/ccip-tools-ts",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "CLI and library to interact with CCIP",
   "author": "Chainlink devs",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -28,18 +28,18 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@types/node": "25.9.1",
+    "@types/node": "25.9.2",
     "c8": "^11.0.0",
     "eslint": "^10.4.1",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-import-x": "^4.16.2",
-    "eslint-plugin-jsdoc": "^63.0.1",
+    "eslint-plugin-jsdoc": "^63.0.2",
     "eslint-plugin-prettier": "^5.5.6",
     "eslint-plugin-tsdoc": "^0.5.2",
     "glob": "13.0.6",
     "prettier": "3.8.3",
     "typescript": "6.0.3",
-    "typescript-eslint": "8.60.1",
+    "typescript-eslint": "8.61.0",
     "yaml": "2.9.0"
   },
   "overrides": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "ES2025",
+    "target": "ESNext",
     "module": "NodeNext",
-    "lib": ["ES2025"],
+    "lib": ["ESNext"],
     "types": ["node"],
     "strict": true,
     "skipLibCheck": true,


### PR DESCRIPTION
### Problem
Since 1.8.0, `getFee` runs a token-pool preflight (`checkSendMessage`, added in "validate token is connected to remote and has enough RL before send"). The preflight resolves a `TokenAdminRegistry` from the `router` address and looks up a token pool **per token in the message**.

This breaks **native value transfers**:
- Native is represented as `token: ZeroAddress`, which has **no token pool / registry entry / rate limiter** — so `getTokenPoolRemote(tokenPool!)` runs against an undefined pool.
- Integrators that send native via a helper contract (e.g. `EtherSenderReceiver`) pass that contract as `router`, so `getTokenAdminRegistryFor(router)` throws `CCIPContractNotRouterError` ("Not a Router, Ramp or expected contract").

Either way `getFee` throws for native, where 1.7.1 succeeded.

### Fix
Native value transfers aren't pool-managed, so they must be excluded from the token preflights:
- Add `protected isNativeAsset(token)` on `Chain` (default `false`), overridden in `EVMChain` (`token === ZeroAddress`).
- Skip native tokens in `checkSendMessage` and `checkExecute` before any registry/pool lookup.

For a native-only message the preflight loop is a no-op, the registry is never resolved, and `getFee` proceeds. ERC20 transfers over a real Router are unchanged.

### Scope / risk
- No change to fee computation or to ERC20 rate-limit behavior.
- `isNativeAsset` defaults to `false`, so non-EVM chains are unaffected unless they opt in.
