### PR TITLE
getLogs, CCTP v2 Proxy multi-target support

### DIFF
--- a/ccip-api-ref/package.json
+++ b/ccip-api-ref/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/ccip-api-ref",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "private": true,
   "description": "API Reference documentation for CCIP SDK and CLI",
   "scripts": {

--- a/ccip-cli/package.json
+++ b/ccip-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/ccip-cli",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "CCIP Command Line Interface, based on @chainlink/ccip-sdk",
   "author": "Chainlink devs",
   "license": "MIT",
@@ -42,7 +42,7 @@
     "!**/__mocks__"
   ],
   "devDependencies": {
-    "@types/node": "25.9.2",
+    "@types/node": "25.9.3",
     "@types/update-notifier": "^6.0.8",
     "@types/yargs": "17.0.35",
     "tsx": "4.22.4",
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "@aptos-labs/ts-sdk": "^6.3.1",
-    "@chainlink/ccip-sdk": "^1.9.1",
+    "@chainlink/ccip-sdk": "^1.9.2",
     "@coral-xyz/anchor": "^0.29.0",
     "@ethers-ext/signer-ledger": "^6.0.0-beta.1",
     "@inquirer/prompts": "8.5.2",

--- a/ccip-cli/src/index.ts
+++ b/ccip-cli/src/index.ts
@@ -28,7 +28,7 @@ Error.stackTraceLimit = 50 // show more stack frames for better debugging
 
 // generate:nofail
 // `const VERSION = '${require('./package.json').version}-${require('child_process').execSync('git rev-parse --short HEAD').toString().trim()}'`
-const VERSION = '1.9.1-c63fc08'
+const VERSION = '1.9.2-ae443e7'
 // generate:end
 
 const require = createRequire(import.meta.url)

--- a/ccip-sdk/package.json
+++ b/ccip-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/ccip-sdk",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "SDK/Library to interact with CCIP",
   "author": "Chainlink devs",
   "license": "MIT",
@@ -57,7 +57,7 @@
   },
   "devDependencies": {
     "@types/bn.js": "^5.2.0",
-    "@types/node": "25.9.2",
+    "@types/node": "25.9.3",
     "ethers-abitype": "1.0.3",
     "prool": "^0.2.4",
     "typescript": "6.0.3",

--- a/ccip-sdk/src/api/index.ts
+++ b/ccip-sdk/src/api/index.ts
@@ -61,7 +61,7 @@ export const DEFAULT_TIMEOUT_MS = 30000
 /** SDK version string for telemetry header */
 // generate:nofail
 // `export const SDK_VERSION = '${require('./package.json').version}-${require('child_process').execSync('git rev-parse --short HEAD').toString().trim()}'`
-export const SDK_VERSION = '1.9.1-c63fc08'
+export const SDK_VERSION = '1.9.2-ae443e7'
 // generate:end
 
 /** SDK telemetry header name */

--- a/ccip-sdk/src/evm/index.ts
+++ b/ccip-sdk/src/evm/index.ts
@@ -27,7 +27,7 @@ import {
 } from 'ethers'
 import type { TypedContract } from 'ethers-abitype'
 import { memoize } from 'micro-memoize'
-import type { PickDeep, SetFieldType, SetRequired, TupleOf } from 'type-fest'
+import type { PickDeep, SetFieldType, SetRequired } from 'type-fest'
 
 import {
   type BlockInfo,
@@ -2006,23 +2006,55 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
     const { typeAndVersion, previousPool } = await this.getTokenPoolConfig(tokenPool)
     const [type, version] = parseTypeAndVersion(typeAndVersion)
 
-    if (type === 'USDCTokenPoolProxy' && version >= CCIPVersion.V2_0) {
-      // USDC v2 proxys need to fetch most data from the implementation pool
-      tokenPool = previousPool!
-    }
-    // all versions share the same getSupportedChains() interface, and >=v1.5 getRemoteToken
+    // all versions share the same getSupportedChains() interface (except CCTPv2 Proxy), and >=v1.5 getRemoteToken
     const contract = new Contract(
       tokenPool,
       interfaces.TokenPool_v2_0,
       this.provider,
     ) as unknown as TypedContract<typeof TokenPool_2_0_ABI>
 
-    const supportedChains: Promise<NetworkInfo[]> = remoteChainSelector
-      ? Promise.resolve([networkInfo(remoteChainSelector)])
-      : (async () => {
-          const chains = await contract.getSupportedChains()
-          return chains.map(networkInfo)
-        })()
+    const cctpPools:
+      | CleanAddressable<
+          Awaited<ReturnType<TypedContract<typeof USDCTokenPoolProxy_2_0_ABI>['getPools']>>
+        >
+      | undefined =
+      type === 'USDCTokenPoolProxy' && version >= CCIPVersion.V2_0
+        ? await (async () => {
+            const proxy = new Contract(
+              tokenPool,
+              interfaces.USDCTokenPoolProxy_v2_0,
+              this.provider,
+            ) as unknown as TypedContract<typeof USDCTokenPoolProxy_2_0_ABI>
+            return resultToObject(proxy.getPools())
+          })()
+        : undefined
+    const supportedChainSelectors: Promise<readonly bigint[]> = remoteChainSelector
+      ? Promise.resolve([remoteChainSelector])
+      : cctpPools
+        ? (async () => {
+            // CCTP v2 Proxy need to query supported chains from the underlying pools
+            return [
+              ...new Set(
+                (
+                  await Promise.all(
+                    Object.values(cctpPools).map(async (pool) => {
+                      if (!pool || pool.match(/^(0x)?0*$/)) return []
+                      const contract = new Contract(
+                        pool,
+                        interfaces.TokenPool_v2_0,
+                        this.provider,
+                      ) as unknown as TypedContract<typeof TokenPool_2_0_ABI>
+                      return contract.getSupportedChains()
+                    }),
+                  )
+                ).flat(),
+              ),
+            ]
+          })()
+        : contract.getSupportedChains()
+    const supportedChains: Promise<NetworkInfo[]> = supportedChainSelectors.then((sels) =>
+      sels.map(networkInfo),
+    )
 
     const remoteTokens: Promise<string[]> = supportedChains.then((chains) =>
       Promise.all(
@@ -2063,7 +2095,16 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
     })
 
     const remoteRateLimits = supportedChains.then(
-      (chains): Promise<Readonly<TupleOf<2 | 4, RateLimiterBucket>>[]> => {
+      (
+        chains,
+      ): Promise<
+        {
+          outbound: RateLimiterBucket
+          inbound: RateLimiterBucket
+          fastOutbound?: RateLimiterBucket
+          fastInbound?: RateLimiterBucket
+        }[]
+      > => {
         if (version < CCIPVersion.V2_0) {
           // <v2 == v1.4..v1.6 TPs have compatible getCurrent(Out|In)boundRateLimiterState methods;
           // assumes v1 *AndProxy (i.e. non-null previousPool) has v1 previousPool
@@ -2077,7 +2118,72 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
               Promise.all([
                 contract.getCurrentOutboundRateLimiterState(chain.chainSelector),
                 contract.getCurrentInboundRateLimiterState(chain.chainSelector),
-              ] as const),
+              ] as const).then(([outbound, inbound]) => ({ outbound, inbound })),
+            ),
+          )
+        } else if (cctpPools) {
+          const proxy = new Contract(
+            tokenPool,
+            interfaces.USDCTokenPoolProxy_v2_0,
+            this.provider,
+          ) as unknown as TypedContract<typeof USDCTokenPoolProxy_2_0_ABI>
+          return Promise.all(
+            chains.map(
+              async (
+                chain,
+              ): Promise<{
+                outbound: RateLimiterBucket
+                inbound: RateLimiterBucket
+                fastOutbound?: RateLimiterBucket
+                fastInbound?: RateLimiterBucket
+              }> => {
+                const mechanism = Number(await proxy.getLockOrBurnMechanism(chain.chainSelector))
+                let poolAddr
+                switch (mechanism) {
+                  case 1 /* CCTP_V1 */: {
+                    poolAddr = cctpPools['cctpV1Pool']
+                    const contract = new Contract(
+                      poolAddr,
+                      interfaces.TokenPool_v1_6,
+                      this.provider,
+                    ) as unknown as TypedContract<typeof TokenPool_ABI>
+                    return Promise.all([
+                      contract.getCurrentOutboundRateLimiterState(chain.chainSelector),
+                      contract.getCurrentInboundRateLimiterState(chain.chainSelector),
+                    ] as const).then(([outbound, inbound]) => ({ outbound, inbound }))
+                  }
+                  case 3 /* LOCK_RELEASE (v1) */:
+                    poolAddr ??= cctpPools['siloedLockReleasePool']
+                  // fall through
+                  case 2 /* CCTP_V2 */:
+                    poolAddr ??= cctpPools['cctpV2Pool']
+                  // fall through
+                  case 4 /* CCV */: {
+                    poolAddr ??= cctpPools['cctpV2PoolWithCCV']
+                    const contract = new Contract(
+                      poolAddr,
+                      interfaces.TokenPool_v2_0,
+                      this.provider,
+                    ) as unknown as TypedContract<typeof TokenPool_2_0_ABI>
+
+                    return Promise.all([
+                      contract.getCurrentRateLimiterState(chain.chainSelector, false),
+                      contract.getCurrentRateLimiterState(chain.chainSelector, true),
+                    ] as const).then(([[outbound, inbound], [fastOutbound, fastInbound]]) => ({
+                      outbound,
+                      inbound,
+                      fastOutbound,
+                      fastInbound,
+                    }))
+                  }
+                  default:
+                    throw new CCIPTokenPoolChainConfigNotFoundError(
+                      tokenPool,
+                      previousPool!,
+                      chain.name,
+                    )
+                }
+              },
             ),
           )
         }
@@ -2086,9 +2192,12 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
             Promise.all([
               contract.getCurrentRateLimiterState(chain.chainSelector, false),
               contract.getCurrentRateLimiterState(chain.chainSelector, true),
-            ] as const).then(([[outbound, inbound], [fastOutbound, fastInbound]]) => {
-              return [outbound, inbound, fastOutbound, fastInbound] as const
-            }),
+            ] as const).then(([[outbound, inbound], [fastOutbound, fastInbound]]) => ({
+              outbound,
+              inbound,
+              fastOutbound,
+              fastInbound,
+            })),
           ),
         )
       },
