### PR TITLE
feat(evm): pre-send CCV/finality preflight via getCCVsForMessage

### DIFF
--- a/ccip-cli/src/commands/send.ts
+++ b/ccip-cli/src/commands/send.ts
@@ -30,6 +30,7 @@ import {
   decodeAddress,
   estimateReceiveExecution,
   getDataBytes,
+  getRequiredCCVs,
   jsonParse,
   jsonStringify,
   networkInfo,
@@ -143,6 +144,12 @@ export const builder = (yargs: Argv) =>
         type: 'boolean',
         describe: 'Print gas estimate and exit',
         implies: 'estimate-gas-limit',
+      },
+      'only-ccvs': {
+        type: 'boolean',
+        describe:
+          'Print the destination-required CCV set (requiredCCVs/optionalCCVs/threshold) and exit. ' +
+          'A disallowed finality surfaces as an error.',
       },
       'approve-max': {
         type: 'boolean',
@@ -314,6 +321,32 @@ async function sendMessage(
     ...(!!argv.tokenReceiver && { tokenReceiver: argv.tokenReceiver }),
     ...(!!accounts && { accounts, accountIsWritableBitmap }), // accounts also used as Sui receiverObjectIds
     ...parseExtraArgs(argv.extra),
+  }
+
+  if (argv.onlyCcvs) {
+    // --only-ccvs: read the destination-required CCV set (and finality verdict) and exit; no send.
+    const dest = await getChain(destNetwork.chainSelector)
+    if (!walletAddress) {
+      try {
+        ;[walletAddress, wallet] = await loadChainWallet(source, argv, logger)
+      } catch {
+        // sender is optional here; omitting it yields the lane-default (not sender-scoped) CCV view
+      }
+    }
+    const ccvs = await getRequiredCCVs({
+      source,
+      dest,
+      routerOrRamp: router,
+      message: { sender: walletAddress, receiver, data, tokenAmounts, ...extraArgs },
+    })
+    if (argv.format === Format.json) {
+      output.write(jsonStringify(ccvs, 2))
+    } else {
+      output.write('requiredCCVs      :', ccvs.requiredCCVs)
+      output.write('optionalCCVs      :', ccvs.optionalCCVs)
+      output.write('optionalThreshold :', ccvs.optionalThreshold)
+    }
+    return
   }
 
   if (argv.estimateGasLimit == null || argv.estimateGasLimit > -100)

--- a/ccip-sdk/src/chain.ts
+++ b/ccip-sdk/src/chain.ts
@@ -28,7 +28,7 @@ import type {
   SVMExtraArgsV1,
   SuiExtraArgsV1,
 } from './extra-args.ts'
-import type { EstimateMessageInput } from './gas.ts'
+import type { EstimateMessageInput, GetRequiredCCVsMessage, GetRequiredCCVsResult } from './gas.ts'
 import type { LeafHasher } from './hasher/common.ts'
 import { decodeMessageV1 } from './messages.ts'
 import { type ChainFamily, type NetworkInfo, type NetworkType, networkInfo } from './networks.ts'
@@ -2294,6 +2294,20 @@ export abstract class Chain<F extends ChainFamily = ChainFamily> {
         }
       | { messageId: string },
   ): Promise<number>
