### PR TITLE
fix: EVM.getTokenAdminRegistry for on non-ethereum-connected networks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - SDK: deprecate `bigIntReviver`/`bigIntReplacer` in favor of `jsonParse`/`jsonStringify` helpers
 - SDK: fix Hedera's tinybar to weibar fee conversion when `generateUnsignedSendMessage`
+- SDK: fix `EVM.getTokenAdminRegistryFor` routers on networks NOT connected to some Ethereum chain
 
 ## [1.9.0] - 2026-06-18
 

--- a/ccip-api-ref/package.json
+++ b/ccip-api-ref/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/ccip-api-ref",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "private": true,
   "description": "API Reference documentation for CCIP SDK and CLI",
   "scripts": {

--- a/ccip-cli/package.json
+++ b/ccip-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/ccip-cli",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "CCIP Command Line Interface, based on @chainlink/ccip-sdk",
   "author": "Chainlink devs",
   "license": "MIT",
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "@aptos-labs/ts-sdk": "^6.3.1",
-    "@chainlink/ccip-sdk": "^1.10.0",
+    "@chainlink/ccip-sdk": "^1.10.1",
     "@coral-xyz/anchor": "^0.29.0",
     "@ethers-ext/signer-ledger": "^6.0.0-beta.1",
     "@inquirer/prompts": "8.5.2",

--- a/ccip-cli/src/index.ts
+++ b/ccip-cli/src/index.ts
@@ -28,7 +28,7 @@ Error.stackTraceLimit = 50 // show more stack frames for better debugging
 
 // generate:nofail
 // `const VERSION = '${require('./package.json').version}-${require('child_process').execSync('git rev-parse --short HEAD').toString().trim()}'`
-const VERSION = '1.10.0-c58294d'
+const VERSION = '1.10.1-e1453cd'
 // generate:end
 
 const require = createRequire(import.meta.url)

--- a/ccip-sdk/package.json
+++ b/ccip-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/ccip-sdk",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "SDK/Library to interact with CCIP",
   "author": "Chainlink devs",
   "license": "MIT",

--- a/ccip-sdk/src/api/index.ts
+++ b/ccip-sdk/src/api/index.ts
@@ -61,7 +61,7 @@ export const DEFAULT_TIMEOUT_MS = 30000
 /** SDK version string for telemetry header */
 // generate:nofail
 // `export const SDK_VERSION = '${require('./package.json').version}-${require('child_process').execSync('git rev-parse --short HEAD').toString().trim()}'`
-export const SDK_VERSION = '1.10.0-c58294d'
+export const SDK_VERSION = '1.10.1-e1453cd'
 // generate:end
 
 /** SDK telemetry header name */

--- a/ccip-sdk/src/chain.ts
+++ b/ccip-sdk/src/chain.ts
@@ -1301,6 +1301,7 @@ export abstract class Chain<F extends ChainFamily = ChainFamily> {
    * Needed to map a source token to its dest counterparts.
    *
    * @param address - Contract address (OnRamp, Router, etc.)
+   * @param destChainSelector - Some dest chain connected to this address/router
    * @returns Promise resolving to TokenAdminRegistry address
    *
    * @example Get token registry
@@ -1309,7 +1310,7 @@ export abstract class Chain<F extends ChainFamily = ChainFamily> {
    * console.log(`Registry: ${registry}`)
    * ```
    */
-  abstract getTokenAdminRegistryFor(address: string): Promise<string>
+  abstract getTokenAdminRegistryFor(address: string, destChainSelector?: bigint): Promise<string>
 
   /**
    * Pre-flight check if the token transfers in a message is supported for given lane, and have enough rate limit
@@ -1332,7 +1333,7 @@ export abstract class Chain<F extends ChainFamily = ChainFamily> {
       // and `router` may be a sender helper (e.g. EtherSenderReceiver) rather than a
       // Router/Ramp — skip the token-pool preflight for them.
       if (!token || token.match(/^(0x)?0*$/i)) continue
-      registry ??= await this.getTokenAdminRegistryFor(router)
+      registry ??= await this.getTokenAdminRegistryFor(router, destChainSelector)
       const { tokenPool } = await this.getRegistryTokenConfig(registry, token)
       const remote = await this.getTokenPoolRemote(tokenPool!, destChainSelector)
       if (!remote.outboundRateLimiterState) continue
@@ -1776,7 +1777,7 @@ export abstract class Chain<F extends ChainFamily = ChainFamily> {
 
     if (opts.token) {
       const { tokenPool } = await this.getRegistryTokenConfig(
-        await this.getTokenAdminRegistryFor(onRamp),
+        await this.getTokenAdminRegistryFor(onRamp, opts.destChainSelector),
         opts.token,
       )
       if (tokenPool) {

--- a/ccip-sdk/src/evm/index.ts
+++ b/ccip-sdk/src/evm/index.ts
@@ -1074,36 +1074,41 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
    * @param address - Router or OnRamp contract address.
    * @returns OnRamp contract address.
    */
-  async _getSomeOnRampFor(address: string): Promise<string> {
+  async _getSomeOnRampFor(address: string, destChainSelector?: bigint): Promise<string> {
     const [type, , typeAndVersion] = await this.typeAndVersion(address)
     if (type.includes('OnRamp')) return address
     else if (type !== 'Router') throw new CCIPContractNotRouterError(address, typeAndVersion)
     // when given a router, we take any onRamp we can find, as usually they all use same registry
-    const someOtherNetwork =
-      this.network.networkType === NetworkType.Testnet
-        ? this.network.name === 'ethereum-testnet-sepolia'
-          ? 'avalanche-testnet-fuji'
-          : 'ethereum-testnet-sepolia'
-        : this.network.name === 'ethereum-mainnet'
-          ? 'avalanche-mainnet'
-          : 'ethereum-mainnet'
-    return this.getOnRampForRouter(address, networkInfo(someOtherNetwork).chainSelector)
+    if (!destChainSelector) {
+      // usually, we're handed a destChainSelector hint;
+      // but if not, assume this router is connected to one of the ethereum networks (or to Avalanche, if Ethereum)
+      const someOtherNetwork =
+        this.network.networkType === NetworkType.Testnet
+          ? this.network.name === 'ethereum-testnet-sepolia'
+            ? 'avalanche-testnet-fuji'
+            : 'ethereum-testnet-sepolia'
+          : this.network.name === 'ethereum-mainnet'
+            ? 'avalanche-mainnet'
+            : 'ethereum-mainnet'
+      destChainSelector = networkInfo(someOtherNetwork).chainSelector
+    }
+    return this.getOnRampForRouter(address, destChainSelector)
   }
 
   /**
    * {@inheritDoc Chain.getTokenAdminRegistryFor}
    * @throws {@link CCIPContractNotRouterError} if address is not a Router, OnRamp, or OffRamp
    */
-  async getTokenAdminRegistryFor(address: string): Promise<string> {
+  async getTokenAdminRegistryFor(address: string, destChainSelector?: bigint): Promise<string> {
     const [type, version] = await this.typeAndVersion(address)
     if (type === 'TokenAdminRegistry') {
       return address
     } else if (type.includes('TokenPool')) {
       address = (await this.getTokenPoolConfig(address)).router
-      return this.getTokenAdminRegistryFor(address)
+      return this.getTokenAdminRegistryFor(address, destChainSelector)
     } else if (type === 'Router') {
-      address = await this._getSomeOnRampFor(address)
-      return this.getTokenAdminRegistryFor(address)
+      address = await this._getSomeOnRampFor(address, destChainSelector)
+      return this.getTokenAdminRegistryFor(address, destChainSelector)
     } else if (!type.includes('Ramp')) {
       const [, , typeAndVersion] = await this.typeAndVersion(address)
       throw new CCIPContractNotRouterError(address, typeAndVersion)

--- a/ccip-sdk/src/gas.ts
+++ b/ccip-sdk/src/gas.ts
@@ -111,7 +111,7 @@ export async function sourceToDestTokenAddresses<S extends { token: string }>({
     destTokenAddress: string
   }
 > {
-  const tokenAdminRegistry = await source.getTokenAdminRegistryFor(onRamp)
+  const tokenAdminRegistry = await source.getTokenAdminRegistryFor(onRamp, destChainSelector)
   const sourceTokenAddress = sourceTokenAmount.token
   const { tokenPool: sourcePoolAddress } = await source.getRegistryTokenConfig(
     tokenAdminRegistry,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chainlink/ccip-tools-ts",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chainlink/ccip-tools-ts",
-      "version": "1.10.0",
+      "version": "1.10.1",
       "license": "MIT",
       "workspaces": [
         "ccip-sdk",
@@ -32,7 +32,7 @@
     },
     "ccip-api-ref": {
       "name": "@chainlink/ccip-api-ref",
-      "version": "1.10.0",
+      "version": "1.10.1",
       "dependencies": {
         "@chainlink/ccip-sdk": "*",
         "@chainlink/design-system": "^0.2.8",
@@ -65,11 +65,11 @@
     },
     "ccip-cli": {
       "name": "@chainlink/ccip-cli",
-      "version": "1.10.0",
+      "version": "1.10.1",
       "license": "MIT",
       "dependencies": {
         "@aptos-labs/ts-sdk": "^6.3.1",
-        "@chainlink/ccip-sdk": "^1.10.0",
+        "@chainlink/ccip-sdk": "^1.10.1",
         "@coral-xyz/anchor": "^0.29.0",
         "@ethers-ext/signer-ledger": "^6.0.0-beta.1",
         "@inquirer/prompts": "8.5.2",
@@ -201,7 +201,7 @@
     },
     "ccip-sdk": {
       "name": "@chainlink/ccip-sdk",
-      "version": "1.10.0",
+      "version": "1.10.1",
       "license": "MIT",
       "dependencies": {
         "@aptos-labs/ts-sdk": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/ccip-tools-ts",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "CLI and library to interact with CCIP",
   "author": "Chainlink devs",
   "license": "MIT",


### PR DESCRIPTION
- We used to assume every EVM network was connected to ethereum-mainnet/sepolia OR was one of them
- This broke on some networks which do NOT have such lane configured
- Fix is to pass `destChainSelector` hint down on every `getTokenAdminRegistryFor`/`_getSomeOnRampFor` call, and use that when/if available, and keep the assumption above only if not hinted
- Bump hotfix v1.10.1