@@ -2104,11 +2213,15 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
                 {
                   remoteToken: remoteTokens[i]!,
                   remotePools: remotePools[i]!,
-                  outboundRateLimiterState: toRateLimiterState(remoteRateLimits[i]![0]),
-                  inboundRateLimiterState: toRateLimiterState(remoteRateLimits[i]![1]),
-                  ...(remoteRateLimits[i]!.length === 4 && {
-                    fastOutboundRateLimiterState: toRateLimiterState(remoteRateLimits[i]![2]),
-                    fastInboundRateLimiterState: toRateLimiterState(remoteRateLimits[i]![3]),
+                  outboundRateLimiterState: toRateLimiterState(remoteRateLimits[i]!.outbound),
+                  inboundRateLimiterState: toRateLimiterState(remoteRateLimits[i]!.inbound),
+                  ...(remoteRateLimits[i]!.fastOutbound != null && {
+                    fastOutboundRateLimiterState: toRateLimiterState(
+                      remoteRateLimits[i]!.fastOutbound,
+                    ),
+                    fastInboundRateLimiterState: toRateLimiterState(
+                      remoteRateLimits[i]!.fastInbound!,
+                    ),
                   }),
                 },
               ] as const,

--- a/ccip-sdk/src/evm/logs.test.ts
+++ b/ccip-sdk/src/evm/logs.test.ts
@@ -467,13 +467,14 @@ describe('getEvmLogs — backfill invariants', () => {
     )
   })
 