+
+  /**
+   * Resolve the CCV set the destination OffRamp will require for a candidate message, and whether its
+   * finality is accepted (a rejection throws `CCIPFinalityNotAllowedError`). A read via the
+   * `getCCVsForMessage` resolver; EVM destinations only. The set is informative and sender-scoped.
+   *
+   * @param opts - Destination OffRamp (v2.0) address and the candidate message
+   *   ({@link GetRequiredCCVsMessage}).
+   * @returns `{ requiredCCVs, optionalCCVs, optionalThreshold }`.
+   */
+  getRequiredCCVs?(opts: {
+    offRamp: string
+    message: GetRequiredCCVsMessage
+  }): Promise<GetRequiredCCVsResult>
 }
 
 /**

--- a/ccip-sdk/src/evm/finality-preflight.test.ts
+++ b/ccip-sdk/src/evm/finality-preflight.test.ts
@@ -1,17 +1,19 @@
 import assert from 'node:assert/strict'
 import { after, beforeEach, describe, it, mock } from 'node:test'
 
-import { getAddress, hexlify, randomBytes, toBeHex } from 'ethers'
+import { getAddress, hexlify, makeError, randomBytes, toBeHex } from 'ethers'
 
 import { interfaces } from './const.ts'
 import { EVMChain, isTokenOnlyEstimate } from './index.ts'
-import { CCIPFinalityNotAllowedError } from '../errors/index.ts'
+import { CCIPFinalityNotAllowedError, CCIPVersionUnsupportedError } from '../errors/index.ts'
+import { decodeFinalityAllowed } from '../extra-args.ts'
 import { ChainFamily, NetworkType } from '../networks.ts'
 import { CCIPVersion } from '../types.ts'
 
-const recv = interfaces.Receiver_v2_0
-const SUPPORTS_SEL = recv.getFunction('supportsInterface')!.selector
-const CCV_SEL = recv.getFunction('getCCVsAndFinalityConfig')!.selector
+// Under the authoritative preflight, estimateReceiveExecution resolves finality + CCVs via the OffRamp's
+// getCCVsForMessage(bytes) view (through EVMChain.getRequiredCCVs), not by reading the receiver directly.
+const offRampIface = interfaces.OffRamp_v2_0
+const GET_CCVS_SEL = offRampIface.getFunction('getCCVsForMessage')!.selector
 
 const SOURCE_SELECTOR = 16015286601757825753n // ethereum-sepolia
 const DEST_SELECTOR = 10344971235874465080n // base-sepolia
@@ -53,13 +55,32 @@ function makeChain(finalityConfig: string) {
   const provider = {
     // eth_estimateGas (finder probe + final ccipReceive sim) always returns a gas value
     send: mock.fn(async () => toBeHex(44_000)),
-    // selector-aware eth_call: supportsInterface=true, getCCVsAndFinalityConfig=([],[],0,cfg)
+    // selector-aware eth_call that mirrors the OffRamp getCCVsForMessage resolver: revert
+    // InvalidRequestedFinality when the receiver is finalized-only (depth 0), else return a required CCV
+    // set. All finality-gated cases here request depth 1, so depth-1 configs accept and depth-0 rejects.
     call: mock.fn(async (tx: { data?: string }) => {
       const data = tx.data ?? '0x'
       const sel = data.slice(0, 10)
-      if (sel === SUPPORTS_SEL) return recv.encodeFunctionResult('supportsInterface', [true])
-      if (sel === CCV_SEL)
-        return recv.encodeFunctionResult('getCCVsAndFinalityConfig', [[], [], 0, finalityConfig])
+      if (sel === GET_CCVS_SEL) {
+        if (decodeFinalityAllowed(finalityConfig).finalityDepth === 0) {
+          throw makeError('execution reverted', 'CALL_EXCEPTION', {
+            action: 'call',
+            data: offRampIface.encodeErrorResult('InvalidRequestedFinality', [
+              '0x00000001',
+              finalityConfig,
+            ]),
+            reason: null,
+            transaction: { to: null, data, from: undefined },
+            invocation: null,
+            revert: null,
+          })
+        }
+        return offRampIface.encodeFunctionResult('getCCVsForMessage', [
+          [getAddress(hexlify(randomBytes(20)))],
+          [],
+          0,
+        ])
+      }
       return toBeHex(0n, 32) // balanceOf / totalSupply => 0
     }),
   }
@@ -206,6 +227,81 @@ describe('EVMChain.estimateReceiveExecution — token-only finality skip', () =>
     await assert.rejects(
       () => chain.estimateReceiveExecution({ messageId: hexlify(randomBytes(32)) }),
       CCIPFinalityNotAllowedError,
+    )
+  })
+})
+
+// ============================================================================
+// 3) Best-effort: a non-finality resolver failure (v1 lane / transient RPC) is
+//    swallowed so the gas estimate still returns; the finality gate still throws.
+// ============================================================================
+describe('EVMChain.estimateReceiveExecution — finality preflight is best-effort', () => {
+  after(() => mock.restoreAll())
+
+  function makeChainFailingCCVs() {
+    const provider = {
+      send: mock.fn(async () => toBeHex(44_000)),
+      call: mock.fn(async (tx: { data?: string }) => {
+        const sel = (tx.data ?? '0x').slice(0, 10)
+        if (sel === GET_CCVS_SEL)
+          // non-finality revert (unknown selector) — stands in for a v1 lane / transient failure
+          throw makeError('execution reverted', 'CALL_EXCEPTION', {
+            action: 'call',
+            data: '0xdeadbeef',
+            reason: null,
+            transaction: { to: null, data: tx.data ?? '0x', from: undefined },
+            invocation: null,
+            revert: null,
+          })
+        return toBeHex(0n, 32)
+      }),
+    }
+    const chain = Object.create(EVMChain.prototype) as EVMChain
+    Object.assign(chain, {
+      provider,
+      logger: { debug() {}, info() {}, warn() {}, error() {} },
+      network: {
+        name: 'base-sepolia',
+        chainId: 84532,
+        chainSelector: DEST_SELECTOR,
+        family: ChainFamily.EVM,
+        networkType: NetworkType.Testnet,
+      },
+      getRouterForOffRamp: mock.fn(async () => getAddress(hexlify(randomBytes(20)))),
+    })
+    return chain
+  }
+
+  it('swallows a non-finality resolver failure and STILL returns a gas estimate', async () => {
+    const chain = makeChainFailingCCVs()
+    const offRamp = getAddress(hexlify(randomBytes(20)))
+    // data-only at fast finality: the finality gate would run, but the resolver fails for a
+    // non-finality reason → must NOT throw; the estimate proceeds.
+    const result = await chain.estimateReceiveExecution({
+      offRamp,
+      message: baseMessage(DATA_ONLY, 1),
+    })
+    assert.equal(typeof result, 'number')
+  })
+
+  it('getRequiredCCVs throws CCIPVersionUnsupportedError on a non-v2 OffRamp', async () => {
+    const chain = makeChainFailingCCVs()
+    chain.typeAndVersion = mock.fn(async () => [
+      'EVM2EVMOffRamp',
+      CCIPVersion.V1_5,
+      'EVM2EVMOffRamp 1.5.0',
+    ]) as unknown as EVMChain['typeAndVersion']
+    await assert.rejects(
+      () =>
+        chain.getRequiredCCVs({
+          offRamp: getAddress(hexlify(randomBytes(20))),
+          message: {
+            sourceChainSelector: SOURCE_SELECTOR,
+            receiver: getAddress(hexlify(randomBytes(20))),
+            finality: 2,
+          },
+        }),
+      CCIPVersionUnsupportedError,
     )
   })
 })

--- a/ccip-sdk/src/evm/index.ts
+++ b/ccip-sdk/src/evm/index.ts
@@ -25,6 +25,7 @@ import {
   isHexString,
   randomBytes,
   toBeHex,
+  zeroPadValue,
 } from 'ethers'
 import type { TypedContract } from 'ethers-abitype'
 import { memoize } from 'micro-memoize'
@@ -66,13 +67,16 @@ import {
 } from '../errors/index.ts'
 import {
   type ExtraArgs,
-  type FinalityAllowed,
   type FinalityRequested,
   decodeFinalityAllowed,
   encodeFinality,
 } from '../extra-args.ts'
 import { fetchProfileForUrl } from '../fetch.ts'
-import { getDestTokenAmount } from '../gas.ts'
+import {
+  type GetRequiredCCVsMessage,
+  type GetRequiredCCVsResult,
+  getDestTokenAmount,
+} from '../gas.ts'
 import type { LeafHasher } from '../hasher/common.ts'
 import { decodeMessageV1 } from '../messages.ts'
 import { type NetworkInfo, ChainFamily, NetworkType, networkInfo } from '../networks.ts'
@@ -105,7 +109,6 @@ import {
   parseTypeAndVersion,
 } from '../utils.ts'
 import type Token_ABI from './abi/BurnMintERC677Token.ts'
-import type Receiver_2_0_ABI from './abi/CCIPReceiver_2_0.ts'
 import type CCTPVerifier_2_0_ABI from './abi/CCTPVerifier_2_0.ts'
 import CommitStore_1_2_ABI from './abi/CommitStore_1_2.ts'
 import CommitStore_1_5_ABI from './abi/CommitStore_1_5.ts'
@@ -143,6 +146,7 @@ import {
 import { estimateExecGas } from './gas.ts'
 import { getV12LeafHasher, getV16LeafHasher } from './hasher.ts'
 import { type EVMEndBlockTag, getEvmLogs } from './logs.ts'
+import { type MessageV1TokenTransfer, encodeMessageV1 } from './messageCodec.ts'
 import type { CCIPMessage_V1_6_EVM, CCIPMessage_V2_0, CleanAddressable } from './messages.ts'
 import { encodeEVMOffchainTokenData } from './offchain.ts'
 import { type UnsignedEVMTx, resultToObject } from './types.ts'
@@ -2384,6 +2388,88 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
     yield* super.getExecutionReceipts(opts_)
   }
 
+  /**
+   * Resolve the CCVs the destination OffRamp will require for a candidate message, and whether its
+   * finality is accepted, via the on-chain `getCCVsForMessage(bytes)` view (a read; no send). Builds the
+   * MessageV1 candidate with {@link encodeMessageV1}; a rejected finality throws
+   * {@link CCIPFinalityNotAllowedError} (decoded from the resolver's `InvalidRequestedFinality`).
+   *
+   * The required set is sender-scoped: pass the real `sender`, or an omitted one yields the lane-default
+   * view. CCIP v2.0 lanes only.
+   *
+   * @param opts - Destination OffRamp (v2.0) address and the candidate message.
+   * @returns `{ requiredCCVs, optionalCCVs, optionalThreshold }`.
+   */
+  override async getRequiredCCVs(opts: {
+    offRamp: string
+    message: GetRequiredCCVsMessage
+  }): Promise<GetRequiredCCVsResult> {
+    const { offRamp, message } = opts
+    const firstToken = message.destTokenAmounts?.[0]
+    let tokenTransfer: MessageV1TokenTransfer | undefined
+    if (firstToken) {
+      const destTokenAddress = firstToken.token ?? firstToken.destTokenAddress
+      if (destTokenAddress != null) {
+        tokenTransfer = {
+          amount: firstToken.amount,
+          destTokenAddress: getAddress(destTokenAddress),
+          extraData: firstToken.extraData,
+        }
+      }
+    }
+    const encoded = encodeMessageV1({
+      sourceChainSelector: message.sourceChainSelector,
+      destChainSelector: this.network.chainSelector,
+      ccipReceiveGasLimit: Number(message.ccipReceiveGasLimit ?? message.gasLimit ?? 0),
+      finality: toBeHex(encodeFinality(message.finality ?? 'finalized'), 4),
+      // Source-side addresses are abi.encode(address) (32 bytes); dest-side receiver is raw 20 bytes.
+      sender: message.sender ? zeroPadValue(getAddress(message.sender), 32) : ZeroHash,
+      receiver: getAddress(message.receiver),
+      data: message.data != null ? hexlify(message.data) : '0x',
+      tokenTransfer,
+    })
+    const contract = new Contract(
+      offRamp,
+      interfaces.OffRamp_v2_0,
+      this.provider,
+    ) as unknown as TypedContract<typeof OffRamp_2_0_ABI>
+    try {
+      const ccvs = await contract.getCCVsForMessage(encoded)
+      const [requiredCCVs, optionalCCVs, optionalThreshold] = ccvs.map(
+        resultToObject,
+      ) as unknown as CleanAddressable<typeof ccvs>
+      return { requiredCCVs, optionalCCVs, optionalThreshold: Number(optionalThreshold) }
+    } catch (err) {
+      if (isError(err, 'CALL_EXCEPTION')) {
+        const parsed = err.data ? interfaces.OffRamp_v2_0.parseError(err.data) : null
+        if ((err.revert?.name ?? parsed?.name) === 'InvalidRequestedFinality') {
+          const args = err.revert?.args ?? parsed?.args
+          const receiverAllowed = args ? String(args[1]) : '0x00000000'
+          throw new CCIPFinalityNotAllowedError(
+            message.finality ?? 'finalized',
+            decodeFinalityAllowed(receiverAllowed),
+            {
+              context: {
+                source: networkInfo(message.sourceChainSelector).name,
+                sender: message.sender,
+                dest: this.network.name,
+                receiver: message.receiver,
+              },
+            },
+          )
+        }
+        // getCCVsForMessage exists only on a v2.0 OffRamp; an older OffRamp reverts with no data.
+        // Probe the version to surface a clear error rather than a raw CALL_EXCEPTION.
+        const tv = await this.typeAndVersion(offRamp).catch(() => null)
+        if (tv && (!tv[0].includes('OffRamp') || tv[1] < CCIPVersion.V2_0))
+          throw new CCIPVersionUnsupportedError(tv[2] || offRamp, {
+            context: { offRamp, dest: this.network.name },
+          })
+      }
+      throw err
+    }
+  }
+
   /** {@inheritDoc Chain.estimateReceiveExecution} */
   override async estimateReceiveExecution(
     opts: Parameters<NonNullable<Chain['estimateReceiveExecution']>>[0],
@@ -2424,61 +2510,24 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
       }
     }
 
