### PR TITLE
Enable Canton manual exec by message ID (v2 execution inputs + CCV fallback

### DIFF
--- a/ccip-cli/src/index.ts
+++ b/ccip-cli/src/index.ts
@@ -28,7 +28,7 @@ Error.stackTraceLimit = 50 // show more stack frames for better debugging
 
 // generate:nofail
 // `const VERSION = '${require('./package.json').version}-${require('child_process').execSync('git rev-parse --short HEAD').toString().trim()}'`
-const VERSION = '1.10.1-456acfd'
+const VERSION = '1.10.2-73e631c'
 // generate:end
 
 const require = createRequire(import.meta.url)

--- a/ccip-sdk/src/api/api.test.ts
+++ b/ccip-sdk/src/api/api.test.ts
@@ -980,6 +980,115 @@ describe('CCIPAPIClient', () => {
     })
   })
 
+  describe('getExecutionInput', () => {
+    it('should normalize v2 encodedMessage without 0x prefix (Canton API)', async () => {
+      const bareEncoded =
+        '0180a125ef7e2d41dade41ba4fc9d91ad900000000000000ec000531b00000c350000000009a25b2b8f01e3d98ba406630f8a1cda063753407b874762588f561351b46838e2003519eac48d545c4d0ecdc3e3022e443d9e878867827eecb37d5e5a60ae0c98914c6a246a9acdaae651708706494720f79c3e5d0a12028b2421067c474960f680ee23de0c86ce91d3ec7b24f8f5819289160f4d124a7148C244f0B2164E6A3BED74ab429B0ebd661Bb14CA00000000000568656c6c6f'
+      const messageId = '0x387873167bf01283a4803b13698c1ce9d3990c2f72c192477f78cbf6902eec31'
+      const customFetch = mock.fn(() =>
+        Promise.resolve({
+          ok: true,
+          text: () =>
+            Promise.resolve(
+              JSON.stringify({
+                offramp: '0xc6A246A9AcdAaE651708706494720F79C3E5d0A1',
+                encodedMessage: bareEncoded,
+                ccvData: ['0xe9a05a20'],
+                verifierAddresses: ['0x8f3ee3c77D2B27c32306a89D367654F959Db223D'],
+              }),
+            ),
+        }),
+      )
+      const client = new CCIPAPIClient(undefined, { fetch: customFetch as any })
+      const result = await client.getExecutionInput(messageId)
+
+      assert.ok('encodedMessage' in result)
+      assert.match(result.encodedMessage, /^0x[0-9a-fA-F]+$/)
+      assert.equal(result.encodedMessage.slice(2).toLowerCase(), bareEncoded.toLowerCase())
+      assert.equal(result.version, CCIPVersion.V2_0)
+      assert.equal(result.offRamp, '0xc6A246A9AcdAaE651708706494720F79C3E5d0A1')
+    })
+
+    it('falls back to getMessageById verifiers when execution-inputs CCV data is empty', async () => {
+      const messageId = '0x62c8432ef490e06659677a0163bca342fffc62a2b6fbc3a871a312c4ecab53ff'
+      const encodedMessage =
+        '0x01de41ba4fc9d91ad980a125ef7e2d41da00000000000001c300041c50000186a000000001627a052d6d9e5076321c70be47e1c04871e7d06759079187b41ebc78c7f2414a20000000000000000000000000181ac7dc295f1c8c87342d07cfaba90bc477db5d20d03375cb15a7179bfbfa7cfb843250a6b26e4ddc7a4c30e7bc1777cf3afbf580200000000000000000000000008c244f0b2164e6a3bed74ab429b0ebd661bb14ca2028b2421067c474960f680ee23de0c86ce91d3ec7b24f8f5819289160f4d124a700000000000568656c6c6f'
+      const cantonCcv = '0xec1e288bcf8bbf034ac2d31b67f9b15a3f1f828d086c5b9d8fc2866129cd02fe'
+      const ccvProof = '0x' + 'ab'.repeat(100)
+
+      const customFetch = mock.fn((url: string) => {
+        if (url.includes('execution-inputs')) {
+          return Promise.resolve({
+            ok: true,
+            text: () =>
+              Promise.resolve(
+                JSON.stringify({
+                  offramp: '0xd03375cb15a7179bfbfa7cfb843250a6b26e4ddc7a4c30e7bc1777cf3afbf580',
+                  encodedMessage,
+                  verifierAddresses: [],
+                  ccvData: [],
+                  verificationComplete: false,
+                }),
+              ),
+          })
+        }
+        return Promise.resolve({
+          ok: true,
+          text: () =>
+            Promise.resolve(
+              JSON.stringify({
+                messageId,
+                sender: '0x1111111111111111111111111111111111111111',
+                receiver: '0x2222222222222222222222222222222222222222',
+                status: 'VERIFIED',
+                sourceNetworkInfo: {
+                  name: 'ethereum-testnet-sepolia',
+                  chainSelector: '16015286601757825753',
+                  chainId: '11155111',
+                  chainFamily: 'EVM',
+                },
+                destNetworkInfo: {
+                  name: 'canton-testnet',
+                  chainSelector: '9268731218649498074',
+                  chainId: 'canton:TestNet',
+                  chainFamily: 'Canton',
+                },
+                sendTransactionHash: '0x' + 'bb'.repeat(32),
+                sendTimestamp: '2026-07-09T13:22:48.000Z',
+                tokenAmounts: [],
+                extraArgs: { gasLimit: '100000', finality: 1 },
+                verifiers: {
+                  items: [
+                    {
+                      sourceAddress: '0x8f3ee3c77D2B27c32306a89D367654F959Db223D',
+                      destAddress: cantonCcv,
+                      isRequired: true,
+                      verification: { data: ccvProof, timestamp: '2026-07-09T13:23:03.330Z' },
+                    },
+                  ],
+                  optionalThreshold: '0',
+                },
+                version: '2.0.0',
+                onramp: '0x181Ac7dC295f1C8C87342d07CFaBA90bC477DB5d',
+                origin: '0x1111111111111111111111111111111111111111',
+                sequenceNumber: '451',
+                data: '0x68656c6c6f',
+              }),
+            ),
+        })
+      })
+
+      const client = new CCIPAPIClient(undefined, { fetch: customFetch as any })
+      const result = await client.getExecutionInput(messageId)
+
+      assert.ok('verifications' in result)
+      assert.equal(result.verifications.length, 1)
+      assert.equal(result.verifications[0]!.destAddress, cantonCcv)
+      assert.equal(result.verifications[0]!.ccvData, ccvProof)
+      assert.equal(customFetch.mock.callCount(), 2)
+    })
+  })
+
   describe('searchMessages', () => {
     const mockSearchResponse = {
       data: [

--- a/ccip-sdk/src/api/index.ts
+++ b/ccip-sdk/src/api/index.ts
@@ -1,3 +1,4 @@
+import { hexlify } from 'ethers'
 import { memoize } from 'micro-memoize'
 import type { SetRequired } from 'type-fest'
 
@@ -27,7 +28,7 @@ import {
   CCIPVersion,
   MessageStatus,
 } from '../types.ts'
-import { decodeAddress, jsonParse } from '../utils.ts'
+import { decodeAddress, getDataBytes, jsonParse } from '../utils.ts'
 import type {
   APIErrorResponse,
   LaneLatencyResponse,
@@ -61,7 +62,7 @@ export const DEFAULT_TIMEOUT_MS = 30000
 /** SDK version string for telemetry header */
 // generate:nofail
 // `export const SDK_VERSION = '${require('./package.json').version}-${require('child_process').execSync('git rev-parse --short HEAD').toString().trim()}'`
-export const SDK_VERSION = '1.10.1-456acfd'
+export const SDK_VERSION = '1.10.2-73e631c'
 // generate:end
 
 /** SDK telemetry header name */
@@ -460,6 +461,42 @@ export class CCIPAPIClient {
   }
 
   /**
+   * CCV proofs for v2 `/execution-inputs` when the endpoint omits or marks them incomplete.
+   * Falls back to {@link getVerifications} (from `GET /v2/messages/{id}`) which is populated
+   * for Canton lanes before execution-inputs catches up.
+   */
+  private async resolveV2ExecutionVerifications(
+    messageId: string,
+    raw: Extract<RawExecutionInputsResult, { encodedMessage: string }>,
+    options?: { signal?: AbortSignal },
+  ): Promise<Pick<VerifierResult, 'ccvData' | 'destAddress'>[]> {
+    const ccvData = raw.ccvData ?? []
+    const verifierAddresses = raw.verifierAddresses
+    const hasCompleteExecutionInputs =
+      ccvData.length > 0 &&
+      ccvData.length === verifierAddresses.length &&
+      raw.verificationComplete !== false
+
+    if (hasCompleteExecutionInputs) {
+      return ccvData.map((data, i) => ({
+        ccvData: data,
+        destAddress: verifierAddresses[i]!,
+      }))
+    }
+
+    this.logger.debug(
+      'getExecutionInput: execution-inputs CCV data incomplete; falling back to getMessageById verifiers',
+      {
+        messageId,
+        verificationComplete: raw.verificationComplete,
+        ccvCount: ccvData.length,
+        verifierAddressCount: verifierAddresses.length,
+      },
+    )
+    return this.getVerifications(messageId, options)
+  }
+
+  /**
    * Searches CCIP messages using filters with cursor-based pagination.
    *
    * @param filters - Optional search filters. Ignored when `options.cursor` is provided
@@ -761,23 +798,22 @@ export class CCIPAPIClient {
     const offRamp = raw.offramp
     let lane: Lane
     if ('encodedMessage' in raw) {
-      // CCIP 2.0 messages use MessageV1Codec, which is chain-independent serialization
+      // CCIP 2.0 messages use MessageV1Codec, which is chain-independent serialization.
+      // Canton API responses omit the `0x` prefix (Daml BytesHex); normalize for ethers.
+      const encodedMessage = hexlify(getDataBytes(raw.encodedMessage))
       const {
         sourceChainSelector,
         destChainSelector,
         onRampAddress: onRamp,
-      } = decodeMessageV1(raw.encodedMessage)
+      } = decodeMessageV1(encodedMessage)
       return {
         sourceChainSelector,
         destChainSelector,
         onRamp,
         offRamp,
         version: CCIPVersion.V2_0,
-        encodedMessage: raw.encodedMessage,
-        verifications: (raw.ccvData ?? []).map((ccvData, i) => ({
-          ccvData,
-          destAddress: raw.verifierAddresses[i]!,
-        })),
+        encodedMessage,
+        verifications: await this.resolveV2ExecutionVerifications(messageId, raw, options),
       }
     }
 

--- a/ccip-sdk/src/canton/generateUnsignedExecute.test.ts
+++ b/ccip-sdk/src/canton/generateUnsignedExecute.test.ts
@@ -1,0 +1,184 @@
+import assert from 'node:assert/strict'
+import { describe, it, mock } from 'node:test'
+
+import '../index.ts'
+import { CCIPAPIClient } from '../api/index.ts'
+import { type NetworkInfo, ChainFamily, networkInfo } from '../networks.ts'
+import type { CantonClient, JsGetActiveContractsResponse } from './client/index.ts'
+import { AcsDisclosureProvider } from './explicit-disclosures/acs.ts'
+import type { EdsDisclosureProvider } from './explicit-disclosures/eds.ts'
+import { CantonChain } from './index.ts'
+import type { TokenMetadataClient } from './token-metadata/client.ts'
+import type { TransferInstructionClient } from './transfer-instruction/client.ts'
+
+const PARTY = 'party1::aabbcc'
+
+const ROUTER_CONTRACT_ID = 'router-cid-001'
+const ROUTER_BLOB = 'router-blob'
+const ROUTER_TEMPLATE_ID = 'pkg-router:CCIP.PerPartyRouter:PerPartyRouter'
+
+const RECEIVER_CONTRACT_ID = 'receiver-cid-002'
+const RECEIVER_BLOB = 'receiver-blob'
+const RECEIVER_TEMPLATE_ID = 'pkg-receiver:CCIP.CCIPReceiver:CCIPReceiver'
+
+function makeAcsEntry(
+  templateId: string,
+  contractId: string,
+  createdEventBlob: string,
+  signatory: string,
+): JsGetActiveContractsResponse {
+  return {
+    contractEntry: {
+      JsActiveContract: {
+        synchronizerId: 'synchronizer::001122',
+        createdEvent: {
+          templateId,
+          contractId,
+          createdEventBlob,
+          signatories: [signatory],
+          createArgument: { partyOwner: signatory, owner: signatory },
+          observers: [],
+          witnesses: [],
+          offset: 1,
+          nodeId: 0,
+          packageName: '',
+          interfaceViews: [],
+          agreementText: '',
+        },
+      },
+    },
+  } as unknown as JsGetActiveContractsResponse
+}
+
+const EXECUTE_ACS: JsGetActiveContractsResponse[] = [
+  makeAcsEntry(ROUTER_TEMPLATE_ID, ROUTER_CONTRACT_ID, ROUTER_BLOB, PARTY),
+  makeAcsEntry(RECEIVER_TEMPLATE_ID, RECEIVER_CONTRACT_ID, RECEIVER_BLOB, PARTY),
+]
+
+function makeStubClient(acsEntries: JsGetActiveContractsResponse[]): CantonClient {
+  return {
+    getLedgerEnd: async () => ({ offset: 42 }),
+    getActiveContracts: async () => acsEntries,
+  } as unknown as CantonClient
+}
+
+/** EVM → Canton v2 payload: bare hex encodedMessage (no `0x`), as returned by CCIP API. */
+const BARE_ENCODED_MESSAGE =
+  '0180a125ef7e2d41dade41ba4fc9d91ad900000000000000ec000531b00000c350000000009a25b2b8f01e3d98ba406630f8a1cda063753407b874762588f561351b46838e2003519eac48d545c4d0ecdc3e3022e443d9e878867827eecb37d5e5a60ae0c98914c6a246a9acdaae651708706494720f79c3e5d0a12028b2421067c474960f680ee23de0c86ce91d3ec7b24f8f5819289160f4d124a7148C244f0B2164E6A3BED74ab429B0ebd661Bb14CA00000000000568656c6c6f'
+
+const MESSAGE_ID = '0x62c8432ef490e06659677a0163bca342fffc62a2b6fbc3a871a312c4ecab53ff'
+
+function makeEdsStub() {
+  const fetchExecutionDisclosures = mock.fn(async () => ({
+    contextData: 'global-context',
+    disclosedContracts: [],
+  }))
+  const fetchCcvExecuteDisclosure = mock.fn(async () => ({
+    contractId: 'ccv-cid',
+    contextData: 'ccv-context',
+    disclosedContracts: [],
+  }))
+  const fetchTokenPoolExecuteDisclosure = mock.fn()
+
+  const eds = {
+    fetchExecutionDisclosures,
+    fetchCcvExecuteDisclosure,
+    fetchTokenPoolExecuteDisclosure,
+  } as unknown as EdsDisclosureProvider
+
+  return { eds, fetchExecutionDisclosures, fetchCcvExecuteDisclosure }
+}
+
+function makeTestCantonChain(apiClient: CCIPAPIClient, eds: EdsDisclosureProvider): CantonChain {
+  const client = makeStubClient(EXECUTE_ACS)
+  const acs = new AcsDisclosureProvider(client, { party: PARTY })
+  const cantonNetwork = networkInfo('canton:TestNet') as NetworkInfo<typeof ChainFamily.Canton>
+  return new CantonChain(
+    client,
+    acs,
+    eds,
+    {} as TransferInstructionClient,
+    {} as TransferInstructionClient,
+    {} as TokenMetadataClient,
+    'ccipOwner::1220e382f4e57b0815e6be737006e381e6b7de448e06bd033ece6df498017879f551',
+    'https://indexer.testnet.ccip.chain.link',
+    cantonNetwork,
+    PARTY,
+    { apiClient, logger: console },
+  )
+}
+
+describe('CantonChain.generateUnsignedExecute (messageId)', () => {
+  it('resolves messageId via CCIP API and builds Execute JsCommands', async () => {
+    const mockFetch = mock.fn(() =>
+      Promise.resolve({
+        ok: true,
+        text: () =>
+          Promise.resolve(
+            JSON.stringify({
+              offramp: '0xd03375cb15a7179bfbfa7cfb843250a6b26e4ddc7a4c30e7bc1777cf3afbf580',
+              encodedMessage: BARE_ENCODED_MESSAGE,
+              ccvData: ['0xe9a05a200240'],
+              verifierAddresses: [
+                '0xec1e288bcf8bbf034ac2d31b67f9b15a3f1f828d086c5b9d8fc2866129cd02fe',
+              ],
+            }),
+          ),
+      }),
+    )
+    const apiClient = new CCIPAPIClient('https://api.test', { fetch: mockFetch as any })
+    const { eds, fetchExecutionDisclosures, fetchCcvExecuteDisclosure } = makeEdsStub()
+    const chain = makeTestCantonChain(apiClient, eds)
+
+    const unsigned = await chain.generateUnsignedExecute({
+      messageId: MESSAGE_ID,
+      payer: PARTY,
+      _cantonReceiverCid: RECEIVER_CONTRACT_ID,
+    } as unknown as Parameters<CantonChain['generateUnsignedExecute']>[0])
+
+    assert.equal(unsigned.family, ChainFamily.Canton)
+    assert.equal(unsigned.commands.commands.length, 1)
+    assert.equal(
+      (unsigned.commands.commands[0] as { ExerciseCommand: { choice: string } }).ExerciseCommand
+        .choice,
+      'Execute',
+    )
+    assert.equal(mockFetch.mock.callCount(), 1)
+    const fetchUrl = (mockFetch.mock.calls[0] as unknown as { arguments: string[] }).arguments[0]!
+    assert.match(fetchUrl, /execution-inputs/)
+    assert.equal(fetchExecutionDisclosures.mock.callCount(), 1)
+    assert.equal(fetchCcvExecuteDisclosure.mock.callCount(), 1)
+
+    const choiceArgument = (
+      unsigned.commands.commands[0] as {
+        ExerciseCommand: { choiceArgument: { encodedMessage: string } }
+      }
+    ).ExerciseCommand.choiceArgument
+    assert.equal(choiceArgument.encodedMessage, BARE_ENCODED_MESSAGE.toLowerCase())
+  })
+
+  it('accepts pre-resolved offRamp + input without calling the API', async () => {
+    const mockFetch = mock.fn()
+    const apiClient = new CCIPAPIClient('https://api.test', { fetch: mockFetch as any })
+    const { eds, fetchExecutionDisclosures } = makeEdsStub()
+    const chain = makeTestCantonChain(apiClient, eds)
+
+    await chain.generateUnsignedExecute({
+      offRamp: '0xd03375cb15a7179bfbfa7cfb843250a6b26e4ddc7a4c30e7bc1777cf3afbf580',
+      input: {
+        encodedMessage: `0x${BARE_ENCODED_MESSAGE}`,
+        verifications: [
+          {
+            ccvData: '0xdeadbeef',
+            destAddress: '0xec1e288bcf8bbf034ac2d31b67f9b15a3f1f828d086c5b9d8fc2866129cd02fe',
+          },
+        ],
+      },
+      payer: PARTY,
+      _cantonReceiverCid: RECEIVER_CONTRACT_ID,
+    } as unknown as Parameters<CantonChain['generateUnsignedExecute']>[0])
+
+    assert.equal(mockFetch.mock.callCount(), 0)
+    assert.equal(fetchExecutionDisclosures.mock.callCount(), 1)
+  })
+})

--- a/ccip-sdk/src/canton/index.ts
+++ b/ccip-sdk/src/canton/index.ts
@@ -1024,7 +1024,8 @@ export class CantonChain extends Chain<typeof ChainFamily.Canton> {
    * 3. **Choice argument** – assembled from the encoded CCIP message,
    *    verification data, and the opaque `contextData` returned by the EDS.
    *
-   * @param opts - Must use the `offRamp` + `input` variant of {@link ExecuteOpts}.
+   * @param opts - {@link ExecuteOpts} with `offRamp` + `input`, or `{ messageId }` when
+   *   `apiClient` is configured (fetches execution inputs from the CCIP API).
    *   `input` must contain `encodedMessage` and `verifications` (CCIP v2.0).
    *   `payer` is the Daml party ID used for `actAs`.
    * @returns An {@link UnsignedCantonTx} wrapping the ready-to-submit
@@ -1033,21 +1034,18 @@ export class CantonChain extends Chain<typeof ChainFamily.Canton> {
   override async generateUnsignedExecute(
     opts: Parameters<Chain['generateUnsignedExecute']>[0],
   ): Promise<UnsignedCantonTx> {
-    // --- validate opts shape ---
-    if (!('offRamp' in opts) || !('input' in opts)) {
-      throw new CCIPNotImplementedError(
-        'CantonChain.generateUnsignedExecute: messageId-based execution is not supported; ' +
-          'provide offRamp + input instead',
-      )
-    }
+    const { payer, ...executeOpts } = opts
+    const cantonOpts = opts as typeof opts & { _cantonReceiverCid?: string }
+    const resolved = await this.resolveExecuteOpts(executeOpts)
 
-    const { input, payer } = opts
     if (!payer) {
       throw new CCIPError(
         CCIPErrorCode.WALLET_INVALID,
         'CantonChain.generateUnsignedExecute: payer (party ID) is required',
       )
     }
+
+    const { input } = resolved
 
     // v2.0 input shape: { encodedMessage, verifications }
     if (!('encodedMessage' in input) || !('verifications' in input)) {
@@ -1070,7 +1068,6 @@ export class CantonChain extends Chain<typeof ChainFamily.Canton> {
       'CantonChain.generateUnsignedExecute: fetching ACS disclosures for CCIPReceiver and PerPartyRouter...',
     )
     // Check opts for a pre-resolved receiver CID (threaded from execute() after find/create).
-    const cantonOpts = opts as typeof opts & { _cantonReceiverCid?: string }
     const acsDisclosures = await this.acsDisclosureProvider.fetchExecutionDisclosures(
       cantonOpts._cantonReceiverCid,
     )
@@ -1178,17 +1175,22 @@ export class CantonChain extends Chain<typeof ChainFamily.Canton> {
    * @throws {@link CCIPError} if the Ledger API submission or result parsing fails
    */
   async execute(opts: Parameters<Chain['execute']>[0]): Promise<CCIPExecution> {
-    const { wallet } = opts
+    const { wallet, ...executeOpts } = opts
     if (!isCantonWallet(wallet)) {
       throw new CCIPWalletInvalidError(wallet)
     }
 
-    // Decode the message finality and find/create a compatible CCIPReceiver.
-    const inputOpts = opts as {
-      input?: { encodedMessage?: string; verifications?: Array<{ destAddress: string }> }
+    const resolved = await this.resolveExecuteOpts(executeOpts)
+    if (!('encodedMessage' in resolved.input) || !('verifications' in resolved.input)) {
+      throw new CCIPError(
+        CCIPErrorCode.METHOD_UNSUPPORTED,
+        'CantonChain.execute: only CCIP v2.0 ExecutionInput ' +
+          '(encodedMessage + verifications) is supported',
+      )
     }
-    const encodedMessageHex = inputOpts.input?.encodedMessage ?? ''
-    const verifications = inputOpts.input?.verifications ?? []
+
+    const { encodedMessage, verifications } = resolved.input
+    const encodedMessageHex = stripHexPrefix(String(encodedMessage))
     const attestationCcvRaw =
       verifications[0] != null
         ? decodeCantonVerifierDestAddress(verifications[0].destAddress)
@@ -1213,7 +1215,9 @@ export class CantonChain extends Chain<typeof ChainFamily.Canton> {
 
     // Build the unsigned command, passing the resolved receiver CID via Canton-specific opts.
     const unsigned = await this.generateUnsignedExecute({
-      ...opts,
+      offRamp: resolved.offRamp,
+      input: resolved.input,
+      receiver: opts.receiver,
       payer: wallet.party,
       _cantonReceiverCid: receiverCid,
     } as unknown as Parameters<Chain['generateUnsignedExecute']>[0])

--- a/ccip-sdk/src/chain.ts
+++ b/ccip-sdk/src/chain.ts
@@ -1,4 +1,4 @@
-import { type BytesLike, dataLength, isBytesLike, keccak256 } from 'ethers'
+import { type BytesLike, dataLength, hexlify, isBytesLike, keccak256 } from 'ethers'
 import type { PickDeep } from 'type-fest'
 
 import { type LaneLatencyResponse, CCIPAPIClient } from './api/index.ts'
@@ -63,7 +63,7 @@ import {
   CCIPVersion,
   ExecutionState,
 } from './types.ts'
-import { util, withRetry } from './utils.ts'
+import { getDataBytes, util, withRetry } from './utils.ts'
 
 /** All valid field names for GenericExtraArgsV2. */
 const V2_FIELDS = new Set(['gasLimit', 'allowOutOfOrderExecution'])
@@ -1542,7 +1542,7 @@ export abstract class Chain<F extends ChainFamily = ChainFamily> {
           ? opts.messageId
           : 'message' in opts.input
             ? opts.input.message.messageId
-            : keccak256(opts.input.encodedMessage)
+            : keccak256(getDataBytes(opts.input.encodedMessage))
       const { offRamp, ...input } = await this.apiClient.getExecutionInput(messageId)
       if (
         'offchainTokenData' in input &&
@@ -1574,10 +1574,11 @@ export abstract class Chain<F extends ChainFamily = ChainFamily> {
           tokenAmounts: opts_.input.message.tokenAmounts,
         }
       } else {
-        const decoded = decodeMessageV1(opts_.input.encodedMessage)
+        const encodedMessage = hexlify(getDataBytes(opts_.input.encodedMessage))
+        const decoded = decodeMessageV1(encodedMessage)
         message = {
           ...decoded,
-          messageId: keccak256(opts_.input.encodedMessage),
+          messageId: keccak256(encodedMessage),
           tokenAmounts: decoded.tokenTransfer,
         }
       }


### PR DESCRIPTION
Enables `ccip-cli manual-exec <messageId>` for Canton lanes in both directions by fixing how the SDK resolves CCIP v2 execution inputs from the CCIP API.

- **Normalize v2 `encodedMessage`** — The CCIP API returns bare hex (no `0x` prefix) for Canton lanes. Normalize via `hexlify(getDataBytes(...))` in `getExecutionInput()` and `resolveExecuteOpts()` so `keccak256` / `decodeMessageV1` work correctly (fixes Canton → EVM manual exec by message ID).
- **Canton `generateUnsignedExecute` via message ID** — `CantonChain.generateUnsignedExecute()` and `execute()` now call `resolveExecuteOpts()` like other chains, so `{ messageId }` resolves off-ramp, encoded message, and verifications from the CCIP API (fixes EVM → Canton manual exec by message ID).
- **CCV verification fallback** — When the CCIP API `/execution-inputs` response has empty or incomplete CCV data (`ccvData: []`, `verificationComplete: false`), fall back to `GET /v2/messages/{id}` verifiers so Canton execute still receives required CCV proofs.