-  it('A9 — tolerates -32602 from a lagging RPC: skips unservable chunks, no throw', async () => {
+  it('A9 — -32602 from a lagging RPC throws in backfill (no silent log loss)', async () => {
     const url = 'https://fake-bf-a9.example.com/rpc'
     // Simulate a round-robin proxy whose serving node lags: endBlock resolves to
     // 10000 (an ahead RPC), but getLogs rejects any chunk past head=5000 with
-    // -32602. streamLogs must skip those chunks and stream the servable ones.
+    // -32602. In backfill mode this must throw — silently skipping chunks would
+    // let callers checkpoint past blocks that were never read (silent log loss).
+    // Temporal activities retry from the same startBlock on a healthier node.
     const head = 5000
-    const calls: Array<{ fromBlock: number; toBlock: number }> = []
     const provider = {
       _getConnection: () => ({ url }),
       getBlock: async (tag: string | number) => ({
@@ -481,7 +482,6 @@ describe('getEvmLogs — backfill invariants', () => {
         timestamp: 0,
       }),
       getLogs: async (filter: { fromBlock: number; toBlock: number }) => {
-        calls.push({ fromBlock: filter.fromBlock, toBlock: filter.toBlock })
         if (filter.toBlock > head) {
           throw Object.assign(new Error('invalid block range params'), {
             error: { code: -32602 },
@@ -494,23 +494,18 @@ describe('getEvmLogs — backfill invariants', () => {
       once: (_e: unknown, cb: () => void) => setTimeout(cb, 0),
     } as unknown as JsonRpcApiProvider
 
-    const logs = await collect(
-      getEvmLogs(
-        { startBlock: 1, endBlock: 10_000, page: 1000 },
-        { provider, getBlockInfo, logger: silentLogger },
-      ),
-    )
-
-    // Chunks [1..5000] (toBlock <= head) yield logs; [5001..10000] are skipped.
-    assert.equal(logs.length, 5, 'only the 5 servable chunks (up to head) yield logs')
-    assert.ok(
-      logs.every((l) => l.blockNumber <= head),
-      'no logs should come from blocks past the serving RPC head',
-    )
-    // The unservable chunks were attempted (and skipped), not throwing.
-    assert.ok(
-      calls.some((c) => c.toBlock > head),
-      'expected the unservable chunks to have been attempted',
+    await assert.rejects(
+      () =>
+        collect(
+          getEvmLogs(
+            { startBlock: 1, endBlock: 10_000, page: 1000 },
+            { provider, getBlockInfo, logger: silentLogger },
+          ),
+        ),
+      (err: Error) => {
+        assert.equal((err as { error?: { code?: number } }).error?.code, -32602)
+        return true
+      },
     )
   })
 

--- a/ccip-sdk/src/evm/logs.ts
+++ b/ccip-sdk/src/evm/logs.ts
@@ -138,20 +138,14 @@ async function* streamLogs(
       yield* await provider.getLogs(filter_)
       cursor = chunkTo + 1 // advance only after a chunk succeeds
     } catch (err) {
-      // Invalid/inverted range for the serving RPC — e.g. a round-robin proxy
-      // landed on a downstream node whose head lags behind this chunk, so
-      // fromBlock/toBlock sit beyond its tip. Benign: skip the chunk as empty and
-      // move on (the watch loop re-scans the tail on a later tick).
-      if (isInvalidBlockRangesError(err)) {
-        logger.debug('evm getLogs: invalid block range, skipping chunk', {
-          fromBlock: cursor,
-          toBlock: chunkTo,
-          url,
-        })
-        cursor = chunkTo + 1
-        continue
-      }
-
+      // An invalid/inverted range (-32602) — e.g. a round-robin proxy landed on a
+      // downstream node whose head lags behind this chunk — is deliberately NOT
+      // swallowed here. In a bounded (non-watch) backfill there is no later tick to
+      // re-scan the tail, so skipping the chunk as empty would let the caller
+      // checkpoint past blocks that were never actually read (silent log loss).
+      // Let it bubble: the activity fails and Temporal retries from the same
+      // startBlock, hitting a healthier node. parseLogRangeError returns null for
+      // -32602, so the throw below covers it.
       const rangeInfo = parseLogRangeError(err)
       if (rangeInfo === null) throw err
 

--- a/ccip-sdk/src/requests.ts
+++ b/ccip-sdk/src/requests.ts
@@ -72,9 +72,9 @@ export function normalizeDeep<T extends Record<string, unknown>>(
         v && decodeAddress((typeof v === 'bigint' ? v.toString() : v) as BytesLike, opts.destFamily)
       )
     if (k?.match(/((source.*address)|sender|issuer|origin|onramp|(feetoken$)|(token.*address$))/i))
-      return decodeAddress(
-        (typeof v === 'bigint' ? v.toString() : v) as BytesLike,
-        opts.sourceFamily,
+      return (
+        v &&
+        decodeAddress((typeof v === 'bigint' ? v.toString() : v) as BytesLike, opts.sourceFamily)
       )
     if (
       v instanceof Uint8Array ||

--- a/ccip-sdk/src/selectors.ts
+++ b/ccip-sdk/src/selectors.ts
@@ -1686,6 +1686,12 @@ const SELECTORS: Selectors = {
     network_type: 'TESTNET',
     family: 'EVM',
   },
+  '2026041005': {
+    selector: 13879014182901017172n,
+    name: 'dtcc-mainnet-appchain',
+    network_type: 'MAINNET',
+    family: 'EVM',
+  },
   '2494104990': {
     selector: 13231703482326770598n,
     name: 'tron-testnet-shasta-evm',

--- a/ccip-sdk/src/solana/index.ts
+++ b/ccip-sdk/src/solana/index.ts
@@ -404,7 +404,8 @@ export class SolanaChain extends Chain<typeof ChainFamily.Solana> {
       commitment: 'confirmed',
       maxSupportedTransactionVersion: 0,
     })
-    if (!tx) throw new CCIPTransactionNotFoundError(hash)
+    if (!tx)
+      throw new CCIPTransactionNotFoundError(hash, { context: { network: this.network.name } })
     if (tx.blockTime) {
       ;(this.getBlockInfo as Memoized<typeof this.getBlockInfo, { async: true }>).cache.set(
         [tx.slot],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chainlink/ccip-tools-ts",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chainlink/ccip-tools-ts",
-      "version": "1.9.1",
+      "version": "1.9.2",
       "license": "MIT",
       "workspaces": [
         "ccip-sdk",
@@ -15,7 +15,7 @@
       ],
       "devDependencies": {
         "@eslint/js": "^10.0.1",
-        "@types/node": "25.9.2",
+        "@types/node": "25.9.3",
         "c8": "^11.0.0",
         "eslint": "^10.4.1",
         "eslint-config-prettier": "^10.1.8",
@@ -32,7 +32,7 @@
     },
     "ccip-api-ref": {
       "name": "@chainlink/ccip-api-ref",
-      "version": "1.9.1",
+      "version": "1.9.2",
       "dependencies": {
         "@chainlink/ccip-sdk": "*",
         "@chainlink/design-system": "^0.2.8",
@@ -65,11 +65,11 @@
     },
     "ccip-cli": {
       "name": "@chainlink/ccip-cli",
-      "version": "1.9.1",
+      "version": "1.9.2",
       "license": "MIT",
       "dependencies": {
         "@aptos-labs/ts-sdk": "^6.3.1",
-        "@chainlink/ccip-sdk": "^1.9.1",
+        "@chainlink/ccip-sdk": "^1.9.2",
         "@coral-xyz/anchor": "^0.29.0",
         "@ethers-ext/signer-ledger": "^6.0.0-beta.1",
         "@inquirer/prompts": "8.5.2",
@@ -91,7 +91,7 @@
         "ccip-cli": "dist/index.js"
       },
       "devDependencies": {
-        "@types/node": "25.9.2",
+        "@types/node": "25.9.3",
         "@types/update-notifier": "^6.0.8",
         "@types/yargs": "17.0.35",
         "tsx": "4.22.4",
@@ -201,7 +201,7 @@
     },
     "ccip-sdk": {
       "name": "@chainlink/ccip-sdk",
-      "version": "1.9.1",
+      "version": "1.9.2",
       "license": "MIT",
       "dependencies": {
         "@aptos-labs/ts-sdk": "^6.3.1",
@@ -226,7 +226,7 @@
       },
       "devDependencies": {
         "@types/bn.js": "^5.2.0",
-        "@types/node": "25.9.2",
+        "@types/node": "25.9.3",
         "ethers-abitype": "1.0.3",
         "prool": "^0.2.4",
         "typescript": "6.0.3",
@@ -10143,9 +10143,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.9.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.2.tgz",
-      "integrity": "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==",
+      "version": "25.9.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
+      "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
       "license": "MIT",
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/ccip-tools-ts",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "CLI and library to interact with CCIP",
   "author": "Chainlink devs",
   "license": "MIT",
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@types/node": "25.9.2",
+    "@types/node": "25.9.3",
     "c8": "^11.0.0",
     "eslint": "^10.4.1",
     "eslint-config-prettier": "^10.1.8",


### PR DESCRIPTION
- some small getLogs improvements
- CCTP v2 Proxy support for multiple target underlying Pools (e.g. V1)
- bump v1.9.2