-    // v2: check allowed finality — but SKIP for token-only transfers (empty data + no receive-gas),
-    // mirroring the OffRamp which delegates finality to the pool and does not consult the receiver
-    // for token-only transfers (see isTokenOnlyEstimate / OffRamp._isTokenOnlyTransfer).
+    // v2 finality gate via the OffRamp getCCVsForMessage resolver. Skipped for token-only transfers
+    // (OffRamp._isTokenOnlyTransfer delegates their finality to the pool). Best-effort: the finality
+    // rejection propagates; any other failure (non-v2 lane, transient RPC) is swallowed so the estimate
+    // still returns.
     if (
       'finality' in opts_.message &&
       opts_.message.finality &&
       opts_.message.finality !== 'finalized' &&
       !isTokenOnlyEstimate(opts_.message)
     ) {
-      let allowedFinality: FinalityAllowed = {
-        finalityDepth: 1,
-        finalitySafe: true,
-      } // default=loose for non-receivers
       try {
-        const receiver = new Contract(
-          opts_.message.receiver,
-          interfaces.Receiver_v2_0,
-          this.provider,
-        ) as unknown as TypedContract<typeof Receiver_2_0_ABI>
-        if (await receiver.supportsInterface(receiver.ccipReceive.fragment.selector))
-          allowedFinality = { finalityDepth: 0 } // default=finalized for legacy receivers
-
-        const [, , , allowedFinality_] = await receiver.getCCVsAndFinalityConfig(
-          opts_.message.sourceChainSelector,
-          opts_.message.sender ?? ZeroHash,
-        )
-        allowedFinality = decodeFinalityAllowed(allowedFinality_)
+        await this.getRequiredCCVs({ offRamp: opts_.offRamp, message: opts_.message })
       } catch (err) {
+        if (err instanceof CCIPFinalityNotAllowedError) throw err
         this.logger.debug(
-          `Failed to fetch allowed finality config from receiver="${opts_.message.receiver}", defaulting to: ${JSON.stringify(allowedFinality)}. Error:`,
+          'CCV/finality preflight unavailable; continuing with gas estimate. Error:',
           err,
         )
-      }
-      if (opts_.message.finality === 'safe') {
-        if (!allowedFinality.finalitySafe)
-          throw new CCIPFinalityNotAllowedError(opts_.message.finality, allowedFinality, {
-            context: {
-              source: networkInfo(opts_.message.sourceChainSelector).name,
-              sender: opts_.message.sender,
-              dest: this.network.name,
-              receiver: opts_.message.receiver,
-            },
-          })
-      } else if (
-        allowedFinality.finalityDepth == 0 ||
-        opts_.message.finality < allowedFinality.finalityDepth
-      ) {
-        throw new CCIPFinalityNotAllowedError(opts_.message.finality, allowedFinality, {
-          context: {
-            source: networkInfo(opts_.message.sourceChainSelector).name,
-            sender: opts_.message.sender,
-            dest: this.network.name,
-            receiver: opts_.message.receiver,
-          },
-        })
       }
     }
 

--- a/ccip-sdk/src/evm/messageCodec.test.ts
+++ b/ccip-sdk/src/evm/messageCodec.test.ts
@@ -1,0 +1,104 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import { ZeroHash, dataLength } from 'ethers'
+
+import { type MessageV1, encodeMessageV1, encodeTokenTransferV1 } from './messageCodec.ts'
+
+// 0x00000000 -> 0x00000002. Reproducing these byte-for-byte proves the encoder matches the on-chain
+// MessageV1Codec._encodeMessageV1.
+const ENC0 =
+  '0x01de41ba4fc9d91ad9ccf0a31a221f3c9b00000000000000000000000000030d4000000000000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000014e60c1d654283252623e448f53f648663a701cd7b20000000000000000000000000000000000000000000000000000000000000000014161d23c30b5ae2899c3d4d969ba2b82026f3954a00000000000f68656c6c6f2d707265666c69676874'
+const ENC2 =
+  '0x01de41ba4fc9d91ad9ccf0a31a221f3c9b00000000000000000000000000030d4000000002000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000014e60c1d654283252623e448f53f648663a701cd7b20000000000000000000000000000000000000000000000000000000000000000014161d23c30b5ae2899c3d4d969ba2b82026f3954a00000000000f68656c6c6f2d707265666c69676874'
+
+// Sepolia -> Fuji, data-only ("hello-preflight"), 200k ccipReceive gas, source addrs abi.encoded(0),
+// dest OffRamp/receiver raw 20 bytes. Matches the decoded ENC0 fields exactly.
+function baseCandidate(): MessageV1 {
+  return {
+    sourceChainSelector: 16015286601757825753n,
+    destChainSelector: 14767482510784806043n,
+    messageNumber: 0n,
+    executionGasLimit: 0,
+    ccipReceiveGasLimit: 200000,
+    finality: '0x00000000',
+    ccvAndExecutorHash: ZeroHash,
+    onRampAddress: ZeroHash, // abi.encode(address(0)) = 32 zero bytes
+    offRampAddress: '0xe60c1d654283252623e448f53f648663a701cd7b',
+    sender: ZeroHash, // abi.encode(address(0)) = 32 zero bytes
+    receiver: '0x161d23c30b5ae2899c3d4d969ba2b82026f3954a',
+    data: '0x68656c6c6f2d707265666c69676874', // "hello-preflight"
+  }
+}
+
+describe('encodeMessageV1 golden vectors', () => {
+  it('reproduces the finalized (finality=0) data-only candidate byte-for-byte (ENC0)', () => {
+    assert.equal(encodeMessageV1(baseCandidate()), ENC0)
+  })
+
+  it('reproduces the finality=2 candidate byte-for-byte (ENC2 = ENC0 with finality flipped)', () => {
+    assert.equal(encodeMessageV1({ ...baseCandidate(), finality: '0x00000002' }), ENC2)
+  })
+
+  it('the only difference between ENC0 and ENC2 is the 4-byte finality field', () => {
+    const enc0 = encodeMessageV1(baseCandidate())
+    const enc2 = encodeMessageV1({ ...baseCandidate(), finality: '0x00000002' })
+    assert.equal(enc0.length, enc2.length)
+    let diffs = 0
+    for (let i = 0; i < enc0.length; i++) if (enc0[i] !== enc2[i]) diffs++
+    assert.equal(diffs, 1) // single nibble: ...0000000[0] vs ...0000000[2]
+  })
+})
+
+describe('encodeMessageV1 structure', () => {
+  it('header is the fixed 69 bytes before any variable field', () => {
+    // version(1)+srcSel(8)+dstSel(8)+msgNumber(8)+execGas(4)+ccipReceiveGas(4)+finality(4)+ccvHash(32)
+    const enc = encodeMessageV1(baseCandidate())
+    const header = 1 + 8 + 8 + 8 + 4 + 4 + 4 + 32
+    // First length-prefix byte (onRampAddressLength) sits right after the header.
+    assert.equal(dataLength(enc) > header, true)
+  })
+
+  it('defaults omit optional fields: empty onRamp/offRamp/destBlob get a zero length prefix', () => {
+    const minimal: MessageV1 = {
+      sourceChainSelector: 1n,
+      destChainSelector: 2n,
+      ccipReceiveGasLimit: 0,
+      finality: '0x00000000',
+      sender: ZeroHash,
+      receiver: '0x161d23c30b5ae2899c3d4d969ba2b82026f3954a',
+    }
+    const enc = encodeMessageV1(minimal)
+    // 69-byte header + onRampLen(1,=0) + offRampLen(1,=0) + senderLen(1)+sender(32) +
+    // receiverLen(1)+receiver(20) + destBlobLen(2,=0) + tokenTransferLen(2,=0) + dataLen(2,=0)
+    assert.equal(dataLength(enc), 69 + 1 + 1 + 1 + 32 + 1 + 20 + 2 + 2 + 2)
+  })
+
+  it('a token transfer is appended with a non-zero uint16 length prefix', () => {
+    const withToken = encodeMessageV1({
+      ...baseCandidate(),
+      data: '0x',
+      tokenTransfer: {
+        amount: 1_000_000_000n,
+        destTokenAddress: '0x161d23c30b5ae2899c3d4d969ba2b82026f3954a',
+      },
+    })
+    const dataOnly = encodeMessageV1({ ...baseCandidate(), data: '0x' })
+    assert.equal(dataLength(withToken) > dataLength(dataOnly), true)
+  })
+})
+
+describe('encodeTokenTransferV1', () => {
+  it('starts with version byte 1 and the 32-byte amount', () => {
+    const enc = encodeTokenTransferV1({
+      amount: 255n,
+      destTokenAddress: '0x161d23c30b5ae2899c3d4d969ba2b82026f3954a',
+    })
+    // version(1) + amount(32) => amount 255 lands in the last byte of the 32-byte word
+    assert.equal(enc.slice(0, 4), '0x01') // version = 1
+    assert.equal(
+      enc.slice(4, 4 + 64),
+      '00000000000000000000000000000000000000000000000000000000000000ff',
+    )
+  })
+})

--- a/ccip-sdk/src/evm/messageCodec.ts
+++ b/ccip-sdk/src/evm/messageCodec.ts
@@ -1,0 +1,180 @@
+import { ZeroHash, dataLength, solidityPacked } from 'ethers'
+
+/**
+ * TypeScript mirror of `chainlink-ccip` `MessageV1Codec` (the CCIP v2 chain-agnostic wire format), used to
+ * build a candidate message for the destination OffRamp's `getCCVsForMessage(bytes)` view. A pure
+ * `abi.encodePacked` builder (ethers `solidityPacked`), wrapping no function selector.
+ *
+ * Mirrors `MessageV1Codec.sol` `_encodeMessageV1` (69-byte header + per-field length-prefixed variable
+ * fields) and `_encodeTokenTransferV1`.
+ */
+
+/** A single CCIP v2 token transfer, mirroring `MessageV1Codec.TokenTransferV1`. */
+export interface MessageV1TokenTransfer {
+  /** Number of tokens transferred. */
+  amount: bigint
+  /** Source pool address, `abi.encode(address)` (32 bytes) for EVM sources. Optional; empty if omitted. */
+  sourcePoolAddress?: string
+  /** Source token address, `abi.encode(address)` (32 bytes) for EVM sources. Optional; empty if omitted. */
+  sourceTokenAddress?: string
+  /** Destination token address, raw bytes (20 bytes for EVM destinations). */
+  destTokenAddress: string
+  /** Token receiver on the destination chain, raw bytes (20 bytes for EVM). Optional; empty if omitted. */
+  tokenReceiver?: string
+  /** Optional pool data forwarded to the destination pool. */
+  extraData?: string
+}
+
+/**
+ * A CCIP v2 `MessageV1`, mirroring `MessageV1Codec.MessageV1`.
+ *
+ * The `bytes`-typed address fields follow the codec's encoding rules exactly: source-side addresses
+ * (`onRampAddress`, `sender`, and the token transfer's `sourcePoolAddress`/`sourceTokenAddress`) are
+ * `abi.encode(address)` (32 bytes) for EVM; destination-side addresses (`offRampAddress`, `receiver`, and the
+ * token transfer's `destTokenAddress`/`tokenReceiver`) are raw minimal bytes (20 bytes for EVM). Callers
+ * building an EVM candidate should encode addresses accordingly before passing them here.
+ */
+export interface MessageV1 {
+  /** Source chain selector. */
+  sourceChainSelector: bigint
+  /** Destination chain selector. */
+  destChainSelector: bigint
+  /** Per-lane message number. Assigned on-chain at send; not read by `getCCVsForMessage`. Default `0n`. */
+  messageNumber?: bigint
+  /** Destination execution gas limit. Not read by `getCCVsForMessage`. Default `0`. */
+  executionGasLimit?: number | bigint
+  /** User callback (`ccipReceive`) gas limit. Read by `getCCVsForMessage` (token-only determination). */
+  ccipReceiveGasLimit: number | bigint
+  /** Per-message finality, `bytes4`. Read by `getCCVsForMessage`. */
+  finality: string
+  /** Hash of verifiers+executor. Has no meaning on the destination and is not checked. Default `ZeroHash`. */
+  ccvAndExecutorHash?: string
+  /** Source onRamp, `abi.encode(address)`. Not read by `getCCVsForMessage`. Default empty. */
+  onRampAddress?: string
+  /** Destination offRamp, raw bytes. Not read by `getCCVsForMessage`. Default empty. */
+  offRampAddress?: string
+  /** Source sender, `abi.encode(address)`. Read by `getCCVsForMessage` (CCV set is sender-scoped). */
+  sender: string
+  /** Destination receiver, raw bytes. Read by `getCCVsForMessage`; must be 20 bytes for EVM. */
+  receiver: string
+  /** Destination-specific blob. Not read by `getCCVsForMessage`. Default empty. */
+  destBlob?: string
+  /** Optional token transfer (0 or 1). Read by `getCCVsForMessage` (pool CCVs). */
+  tokenTransfer?: MessageV1TokenTransfer
+  /** User data payload. Read by `getCCVsForMessage` (its length drives the token-only determination). */
+  data?: string
+}
+
+/** Empty `bytes` value (`abi.encodePacked` emits nothing for a zero-length `bytes`). */
+const EMPTY_BYTES = '0x'
+
+/**
+ * Encode a {@link MessageV1TokenTransfer} to its wire bytes, mirroring
+ * `MessageV1Codec._encodeTokenTransferV1` (version `1`, `uint256 amount`, then each `bytes` field as a
+ * `uint8`/`uint16` byte-length prefix followed by its raw bytes).
+ */
+export function encodeTokenTransferV1(transfer: MessageV1TokenTransfer): string {
+  const sourcePoolAddress = transfer.sourcePoolAddress ?? EMPTY_BYTES
+  const sourceTokenAddress = transfer.sourceTokenAddress ?? EMPTY_BYTES
+  const tokenReceiver = transfer.tokenReceiver ?? EMPTY_BYTES
+  const extraData = transfer.extraData ?? EMPTY_BYTES
+
+  return solidityPacked(
+    [
+      'uint8', // version
+      'uint256', // amount
+      'uint8',
+      'bytes', // sourcePoolAddress
+      'uint8',
+      'bytes', // sourceTokenAddress
+      'uint8',
+      'bytes', // destTokenAddress
+      'uint8',
+      'bytes', // tokenReceiver
+      'uint16',
+      'bytes', // extraData
+    ],
+    [
+      1,
+      transfer.amount,
+      dataLength(sourcePoolAddress),
+      sourcePoolAddress,
+      dataLength(sourceTokenAddress),
+      sourceTokenAddress,
+      dataLength(transfer.destTokenAddress),
+      transfer.destTokenAddress,
+      dataLength(tokenReceiver),
+      tokenReceiver,
+      dataLength(extraData),
+      extraData,
+    ],
+  )
+}
+
+/**
+ * Encode a {@link MessageV1} candidate to its wire bytes, byte-for-byte matching
+ * `MessageV1Codec._encodeMessageV1`: a 69-byte static header (`uint8` version `1`, `uint64` selectors and
+ * message number, `uint32` gas limits, `bytes4` finality, `bytes32` ccvAndExecutorHash) followed by the
+ * variable fields, each prefixed by its byte length (`uint8` for the four address fields, `uint16` for
+ * `destBlob`/`tokenTransfer`/`data`). The token transfer is present iff its encoded length is non-zero.
+ */
+export function encodeMessageV1(message: MessageV1): string {
+  const onRampAddress = message.onRampAddress ?? EMPTY_BYTES
+  const offRampAddress = message.offRampAddress ?? EMPTY_BYTES
+  const destBlob = message.destBlob ?? EMPTY_BYTES
+  const data = message.data ?? EMPTY_BYTES
+  const tokenTransfer = message.tokenTransfer
+    ? encodeTokenTransferV1(message.tokenTransfer)
+    : EMPTY_BYTES
+
+  return solidityPacked(
+    [
+      'uint8', // version
+      'uint64', // sourceChainSelector
+      'uint64', // destChainSelector
+      'uint64', // messageNumber
+      'uint32', // executionGasLimit
+      'uint32', // ccipReceiveGasLimit
+      'bytes4', // finality
+      'bytes32', // ccvAndExecutorHash
+      'uint8',
+      'bytes', // onRampAddress
+      'uint8',
+      'bytes', // offRampAddress
+      'uint8',
+      'bytes', // sender
+      'uint8',
+      'bytes', // receiver
+      'uint16',
+      'bytes', // destBlob
+      'uint16',
+      'bytes', // tokenTransfer
+      'uint16',
+      'bytes', // data
+    ],
+    [
+      1,
+      message.sourceChainSelector,
+      message.destChainSelector,
+      message.messageNumber ?? 0n,
+      message.executionGasLimit ?? 0,
+      message.ccipReceiveGasLimit,
+      message.finality,
+      message.ccvAndExecutorHash ?? ZeroHash,
+      dataLength(onRampAddress),
+      onRampAddress,
+      dataLength(offRampAddress),
+      offRampAddress,
+      dataLength(message.sender),
+      message.sender,
+      dataLength(message.receiver),
+      message.receiver,
+      dataLength(destBlob),
+      destBlob,
+      dataLength(tokenTransfer),
+      tokenTransfer,
+      dataLength(data),
+      data,
+    ],
+  )
+}

--- a/ccip-sdk/src/gas.ts
+++ b/ccip-sdk/src/gas.ts
@@ -1,4 +1,4 @@
-import { formatUnits, hexlify, randomBytes, toBigInt } from 'ethers'
+import { type BytesLike, formatUnits, hexlify, randomBytes, toBigInt } from 'ethers'
 import type { Simplify } from 'type-fest'
 
 import type { Chain } from './chain.ts'
@@ -11,6 +11,7 @@ import {
 } from './errors/index.ts'
 import type { CCIPMessage_V2_0 } from './evm/messages.ts'
 import { discoverOffRamp } from './execution.ts'
+import type { FinalityRequested } from './extra-args.ts'
 import { networkInfo } from './networks.ts'
 import { buildMessageForDest } from './requests.ts'
 import type { CCIPMessage_V1_6_Solana } from './solana/types.ts'
@@ -63,6 +64,34 @@ export type EstimateReceiveExecutionOpts = {
   routerOrRamp: string
   /** message to be simulated */
   message: Omit<EstimateMessageInput, 'sourceChainSelector'>
+}
+
+/**
+ * Candidate message for {@link Chain.getRequiredCCVs} — the fields the destination OffRamp
+ * `getCCVsForMessage` resolver reads. `destTokenAmounts` are the already-resolved destination token
+ * amounts (as produced by {@link getDestTokenAmount}).
+ */
+export type GetRequiredCCVsMessage = {
+  sourceChainSelector: bigint
+  receiver: string
+  finality?: FinalityRequested
+  sender?: string
+  data?: BytesLike
+  ccipReceiveGasLimit?: number | bigint
+  gasLimit?: number | bigint
+  destTokenAmounts?: readonly {
+    token?: string
+    destTokenAddress?: string
+    amount: bigint
+    extraData?: string
+  }[]
+}
+
+/** Resolved CCV requirements returned by {@link Chain.getRequiredCCVs}. */
+export type GetRequiredCCVsResult = {
+  requiredCCVs: readonly string[]
+  optionalCCVs: readonly string[]
+  optionalThreshold: number
 }
 
 /**
@@ -280,4 +309,69 @@ export async function estimateReceiveExecution({
     throw new CCIPMethodUnsupportedError(dest.constructor.name, 'estimateReceiveExecution')
 
   return dest.estimateReceiveExecution(payload)
+}
+
+/**
+ * Resolve the CCVs the destination will require for a candidate message, and whether its finality is
+ * accepted, via the OffRamp's `getCCVsForMessage` view (a read; no send). Resolves the onRamp/offRamp from
+ * `routerOrRamp` like {@link estimateReceiveExecution}, maps token amounts to their destination
+ * counterparts, then queries the resolver. A disallowed finality throws `CCIPFinalityNotAllowedError`.
+ *
+ * The set is sender-scoped: pass the real `sender`. It is informative only — comparing it against the
+ * source-engaged set is left to the caller, since source and destination CCVs are distinct per-chain
+ * contracts with no on-chain address link.
+ *
+ * @param opts - {@link EstimateReceiveExecutionOpts} (source, dest, routerOrRamp, message)
+ * @returns `{ requiredCCVs, optionalCCVs, optionalThreshold }`.
+ */
+export async function getRequiredCCVs({
+  source,
+  dest,
+  routerOrRamp,
+  message,
+}: EstimateReceiveExecutionOpts): Promise<GetRequiredCCVsResult> {
+  let onRamp: string, offRamp: string
+  if (message.onRampAddress) onRamp = message.onRampAddress
+  if (message.offRampAddress) offRamp = message.offRampAddress
+  if (!onRamp! || !offRamp!)
+    try {
+      const [type] = await source.typeAndVersion(routerOrRamp)
+      if (!type.includes('OnRamp'))
+        onRamp = await source.getOnRampForRouter(routerOrRamp, dest.network.chainSelector)
+      else onRamp = routerOrRamp
+      offRamp ||= await discoverOffRamp(source, dest, onRamp, source)
+    } catch (sourceErr) {
+      try {
+        const [type, , tnv] = await dest.typeAndVersion(routerOrRamp)
+        if (!type.includes('OffRamp'))
+          throw new CCIPContractTypeInvalidError(routerOrRamp, tnv, ['OffRamp'])
+        offRamp = routerOrRamp
+        const onRamps = await dest.getOnRampsForOffRamp(offRamp, source.network.chainSelector)
+        if (!onRamps.length) throw new CCIPOnRampRequiredError()
+        onRamp = onRamps[onRamps.length - 1]!
+      } catch {
+        throw sourceErr // re-throw original error
+      }
+    }
+
+  const destTokenAmounts = await Promise.all(
+    (message.tokenAmounts ?? []).map(async (tokenAmount) =>
+      getDestTokenAmount({ source, dest, onRamp, tokenAmount }),
+    ),
+  )
+
+  if (!dest.getRequiredCCVs)
+    throw new CCIPMethodUnsupportedError(dest.constructor.name, 'getRequiredCCVs')
+
+  return dest.getRequiredCCVs({
+    offRamp,
+    message: {
+      sourceChainSelector: source.network.chainSelector,
+      receiver: message.receiver,
+      finality: message.finality,
+      sender: message.sender,
+      data: message.data,
+      destTokenAmounts,
+    },
+  })
 }

--- a/ccip-sdk/src/index.ts
+++ b/ccip-sdk/src/index.ts
@@ -64,7 +64,8 @@ export {
   encodeExtraArgs,
   encodeFinality,
 } from './extra-args.ts'
-export { estimateReceiveExecution, sourceToDestTokenAddresses } from './gas.ts'
+export { estimateReceiveExecution, getRequiredCCVs, sourceToDestTokenAddresses } from './gas.ts'
+export type { GetRequiredCCVsMessage, GetRequiredCCVsResult } from './gas.ts'
 export { CCTP_FINALITY_FAST, CCTP_FINALITY_STANDARD, getOffchainTokenData } from './offchain.ts'
 export { decodeMessage, getMessagesInRange } from './requests.ts'
 export {
@@ -118,6 +119,12 @@ export { type NetworkInfo, ChainFamily, NetworkType, networkInfo } from './netwo
 import SELECTORS from './selectors.ts'
 export { SELECTORS }
 export type { UnsignedEVMTx } from './evm/index.ts'
+export {
+  type MessageV1,
+  type MessageV1TokenTransfer,
+  encodeMessageV1,
+  encodeTokenTransferV1,
+} from './evm/messageCodec.ts'
 import { SolanaChain } from './solana/index.ts'
 export type { UnsignedSolanaTx } from './solana/index.ts'
 import { SuiChain } from './sui/index.ts'


### PR DESCRIPTION
Add encodeMessageV1, EVMChain.getRequiredCCVs, and ccip-cli send --only-ccvs; estimateReceiveExecution resolves finality through the OffRamp resolver (best-effort, guarded to v2 lanes).
This pull request introduces a new feature for inspecting the required CCV (Cross-Chain Validation) set for a candidate message in the CCIP CLI and SDK, and refactors the EVM chain's finality and CCV preflight logic to use the new on-chain resolver. It also improves error handling and adds comprehensive tests for these scenarios.

**New feature: CCV set inspection in CLI**
- Adds a `--only-ccvs` flag to the `send` command in `ccip-cli`, allowing users to print the required and optional CCVs and threshold for a destination, without sending a message. This utilizes the new `getRequiredCCVs` method. [[1]](diffhunk://#diff-03090a293d323e64d515b20c6d19df7873c279125ceeeba5ee66605b3b628d92R33) [[2]](diffhunk://#diff-03090a293d323e64d515b20c6d19df7873c279125ceeeba5ee66605b3b628d92R148-R153) [[3]](diffhunk://#diff-03090a293d323e64d515b20c6d19df7873c279125ceeeba5ee66605b3b628d92R326-R351)

**SDK enhancements: CCV and finality preflight**
- Implements `getRequiredCCVs` in the `Chain` and `EVMChain` classes, which queries the destination OffRamp's `getCCVsForMessage` view to resolve the required CCV set and validate requested finality. Throws a clear error if the requested finality is not allowed or if the OffRamp is not v2.0. [[1]](diffhunk://#diff-807a4ca9474665a0a92dd38d0c7b802fa323550a99ef0c98a2ae754be2cd8838L31-R31) [[2]](diffhunk://#diff-807a4ca9474665a0a92dd38d0c7b802fa323550a99ef0c98a2ae754be2cd8838R2297-R2310) [[3]](diffhunk://#diff-cae1d5fb496ff335e72129fb79782365f7f977991d0e3cdb2f7bc062f2e060ceR2391-R2472)

**Finality preflight refactor and error handling**
- Refactors `estimateReceiveExecution` in `EVMChain` to use the new `getRequiredCCVs` method for v2.0 lanes, improving clarity and reliability. Finality rejection errors propagate, while other failures (e.g., non-v2 lanes, transient RPC issues) are swallowed to allow gas estimation to proceed.

**Testing improvements**
- Updates and expands tests in `finality-preflight.test.ts` to cover the new CCV/finality logic, including cases for v2.0 OffRamps, unsupported versions, and best-effort fallback behavior. [[1]](diffhunk://#diff-5019d06657dcd9e685c438c2015e75b458198dc345a2abef82be744e963dfdffL4-R16) [[2]](diffhunk://#diff-5019d06657dcd9e685c438c2015e75b458198dc345a2abef82be744e963dfdffL56-R83) [[3]](diffhunk://#diff-5019d06657dcd9e685c438c2015e75b458198dc345a2abef82be744e963dfdffR233-R307)

**Supporting code and imports**
- Updates imports and type definitions throughout the SDK to support the new features and maintain type safety. [[1]](diffhunk://#diff-cae1d5fb496ff335e72129fb79782365f7f977991d0e3cdb2f7bc062f2e060ceR28) [[2]](diffhunk://#diff-cae1d5fb496ff335e72129fb79782365f7f977991d0e3cdb2f7bc062f2e060ceL69-R79) [[3]](diffhunk://#diff-cae1d5fb496ff335e72129fb79782365f7f977991d0e3cdb2f7bc062f2e060ceL108) [[4]](diffhunk://#diff-cae1d5fb496ff335e72129fb79782365f7f977991d0e3cdb2f7bc062f2e060ceR149)
