### PR TITLE
Misc

### DIFF
--- a/ccip-cli/src/commands/show.test.ts
+++ b/ccip-cli/src/commands/show.test.ts
@@ -268,11 +268,12 @@ describe('e2e command show EVM', () => {
     'should show complete CCIP transaction details EVM to Solana',
     { timeout: 120000 },
     async () => {
-      // Test transaction hash
-      const TX_HASH = '0xb75ffc2bd00b9a9bf5f7942cad201fa6a832fa58ffd7b773ece39531e6513670'
-      const MESSAGE_ID = '0x0be9c1da6942964676b995697e2d1f1ce3a497f1b00bcbe6a3a3b2ea9c8fd67c'
+      // Test transaction hash (refreshed periodically; devnet prunes old history)
+      const TX_HASH = '0x1490f4a989faa35049a79df1ed0c6b610dd123475f2e6cc162fff8f58e4f366f'
+      const MESSAGE_ID = '0xc5f2b594934389d3a2ca9a7218d76a432540316e9bfd544df7f51ae4d73aa4b9'
       const SENDER = '0x90656946eb4065D9FC2a0c0B9aF7Ff37c02F52a2'
-      const RECEIVER = 'BqmcnLFSbKwyMEgi7VhVeJCis1wW26VySztF34CJrKFq'
+      const RECEIVER = '11111111111111111111111111111111'
+      const TOKEN_RECEIVER = 'HNgbNNzP7YLXLhEkaFcD3PhtBWtaBfxSCNRTCsnGyPNx'
       const ONRAMP = '0x23a5084Fa78104F3DF11C63Ae59fcac4f6AD9DeE'
       const OFFRAMP = 'offqSMQWgQud6WJz694LRzkeN5kMYpCHTpXQr3Rkcjm'
 
@@ -293,28 +294,28 @@ describe('e2e command show EVM', () => {
       assert.match(output, new RegExp(`origin.*${SENDER}`, 'i'))
       assert.match(output, new RegExp(`sender.*${SENDER}`, 'i'))
       assert.match(output, new RegExp(`receiver.*${RECEIVER}`, 'i'))
-      assert.match(output, /sequenceNumber.*3923n?/)
+      assert.match(output, /sequenceNumber.*10699n?/)
       assert.match(output, /nonce.*0n?.*allow out-of-order/)
       assert.doesNotMatch(output, /gasLimit/)
-      assert.match(output, /computeUnits.*200000n?/)
+      assert.match(output, /computeUnits.*0n?/)
       assert.match(output, new RegExp(`transactionHash.*${TX_HASH}`, 'i'))
-      assert.match(output, /data.*e2e test\b/)
+      assert.match(output, /data.*0x'?/)
       assert.match(output, /allowOutOfOrderExecution.*true\b/)
-      assert.match(output, /tokenReceiver.*11111111111111111111111111111111\b/)
+      assert.match(output, new RegExp(`tokenReceiver.*${TOKEN_RECEIVER}\\b`, 'i'))
 
       // Commit information
       assert.match(output, /Commit.*dest/i)
       assert.match(
         output,
-        /merkleRoot.*0x68da9013b63f098dbb85b2b4d53933a029c8b4f06b0b2fe15ad001da10375eb4/i,
+        /merkleRoot.*0x71def4008dc00677d732f006d15b794f34eeee29bcb63e62afc012c2529bb4ef/i,
       )
-      assert.match(output, /min.*3919/)
-      assert.match(output, /max.*3924/)
-      assert.match(output, /origin.*Cc7sVief2raXko3WqgjeGYDSC7fWAPwqyAWweScSoikM/i)
+      assert.match(output, /min.*10699/)
+      assert.match(output, /max.*10699/)
+      assert.match(output, /origin.*3av6U8FGbv4W3ib6XGKaPxuKR96BsqXAo2FVhsTnwow6/i)
       assert.match(output, new RegExp(`contract.*${OFFRAMP}`, 'i'))
       assert.match(
         output,
-        /transactionHash.*3iwF1ENtLZEoVMABrFBiWzZ6pMKMngDqvgaRnKtW6NLEjd2SXZsPStwBJQGzaUFawN18CPjHP5HCPkN4mRto9k5L/i,
+        /transactionHash.*5rSzqf9e91SgAAZzLvC9LRR2e4j9f4Ei7FPCW8tgMhELnb4PB5MfT26C4zSfVctX6jCV4S4WDDLptjbgsbsz5jhe/i,
       )
 
       // Receipts information
@@ -322,19 +323,19 @@ describe('e2e command show EVM', () => {
       assert.match(output, /state.*success/i)
       assert.match(
         output,
-        /transactionHash.*u2ExFxWm7wnYEEkp89mkxtW2d9EbSap9q8im3vLg4g4NJ3PSpKTv8szhxCKaYTzSZNoJ8JLdZCVxekCFv4faa4E/i,
+        /transactionHash.*3xi8RrvjnTeVWLtAiLG7wDKZR633fUHbiP6hshjSdSQZLj83JFdgfAjccTRedSe7KTZurbmsxfPGYYPuwAdDEfd4/i,
       )
     },
   )
 })
 
 describe('e2e command show Solana', () => {
-  // Test transaction hash
+  // Test transaction hash (refreshed periodically; devnet prunes old history)
   const TX_HASH =
-    'XkdB6ed7LisqoJR6PVAcaLerckoVfyffCxDAyJG6FesLqz1E1ur1FqVCg7CVRAPz81eggyb6XXm3oKPMvfrc9s9'
-  const MESSAGE_ID = '0x6f2f352064ac9aa184ef36179a19cb47349ad754d36f64fe425db372bcb371c7'
-  const SENDER = 'GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN'
-  const RECEIVER = '0x8C244f0B2164E6A3BED74ab429B0ebd661Bb14CA'
+    '2cxcWLRnFjkwjVChqLYnVYcqU7Bb3scyCGMaVVMbec9Hmpaa6TGi9TQwqbE8CgkF9mZj7o7UBkSpx7xC5hdriYjo'
+  const MESSAGE_ID = '0x7f1af2d5da6f99acedcd9cfd9134edf5419e153389fde8a05605f23499fa95b1'
+  const SENDER = '6XS768SMgF7iEt7ZX8iJBgu7mXHewc95aqAz6XAj1hu3'
+  const RECEIVER = '0x2840D88F9c3E018544aaD8f9275DCCf12cB35160'
   const ONRAMP = 'Ccip842gzYHhvdDkSyi2YVCoAWPbYJoApMFzSxQroE9C'
   const OFFRAMP = '0x0820f975ce90EE5c508657F0C58b71D1fcc85cE0'
 
@@ -359,40 +360,39 @@ describe('e2e command show Solana', () => {
       assert.match(output, new RegExp(`origin.*${SENDER}`, 'i'))
       assert.match(output, new RegExp(`sender.*${SENDER}`, 'i'))
       assert.match(output, new RegExp(`receiver.*${RECEIVER}`))
-      assert.match(output, /sequenceNumber.*3144?/)
+      assert.match(output, /sequenceNumber.*3206?/)
       assert.match(output, /nonce.*0n?.*allow out-of-order/)
-      assert.match(output, /gasLimit.*0n?/)
+      assert.match(output, /gasLimit.*200000n?/)
       assert.match(output, /finalized.*true/)
       assert.match(output, /fee.*\bSOL/)
-      assert.match(output, /tokens.*0\.001 USDC/)
+      assert.match(output, /tokens.*0\.0001 MNT/)
       assert.match(output, new RegExp(`transactionHash.*${TX_HASH}`, 'i'))
-      assert.match(output, /data.*hello from ccip-tools-ts\b/)
+      assert.match(output, /data.*0x'?/)
       assert.match(output, /allowOutOfOrderExecution.*true\b/)
-
-      // USDC attestation
-      assert.match(output, /Attestations:/i)
-      assert.match(output, /type.*\busdc\b/i)
 
       // Commit information
       assert.match(output, /Commit.*dest/i)
       assert.match(
         output,
-        /merkleRoot.*0x291c126410cefe17ef5596ff79b8629e2875d5307e4d1bde2dc75ebcc49046d3/i,
+        /merkleRoot.*0x3b062bfc1deb01d8d93075a0d28ed958713307f5de0eedcdaef85e4af34c45c8/i,
       )
-      assert.match(output, /min.*3144/)
-      assert.match(output, /max.*3144/)
+      assert.match(output, /min.*3206/)
+      assert.match(output, /max.*3206/)
       assert.match(output, new RegExp(`contract.*${OFFRAMP}`, 'i'))
       assert.match(
         output,
-        /transactionHash.*0x1274619287fbab9acf047e32c451608b8bc7fcb2d1b51c15440640fd88fd1ede/i,
+        /transactionHash.*0xbca40d1994f2649afe67d023ebd50b27d9d1f45025d3e10c00f3b0b288580c80/i,
       )
 
-      // Receipts information
+      // Receipts information: this message had a failed execution attempt before succeeding
       assert.match(output, /Receipts.*dest/i)
-      assert.match(output, /state.*success/i)
+      const failedMatches = output.match(/failed/gi) || []
+      const successMatches = output.match(/success/gi) || []
+      assert.ok(failedMatches.length >= 1)
+      assert.ok(successMatches.length >= 1)
       assert.match(
         output,
-        /transactionHash.*0x3af7fa68693261beb5b63b38b28674aabaad1004deccca7d8e1fdbd7ec9ed093/i,
+        /transactionHash.*0x55a309abb85173c347450f957a047c9bdad62507d2f38b1505a0ef621cf1037b/i,
       )
     },
   )

--- a/ccip-cli/src/commands/utils.ts
+++ b/ccip-cli/src/commands/utils.ts
@@ -489,6 +489,15 @@ export function prettyTable(this: Ctx, args: Record<string, unknown>, opts = { s
       typeof value === 'number'
     ) {
       out.push([key, formatDate(value)])
+    } else if (last?.toString().match(/\berr$/) && value === '0x') {
+      out.push([key, '0x [possibly out-of-gas or abi.decode error]'])
+    } else if (typeof value === 'bigint' && last?.toString().match(/[Ss]el(ector)?$/)) {
+      try {
+        const val = `${value} [${networkInfo(value).name}]`
+        out.push([key, val])
+      } catch {
+        out.push([key, value])
+      }
     } else out.push([key, value])
   }
   return this.output.table(Object.fromEntries(out))

--- a/ccip-sdk/src/evm/abi/RMNProxy.ts
+++ b/ccip-sdk/src/evm/abi/RMNProxy.ts
@@ -1,0 +1,109 @@
+export default [
+  // generate:
+  // fetch('https://github.com/smartcontractkit/chainlink-ccip/raw/refs/heads/main/chains/evm/gobindings/generated/latest/rmn_proxy_contract/rmn_proxy_contract.go')
+  //   .then((res) => res.text())
+  //   .then((body) => body.match(/^\s*ABI: "(.*?)",$/m)?.[1])
+  //   .then((abi) => JSON.parse(abi.replace(/\\"/g, '"')))
+  //   .then((obj) => require('util').inspect(obj, {depth:99}).split('\n').slice(1, -1))
+  {
+    type: 'constructor',
+    inputs: [{ name: 'arm', type: 'address', internalType: 'address' }],
+    stateMutability: 'nonpayable',
+  },
+  { type: 'fallback', stateMutability: 'nonpayable' },
+  {
+    type: 'function',
+    name: 'acceptOwnership',
+    inputs: [],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    name: 'getARM',
+    inputs: [],
+    outputs: [{ name: '', type: 'address', internalType: 'address' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'owner',
+    inputs: [],
+    outputs: [{ name: '', type: 'address', internalType: 'address' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'setARM',
+    inputs: [{ name: 'arm', type: 'address', internalType: 'address' }],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    name: 'transferOwnership',
+    inputs: [{ name: 'to', type: 'address', internalType: 'address' }],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    name: 'typeAndVersion',
+    inputs: [],
+    outputs: [{ name: '', type: 'string', internalType: 'string' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'event',
+    name: 'ARMSet',
+    inputs: [
+      {
+        name: 'arm',
+        type: 'address',
+        indexed: false,
+        internalType: 'address',
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: 'event',
+    name: 'OwnershipTransferRequested',
+    inputs: [
+      {
+        name: 'from',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
+      },
+      {
+        name: 'to',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: 'event',
+    name: 'OwnershipTransferred',
+    inputs: [
+      {
+        name: 'from',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
+      },
+      {
+        name: 'to',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
+      },
+    ],
+    anonymous: false,
+  },
+  { type: 'error', name: 'ZeroAddressNotAllowed', inputs: [] },
+  // generate:end
+] as const

--- a/ccip-sdk/src/evm/const.ts
+++ b/ccip-sdk/src/evm/const.ts
@@ -20,6 +20,7 @@ import EVM2EVMOnRamp_1_5_ABI from './abi/OnRamp_1_5.ts'
 import OnRamp_1_6_ABI from './abi/OnRamp_1_6.ts'
 import OnRamp_2_0_ABI from './abi/OnRamp_2_0.ts'
 import PriceRegistry_1_2_ABI from './abi/PriceRegistry_1_2.ts'
+import RMNProxy_ABI from './abi/RMNProxy.ts'
 import Router_ABI from './abi/Router.ts'
 import TokenAdminRegistry_ABI from './abi/TokenAdminRegistry_1_5.ts'
 import TokenPool_2_0_ABI from './abi/TokenPool_2_0.ts'
@@ -49,6 +50,7 @@ export const interfaces = {
   Router: new Interface(Router_ABI),
   Token: new Interface(Token_ABI),
   TokenAdminRegistry: new Interface(TokenAdminRegistry_ABI),
+  RMNProxy: new Interface(RMNProxy_ABI),
   FeeQuoter_v1_6: new Interface(FeeQuoter_1_6_ABI),
   FeeQuoter_v2_0: new Interface(FeeQuoter_2_0_ABI),
   TokenPool_v2_0: new Interface(TokenPool_2_0_ABI),

--- a/ccip-sdk/src/evm/errors.test.ts
+++ b/ccip-sdk/src/evm/errors.test.ts
@@ -118,8 +118,7 @@ describe('recursiveParseError', () => {
     assert.equal(res[1]![0], 'err.error')
     assert.ok((res[1]![1] as string).includes('ReceiverError'))
     assert.equal(res[2]![0], 'err.err')
-    assert.match(res[2]![1] as string, /\b0x\b/)
-    assert.ok((res[2]![1] as string).includes('out-of-gas'))
+    assert.equal(res[2]![1], '0x')
   })
 
   it('should parse array error data', () => {

--- a/ccip-sdk/src/evm/errors.ts
+++ b/ccip-sdk/src/evm/errors.ts
@@ -13,7 +13,8 @@ import {
 
 import { defaultAbiCoder, interfaces } from './const.ts'
 import { decodeExtraArgs } from '../extra-args.ts'
-import { ChainFamily, networkInfo } from '../networks.ts'
+import { decodeMessageV1 } from '../messages.ts'
+import { ChainFamily } from '../networks.ts'
 
 /**
  * Get error data from an error object, if possible
@@ -156,16 +157,6 @@ export function recursiveParseError(
     )
   }
   if (!isBytesLike(data) || [0, 20].includes(dataLength(data))) {
-    if (key.match(/[Ss]el(ector)?$/) && typeof data === 'bigint') {
-      // try to include networkName for chainSelectors
-      try {
-        data = `${data} [${networkInfo(data).name}]`
-      } catch {
-        // ignore
-      }
-    } else if (key.match(/\berr$/) && data === '0x') {
-      data = '0x [possibly out-of-gas or abi.decode error]'
-    }
     return [[key, data]]
   }
   try {
@@ -198,13 +189,19 @@ export function recursiveParseError(
 export function parseData(data: unknown): Record<string, unknown> | undefined {
   if (!data) return
   if (isHexString(data)) {
-    const parsed = recursiveParseError('', data)
-    if (parsed.length === 1 && parsed[0]![1] === data) return
-    // like Object.fromEntries, but on duplicated keys, add a space to first occurrence, to avoid overwriting and keep all values
-    return parsed.reduceRight(
-      (acc, [k, v]) => ({ ...{ [k && k in acc ? k + ' ' : k]: v }, ...acc }),
-      {},
-    )
+    let parsed
+    try {
+      parsed = decodeMessageV1(data)
+      return parsed
+    } catch {
+      parsed = recursiveParseError('', data)
+      if (parsed.length === 1 && parsed[0]![1] === data) return
+      // like Object.fromEntries, but on duplicated keys, add a space to first occurrence, to avoid overwriting and keep all values
+      return parsed.reduceRight(
+        (acc, [k, v]) => ({ ...{ [k && k in acc ? k + ' ' : k]: v }, ...acc }),
+        {},
+      )
+    }
   }
   if (typeof data !== 'object') return
   // ethers tx/simulation/call errors

--- a/ccip-sdk/src/evm/index.ts
+++ b/ccip-sdk/src/evm/index.ts
@@ -2358,10 +2358,10 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
       return { verificationPolicy, verifications }
     } else if (request.lane.version < CCIPVersion.V1_6) {
       // v1.2..v1.5 EVM (only) have separate CommitStore
-      const { commitStore } = await this.getOffRampConfig(
+      const { commitStore } = (await this.getOffRampConfig(
         opts.offRamp,
         request.lane.sourceChainSelector,
-      )
+      )) as Extract<Awaited<ReturnType<EVMChain['getOffRampConfig']>>, { commitStore: unknown }>
       opts.offRamp = commitStore
     }
     // fallback <=v1.6

--- a/ccip-sdk/src/evm/index.ts
+++ b/ccip-sdk/src/evm/index.ts
@@ -122,6 +122,7 @@ import EVM2EVMOnRamp_1_5_ABI from './abi/OnRamp_1_5.ts'
 import OnRamp_1_6_ABI from './abi/OnRamp_1_6.ts'
 import OnRamp_2_0_ABI from './abi/OnRamp_2_0.ts'
 import type PriceRegistry_1_2 from './abi/PriceRegistry_1_2.ts'
+import type RMNProxy_ABI from './abi/RMNProxy.ts'
 import type Router_ABI from './abi/Router.ts'
 import type TokenAdminRegistry_1_5_ABI from './abi/TokenAdminRegistry_1_5.ts'
 import type TokenPool_2_0_ABI from './abi/TokenPool_2_0.ts'
@@ -951,6 +952,18 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
     const sourceFamily = sourceChainSelector
       ? networkInfo(sourceChainSelector).family
       : ChainFamily.EVM
+
+    const getRmn = async (rmnProxy: string): Promise<{ rmn?: string }> => {
+      if (!rmnProxy && rmnProxy === ZeroAddress) return {}
+      const proxyContract = new Contract(
+        rmnProxy,
+        interfaces.RMNProxy,
+        this.provider,
+      ) as unknown as TypedContract<typeof RMNProxy_ABI>
+      const rmn = await proxyContract.getARM()
+      return { rmn: rmn as CleanAddressable<typeof rmn> }
+    }
+
     let offRampABI, commitStoreABI
     switch (version) {
       case CCIPVersion.V1_2:
@@ -992,6 +1005,9 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
           ...csDynamicConfig,
           ...staticConfig,
           ...dynamicConfig,
+          ...(await getRmn(
+            'armProxy' in staticConfig ? staticConfig.armProxy : staticConfig.rmnProxy,
+          )),
           onRamps: [staticConfig.onRamp],
           typeAndVersion,
         }
@@ -1017,6 +1033,7 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
         return {
           ...staticConfig,
           ...dynamicConfig,
+          ...(await getRmn(staticConfig.rmnRemote)),
           sourceChainSelector: sourceChainSelector!,
           ...sourceChainConfig,
           onRamps,
@@ -1037,6 +1054,7 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
         const onRamps = sourceChainConfig.onRamps.map((o) => decodeOnRampAddress(o, sourceFamily))
         return {
           ...staticConfig,
+          ...(await getRmn(staticConfig.rmnRemote)),
           sourceChainSelector: sourceChainSelector!,
           ...sourceChainConfig,
           onRamps,
@@ -2340,10 +2358,10 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
       return { verificationPolicy, verifications }
     } else if (request.lane.version < CCIPVersion.V1_6) {
       // v1.2..v1.5 EVM (only) have separate CommitStore
-      const { commitStore } = (await this.getOffRampConfig(
+      const { commitStore } = await this.getOffRampConfig(
         opts.offRamp,
         request.lane.sourceChainSelector,
-      )) as Extract<Awaited<ReturnType<EVMChain['getOffRampConfig']>>, { commitStore: unknown }>
+      )
       opts.offRamp = commitStore
     }
     // fallback <=v1.6

--- a/ccip-sdk/src/execution.ts
+++ b/ccip-sdk/src/execution.ts
@@ -7,8 +7,9 @@ import {
   CCIPOffRampNotFoundError,
 } from './errors/index.ts'
 import { Tree, getLeafHasher, proofFlagsToBits } from './hasher/index.ts'
+import { ChainFamily } from './networks.ts'
 import type { CCIPMessage, CCIPVersion, Lane, WithLogger } from './types.ts'
-import { decodeOnRampAddress } from './utils.ts'
+import { decodeAddress, decodeOnRampAddress } from './utils.ts'
 
 /**
  * Pure/sync function to calculate/generate OffRamp.executeManually report for messageIds
@@ -124,6 +125,23 @@ export const discoverOffRamp = memoize(
       // pass
     }
 
+    // OnRamp v2.0 has `offRamp` config
+    const onRampConfig: { typeAndVersion: string; offramp?: string; offRamp?: string } =
+      await source.getOnRampConfig(onRamp, dest.network.chainSelector)
+    if (onRampConfig.offramp || onRampConfig.offRamp) {
+      let decoded = decodeAddress(
+        onRampConfig.offramp || onRampConfig.offRamp!,
+        dest.network.family,
+      )
+      if (
+        (dest.network.family === ChainFamily.Aptos || dest.network.family === ChainFamily.Sui) &&
+        !decoded.includes('::')
+      )
+        decoded += '::offramp'
+      return decoded
+    }
+
+    // fallback to pairing routers offramps
     const sourceRouter = await source.getRouterForOnRamp(onRamp, dest.network.chainSelector)
     const sourceOffRamps = await source.getOffRampsForRouter(
       sourceRouter,

--- a/ccip-sdk/src/execution.ts
+++ b/ccip-sdk/src/execution.ts
@@ -203,7 +203,9 @@ export const discoverOffRamp = memoize(
         }
       }
     }
-    throw new CCIPOffRampNotFoundError(onRamp, dest.network.name)
+    throw new CCIPOffRampNotFoundError(onRamp, dest.network.name, {
+      context: { sourceRouter, sourceOffRamps },
+    })
   },
   {
     transformKey: ([source, dest, onRamp]) =>

--- a/ccip-sdk/src/gas.test.ts
+++ b/ccip-sdk/src/gas.test.ts
@@ -36,6 +36,7 @@ function createMockChains(onRamp: string, offRamp: string) {
     getTokenForTokenPool: mock.fn(async () => getAddress(hexlify(randomBytes(20)))),
     getTokenInfo: mock.fn(async () => ({ decimals: 18 })),
     getRouterForOnRamp: mock.fn(async () => sourceRouter),
+    getOnRampConfig: mock.fn(async () => ({ typeAndVersion: 'EVM2EVMOnRamp 1.5.0' })),
     getOnRampForRouter: mock.fn(async (_router: string, _destChainSelector: bigint) => onRamp),
     getOffRampsForRouter: mock.fn(async () => [offRamp]),
     getOnRampsForOffRamp: mock.fn(async () => [destOnRamp]),

--- a/ccip-sdk/src/selectors.ts
+++ b/ccip-sdk/src/selectors.ts
@@ -943,6 +943,12 @@ const SELECTORS: Selectors = {
     network_type: 'TESTNET',
     family: 'EVM',
   },
+  '10323': {
+    selector: 9211758560309513668n,
+    name: 'mova-testnet',
+    network_type: 'TESTNET',
+    family: 'EVM',
+  },
   '11124': {
     selector: 16235373811196386733n,
     name: 'abstract-testnet',
@@ -1232,6 +1238,12 @@ const SELECTORS: Selectors = {
     name: 'treasure-mainnet',
     network_type: 'MAINNET',
     deprecated: true,
+    family: 'EVM',
+  },
+  '61900': {
+    selector: 3314641565992046393n,
+    name: 'mova-mainnet',
+    network_type: 'MAINNET',
     family: 'EVM',
   },
   '68414': {

--- a/ccip-sdk/src/solana/idl/2.0.0/CCIP_OFFRAMP.ts
+++ b/ccip-sdk/src/solana/idl/2.0.0/CCIP_OFFRAMP.ts
@@ -1,0 +1,94 @@
+/**
+ * Minimal CCIP v2 (`ccip-offramp 2.0.0-dev`) IDL.
+ *
+ * Only the pieces the SDK needs beyond the 1.6.0 offramp IDL: the `SourceChain` account
+ * (`source_chain_state` PDA seed) whose layout changed in v2. The `ReferenceAddresses`
+ * account is byte-identical to 1.6.0, so it keeps being read via the 1.6.0 IDL in
+ * "compatibility mode".
+ *
+ * v2 `SourceChain` dropped the `state` field (`minSeqNr`) and reshaped `SourceChainConfig`
+ * (removed `isRmnVerificationDisabled`/`laneCodeVersion`, added the CCV vecs). Anchor 0.29
+ * IDL format.
+ */
+export type CcipOfframpV2 = {
+  version: '2.0.0'
+  name: 'ccip_offramp'
+  instructions: []
+  accounts: [
+    {
+      name: 'sourceChain'
+      type: {
+        kind: 'struct'
+        fields: [
+          { name: 'version'; type: 'u8' },
+          { name: 'chainSelector'; type: 'u64' },
+          { name: 'config'; type: { defined: 'SourceChainConfig' } },
+        ]
+      }
+    },
+  ]
+  types: [
+    {
+      name: 'SourceChainConfig'
+      type: {
+        kind: 'struct'
+        fields: [
+          { name: 'isEnabled'; type: 'bool' },
+          { name: 'onRamp'; type: { defined: 'OnRampAddress' } },
+          { name: 'defaultCcvs'; type: { vec: 'publicKey' } },
+          { name: 'laneMandatedCcvs'; type: { vec: 'publicKey' } },
+        ]
+      }
+    },
+    {
+      name: 'OnRampAddress'
+      type: {
+        kind: 'struct'
+        fields: [{ name: 'bytes'; type: { array: ['u8', 64] } }, { name: 'len'; type: 'u32' }]
+      }
+    },
+  ]
+}
+
+export const IDL: CcipOfframpV2 = {
+  version: '2.0.0',
+  name: 'ccip_offramp',
+  instructions: [],
+  accounts: [
+    {
+      name: 'sourceChain',
+      type: {
+        kind: 'struct',
+        fields: [
+          { name: 'version', type: 'u8' },
+          { name: 'chainSelector', type: 'u64' },
+          { name: 'config', type: { defined: 'SourceChainConfig' } },
+        ],
+      },
+    },
+  ],
+  types: [
+    {
+      name: 'SourceChainConfig',
+      type: {
+        kind: 'struct',
+        fields: [
+          { name: 'isEnabled', type: 'bool' },
+          { name: 'onRamp', type: { defined: 'OnRampAddress' } },
+          { name: 'defaultCcvs', type: { vec: 'publicKey' } },
+          { name: 'laneMandatedCcvs', type: { vec: 'publicKey' } },
+        ],
+      },
+    },
+    {
+      name: 'OnRampAddress',
+      type: {
+        kind: 'struct',
+        fields: [
+          { name: 'bytes', type: { array: ['u8', 64] } },
+          { name: 'len', type: 'u32' },
+        ],
+      },
+    },
+  ],
+}

--- a/ccip-sdk/src/solana/idl/2.0.0/CCIP_ROUTER.ts
+++ b/ccip-sdk/src/solana/idl/2.0.0/CCIP_ROUTER.ts
@@ -1,0 +1,152 @@
+/**
+ * Minimal CCIP v2 (`ccip-router 2.0.0-dev`) IDL.
+ *
+ * We deliberately keep this tiny and only describe what the SDK needs beyond the
+ * v1.6 IDL: the `DestChainCcipV2` account (stored under the `dest_chain_state_v2`
+ * PDA seed) plus the types it references. Everything else about the v2 router is
+ * handled in "compatibility mode" via the existing 1.6.0 IDL — the `Config`
+ * account, for instance, is byte-compatible (v2 only appends a trailing field).
+ *
+ * Anchor 0.29 IDL format. `UsdCents`/`CrossChainGas` are `u32` newtypes in the
+ * upstream v2 IDL, inlined here as `u32` (identical borsh layout).
+ *
+ * NOTE: the upstream v2 IDL also has a trailing `baseExecutionGasCost` (CrossChainGas)
+ * field on `DestChainConfigCcipV2`, but the currently-deployed devnet `-dev` accounts
+ * don't carry it. We stop at `tokenTransferNetworkFee` so decoding matches on-chain
+ * data — borsh ignores trailing bytes, so this stays forward-compatible if/when the
+ * deployed accounts grow the extra field.
+ */
+export type CcipRouterV2 = {
+  version: '2.0.0'
+  name: 'ccip_router'
+  instructions: []
+  accounts: [
+    {
+      name: 'destChainCcipV2'
+      type: {
+        kind: 'struct'
+        fields: [
+          { name: 'bump'; type: 'u8' },
+          { name: 'version'; type: 'u8' },
+          { name: 'chainSelector'; type: 'u64' },
+          { name: 'state'; type: { defined: 'DestChainState' } },
+          { name: 'config'; type: { defined: 'DestChainConfigCcipV2' } },
+        ]
+      }
+    },
+    {
+      // Marker account: existence declares an OffRamp allowed for a (sourceChainSelector, offRamp)
+      // pair. No data beyond the discriminator — the pair lives in the PDA seeds
+      // `[allowed_offramp, sourceChainSelector.to_le_bytes(), offRamp]`.
+      name: 'allowedOfframp'
+      type: { kind: 'struct'; fields: [] }
+    },
+  ]
+  types: [
+    {
+      name: 'DestChainState'
+      type: {
+        kind: 'struct'
+        fields: [
+          { name: 'sequenceNumber'; type: 'u64' },
+          { name: 'sequenceNumberToRestore'; type: 'u64' },
+          { name: 'restoreOnAction'; type: { defined: 'RestoreOnAction' } },
+        ]
+      }
+    },
+    {
+      name: 'DestChainConfigCcipV2'
+      type: {
+        kind: 'struct'
+        fields: [
+          { name: 'laneCodeVersion'; type: { defined: 'CodeVersion' } },
+          { name: 'allowedSenders'; type: { vec: 'publicKey' } },
+          { name: 'allowListEnabled'; type: 'bool' },
+          { name: 'defaultCcvs'; type: { vec: 'publicKey' } },
+          { name: 'laneMandatedCcvs'; type: { vec: 'publicKey' } },
+          { name: 'defaultExecutor'; type: 'publicKey' },
+          { name: 'offramp'; type: 'bytes' },
+          { name: 'messageNetworkFee'; type: 'u32' },
+          { name: 'tokenTransferNetworkFee'; type: 'u32' },
+        ]
+      }
+    },
+    {
+      name: 'CodeVersion'
+      type: { kind: 'enum'; variants: [{ name: 'Default' }, { name: 'V1' }] }
+    },
+    {
+      name: 'RestoreOnAction'
+      type: {
+        kind: 'enum'
+        variants: [{ name: 'None' }, { name: 'Upgrade' }, { name: 'Rollback' }]
+      }
+    },
+  ]
+}
+
+export const IDL: CcipRouterV2 = {
+  version: '2.0.0',
+  name: 'ccip_router',
+  instructions: [],
+  accounts: [
+    {
+      name: 'destChainCcipV2',
+      type: {
+        kind: 'struct',
+        fields: [
+          { name: 'bump', type: 'u8' },
+          { name: 'version', type: 'u8' },
+          { name: 'chainSelector', type: 'u64' },
+          { name: 'state', type: { defined: 'DestChainState' } },
+          { name: 'config', type: { defined: 'DestChainConfigCcipV2' } },
+        ],
+      },
+    },
+    {
+      name: 'allowedOfframp',
+      type: { kind: 'struct', fields: [] },
+    },
+  ],
+  types: [
+    {
+      name: 'DestChainState',
+      type: {
+        kind: 'struct',
+        fields: [
+          { name: 'sequenceNumber', type: 'u64' },
+          { name: 'sequenceNumberToRestore', type: 'u64' },
+          { name: 'restoreOnAction', type: { defined: 'RestoreOnAction' } },
+        ],
+      },
+    },
+    {
+      name: 'DestChainConfigCcipV2',
+      type: {
+        kind: 'struct',
+        fields: [
+          { name: 'laneCodeVersion', type: { defined: 'CodeVersion' } },
+          { name: 'allowedSenders', type: { vec: 'publicKey' } },
+          { name: 'allowListEnabled', type: 'bool' },
+          { name: 'defaultCcvs', type: { vec: 'publicKey' } },
+          { name: 'laneMandatedCcvs', type: { vec: 'publicKey' } },
+          { name: 'defaultExecutor', type: 'publicKey' },
+          { name: 'offramp', type: 'bytes' },
+          { name: 'messageNetworkFee', type: 'u32' },
+          { name: 'tokenTransferNetworkFee', type: 'u32' },
+        ],
+      },
+    },
+    {
+      name: 'CodeVersion',
+      type: { kind: 'enum', variants: [{ name: 'Default' }, { name: 'V1' }] },
+    },
+    {
+      name: 'RestoreOnAction',
+      type: {
+        kind: 'enum',
+        variants: [{ name: 'None' }, { name: 'Upgrade' }, { name: 'Rollback' }],
+      },
+    },
+  ],
+}

--- a/ccip-sdk/src/solana/index.ts
+++ b/ccip-sdk/src/solana/index.ts
@@ -111,13 +111,18 @@ import { cleanUpBuffers } from './cleanup.ts'
 import { generateUnsignedExecuteReport } from './exec.ts'
 import { estimateExecComputeUnits } from './gas.ts'
 import { getV16SolanaLeafHasher } from './hasher.ts'
+import { buildMessageForDest, normalizeDeep } from '../requests.ts'
+import { DEFAULT_GAS_LIMIT } from '../shared/constants.ts'
 import { IDL as BASE_TOKEN_POOL } from './idl/1.6.0/BASE_TOKEN_POOL.ts'
 import { IDL as BURN_MINT_TOKEN_POOL } from './idl/1.6.0/BURN_MINT_TOKEN_POOL.ts'
 import { IDL as CCIP_CCTP_TOKEN_POOL } from './idl/1.6.0/CCIP_CCTP_TOKEN_POOL.ts'
 import { IDL as CCIP_OFFRAMP_IDL } from './idl/1.6.0/CCIP_OFFRAMP.ts'
 import { IDL as CCIP_ROUTER_IDL } from './idl/1.6.0/CCIP_ROUTER.ts'
 import { IDL as FEE_QUOTER_IDL } from './idl/1.6.0/FEE_QUOTER.ts'
+import { IDL as CCIP_OFFRAMP_V2_IDL } from './idl/2.0.0/CCIP_OFFRAMP.ts'
+import { IDL as CCIP_ROUTER_V2_IDL } from './idl/2.0.0/CCIP_ROUTER.ts'
 import { getTransactionsForAddress } from './logs.ts'
+import { patchBorsh } from './patchBorsh.ts'
 import { generateUnsignedCcipSend, getFee } from './send.ts'
 import { type CCIPMessage_V1_6_Solana, type UnsignedSolanaTx, isWallet } from './types.ts'
 import {
@@ -129,9 +134,6 @@ import {
   simulateAndSendTxs,
   simulationProvider,
 } from './utils.ts'
-import { buildMessageForDest, normalizeDeep } from '../requests.ts'
-import { patchBorsh } from './patchBorsh.ts'
-import { DEFAULT_GAS_LIMIT } from '../shared/constants.ts'
 export type { UnsignedSolanaTx }
 
 const routerCoder = new BorshCoder(CCIP_ROUTER_IDL)
@@ -594,8 +596,37 @@ export class SolanaChain extends Chain<typeof ChainFamily.Solana> {
 
   /** {@inheritDoc Chain.getOnRampConfig} */
   async getOnRampConfig(onRamp: string, destChainSelector: bigint) {
-    const [, , typeAndVersion] = await this.typeAndVersion(onRamp)
+    const [, version, typeAndVersion] = await this.typeAndVersion(onRamp)
     const routerConfig = await this._getRouterConfig(onRamp)
+
+    // CCIP v2 router (`ccip-router 2.0.0-dev`) stores the per-lane dest chain state under a
+    // different PDA seed (`dest_chain_state_v2`) and account type (`DestChainCcipV2`), and folds
+    // the lane fee config into that account instead of a separate FeeQuoter dest_chain account
+    // (fees are quoted by a committee-verifier CCV at send time). Handle it separately; the rest
+    // of the router (Config account) stays byte-compatible with the 1.6 IDL.
+    if (version.startsWith('2.')) {
+      const program = new Program(CCIP_ROUTER_V2_IDL, new PublicKey(onRamp), {
+        connection: this.connection,
+      })
+      const [destChainStatePda] = PublicKey.findProgramAddressSync(
+        [Buffer.from('dest_chain_state_v2'), toLeArray(destChainSelector, 8)],
+        new PublicKey(onRamp),
+      )
+      const destChainState = await program.account.destChainCcipV2.fetch(destChainStatePda)
+      return normalizeDeep(
+        {
+          ...routerConfig,
+          destChainSelector,
+          ...destChainState.config,
+          router: onRamp,
+          typeAndVersion,
+        },
+        {
+          sourceFamily: (this.constructor as typeof SolanaChain).family,
+          destFamily: networkInfo(destChainSelector).family,
+        },
+      )
+    }
 
     const program = new Program(CCIP_ROUTER_IDL, new PublicKey(onRamp), {
       connection: this.connection,
@@ -658,22 +689,28 @@ export class SolanaChain extends Chain<typeof ChainFamily.Solana> {
    */
   async getOffRampConfig(offRamp: string, sourceChainSelector: bigint) {
     const offRamp_ = new PublicKey(offRamp)
-    const [, , typeAndVersion] = await this.typeAndVersion(offRamp)
+    const [, version, typeAndVersion] = await this.typeAndVersion(offRamp)
 
+    // referenceAddresses is byte-identical across 1.6 and 2.0, so read it with the 1.6 IDL always.
     const refAddresses = await this._getOffRampReferenceAddresses(offRamp)
 
-    // Read referenceAddresses PDA for router and other fields
-    const program = new Program(CCIP_OFFRAMP_IDL, offRamp_, { connection: this.connection })
+    // The `source_chain_state` PDA seed is unchanged in v2, but the `SourceChain` account layout
+    // differs: v2 dropped the `state` (minSeqNr) field and reshaped `SourceChainConfig`. Decode
+    // with the matching IDL.
+    const isV2 = version.startsWith('2.')
+    const program = new Program(isV2 ? CCIP_OFFRAMP_V2_IDL : CCIP_OFFRAMP_IDL, offRamp_, {
+      connection: this.connection,
+    })
 
     // Read source_chain_state PDA for onRamp and other config fields
     const [statePda] = PublicKey.findProgramAddressSync(
       [Buffer.from('source_chain_state'), toLeArray(sourceChainSelector, 8)],
       offRamp_,
     )
-    const {
-      config: { onRamp: onRampField, ...sourceConfig },
-      state,
-    } = await program.account.sourceChain.fetch(statePda)
+    const sourceChain = await program.account.sourceChain.fetch(statePda)
+    const { onRamp: onRampField, ...sourceConfig } = sourceChain.config
+    // v1 carries a per-lane `state` (minSeqNr); v2 has none.
+    const state = 'state' in sourceChain ? sourceChain.state : undefined
     const onRamp = decodeAddress(
       getAddressBytes(onRampField.bytes).subarray(0, onRampField.len),
       networkInfo(sourceChainSelector).family,
@@ -705,6 +742,11 @@ export class SolanaChain extends Chain<typeof ChainFamily.Solana> {
    * @throws {@link CCIPSolanaOffRampEventsNotFoundError} if no OffRamp events found
    */
   async getOffRampsForRouter(router: string, sourceChainSelector: bigint): Promise<string[]> {
+    const [, version] = await this.typeAndVersion(router)
+    if (version.startsWith('2.')) {
+      return this._getOffRampsForRouterV2(router, sourceChainSelector)
+    }
+
     // feeQuoter is present in router's config, and has a DestChainState account which is updated by
     // the offramps, so we can use it to narrow the search for the offramp
     const { feeQuoter } = await this._getRouterConfig(router)
@@ -724,6 +766,57 @@ export class SolanaChain extends Chain<typeof ChainFamily.Solana> {
       return [log.address] // assume single offramp per router/deployment on Solana
     }
     throw new CCIPSolanaOffRampEventsNotFoundError(feeQuoter.toString())
+  }
+
+  /**
+   * OffRamp discovery for CCIP v2 routers.
+   *
+   * v2 OffRamps don't touch the FeeQuoter's `dest_chain` state, so the v1 event-scan heuristic
+   * finds nothing. Instead, the router owns an `AllowedOfframp` marker PDA per allowed
+   * `(sourceChainSelector, offRamp)` pair, seeded as `[allowed_offramp, selectorLE, offRamp]`.
+   * The offRamp pubkey lives only in the seeds (marker data is just the discriminator), so we:
+   *  1. enumerate the router's `AllowedOfframp` markers,
+   *  2. read each marker's transaction history (offRamps reference their marker when executing),
+   *  3. for every account key seen in those txs, re-derive the marker PDA for our
+   *     `sourceChainSelector` and keep the keys that reproduce the marker address.
+   * A match proves both that the key is the offRamp program and that it's allowed for this source.
+   */
+  private async _getOffRampsForRouterV2(
+    router: string,
+    sourceChainSelector: bigint,
+  ): Promise<string[]> {
+    const routerPk = new PublicKey(router)
+    const program = new Program(CCIP_ROUTER_V2_IDL, routerPk, { connection: this.connection })
+    const markers = await program.account.allowedOfframp.all()
+
+    const offRamps = new Set<string>()
+    for (const { publicKey: marker } of markers) {
+      // Quick check: does this marker belong to our source selector for any candidate offRamp?
+      // We can only answer by testing candidate keys pulled from the marker's txs.
+      const sigs = await this.connection.getSignaturesForAddress(marker, { limit: 10 })
+      for (const { signature } of sigs) {
+        const tx = await this.connection.getTransaction(signature, {
+          maxSupportedTransactionVersion: 0,
+          commitment: 'confirmed',
+        })
+        if (!tx) continue
+        const keys = tx.transaction.message
+          .getAccountKeys({ accountKeysFromLookups: tx.meta?.loadedAddresses })
+          .keySegments()
+          .flat()
+        for (const key of keys) {
+          const [pda] = PublicKey.findProgramAddressSync(
+            [Buffer.from('allowed_offramp'), toLeArray(sourceChainSelector, 8), key.toBuffer()],
+            routerPk,
+          )
+          if (pda.equals(marker)) offRamps.add(key.toBase58())
+        }
+        if (offRamps.size) break // found the offRamp for this marker
+      }
+    }
+
+    if (!offRamps.size) throw new CCIPSolanaOffRampEventsNotFoundError(router)
+    return [...offRamps]
   }
 
   /** {@inheritDoc Chain.getOnRampForRouter} */

--- a/ccip-sdk/src/solana/index.ts
+++ b/ccip-sdk/src/solana/index.ts
@@ -248,6 +248,7 @@ export class SolanaChain extends Chain<typeof ChainFamily.Solana> {
       async: true,
       maxArgs: 1,
       maxSize: 100,
+      expires: 5e3,
     })
     this.getTokenForTokenPool = memoize(this.getTokenForTokenPool.bind(this), {
       async: true,
@@ -259,32 +260,11 @@ export class SolanaChain extends Chain<typeof ChainFamily.Solana> {
       maxArgs: 1,
       maxSize: 100,
     })
-    this.connection.getSignaturesForAddress = memoize(
-      this.connection.getSignaturesForAddress.bind(this.connection),
-      {
-        async: true,
-        maxSize: 100,
-        // if options.before is defined, caches for long, otherwise for short (recent signatures)
-        expires: (key) => (key[1] ? 2 ** 31 - 1 : 5e3),
-        transformKey: ([address, options, commitment]: [
-          address: PublicKey,
-          options?: SignaturesForAddressOptions,
-          commitment?: Finality,
-        ]) =>
-          [
-            address.toBase58(),
-            options?.before,
-            options?.until,
-            options?.limit,
-            commitment,
-          ] as const,
-      },
-    )
     // cache account info for 30 seconds
     this.connection.getAccountInfo = memoize(this.connection.getAccountInfo.bind(this.connection), {
       maxSize: 100,
       maxArgs: 2,
-      expires: 30e3,
+      expires: 5e3,
       transformKey: ([address, commitment]) =>
         [(address as PublicKey).toString(), commitment] as const,
     })

--- a/ccip-sdk/src/solana/index.ts
+++ b/ccip-sdk/src/solana/index.ts
@@ -5,8 +5,6 @@ import { NATIVE_MINT } from '@solana/spl-token'
 import {
   type Commitment,
   type ConnectionConfig,
-  type Finality,
-  type SignaturesForAddressOptions,
   type VersionedTransactionResponse,
   Connection,
   PublicKey,

--- a/ccip-sdk/src/solana/logs.ts
+++ b/ccip-sdk/src/solana/logs.ts
@@ -46,7 +46,7 @@ async function* fetchSigsForward(
   allSigs.reverse() // forward
 
   const notAfter =
-    typeof opts.endBlock !== 'number' && typeof opts.endBlock !== 'bigint'
+    (typeof opts.endBlock !== 'number' && typeof opts.endBlock !== 'bigint') || !opts.endBlock
       ? undefined
       : Number(opts.endBlock) < 0
         ? (await connection.getSlot('confirmed')) + Number(opts.endBlock)

--- a/ccip-sdk/src/ton/utils.ts
+++ b/ccip-sdk/src/ton/utils.ts
@@ -438,7 +438,7 @@ export async function lookupTxByRawHash(
       headers: { Accept: 'application/json' },
     })
   } catch (error) {
-    logger.error(`TonCenter V3 fetch failed:`, error)
+    logger.debug(`TonCenter V3 fetch failed:`, error)
     throw new CCIPTransactionNotFoundError(hash, { cause: error as Error })
   }
 

--- a/ccip-sdk/src/utils.test.ts
+++ b/ccip-sdk/src/utils.test.ts
@@ -1259,8 +1259,8 @@ describe('jsonStringify', () => {
     assert.equal(jsonStringify(false), 'false')
   })
 
-  it('should return undefined for undefined input', () => {
-    assert.equal(jsonStringify(undefined), undefined)
+  it('should serialize undefined as null', () => {
+    assert.equal(jsonStringify(undefined), 'null')
   })
 
   it('should handle nested objects with bigints', () => {

--- a/ccip-sdk/src/utils.ts
+++ b/ccip-sdk/src/utils.ts
@@ -210,7 +210,6 @@ export function jsonStringify(value: unknown, space?: string | number): string {
     space,
   )
   // JSON.stringify is typed `string` but returns undefined for undefined input.
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   return json.replace(INT_TAG_RE, '$1')
 }
 

--- a/ccip-sdk/src/utils.ts
+++ b/ccip-sdk/src/utils.ts
@@ -145,7 +145,7 @@ function createUncircularReplacer() {
     // bigints pass through untouched; serialization to bare JSON numbers is
     // handled by stringifyExtended below.
     const replaced = value
-    if (typeof replaced !== 'object' || replaced === null) return replaced
+    if (typeof replaced !== 'object' || replaced == null) return replaced
 
     while (holderStack.length > 0 && holderStack.at(-1) !== this) {
       holderStack.pop()
@@ -195,6 +195,7 @@ const INT_TAG_RE = new RegExp(`"${INT_TAG}(-?\\d+(?:.0)?)"`, 'g')
  * ```
  */
 export function jsonStringify(value: unknown, space?: string | number): string {
+  if (value == null) return 'null'
   const uncircular = createUncircularReplacer()
   const json = JSON.stringify(
     value,
@@ -210,7 +211,7 @@ export function jsonStringify(value: unknown, space?: string | number): string {
   )
   // JSON.stringify is typed `string` but returns undefined for undefined input.
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-  return json === undefined ? json : json.replace(INT_TAG_RE, '$1')
+  return json.replace(INT_TAG_RE, '$1')
 }
 
 /**


### PR DESCRIPTION
This pull request introduces support for new CCIP v2 (2.0.0) Solana IDLs, adds EVM support for the RMNProxy contract, improves OffRamp discovery for EVM and non-EVM chains, and makes error handling and network selector updates. The changes enhance cross-chain compatibility and improve developer experience when working with new chain versions and error diagnostics.

**Solana v2 IDL Support:**

* Added minimal IDL definitions for Solana CCIP Offramp and Router v2.0.0, supporting new account layouts and fields required for v2 compatibility (`ccip-sdk/src/solana/idl/2.0.0/CCIP_OFFRAMP.ts`, `ccip-sdk/src/solana/idl/2.0.0/CCIP_ROUTER.ts`). [[1]](diffhunk://#diff-88bb8ed17a2b9e29ef3b96b102b2af3ad4f1552dc4e7fd5f53c22ea270598b42R1-R94) [[2]](diffhunk://#diff-e4f4c38f3fa0ad2c4e6c9f713206d77b7a629f05b6ae5d2e1c33b8a001f9576bR1-R152)

**EVM RMNProxy Support:**

* Added the `RMNProxy` ABI and integrated it into the EVM SDK, including logic to fetch the ARM address from a proxy contract and expose it in OffRamp config results (`ccip-sdk/src/evm/abi/RMNProxy.ts`, `ccip-sdk/src/evm/const.ts`, `ccip-sdk/src/evm/index.ts`). [[1]](diffhunk://#diff-9e9c3bafc0f36033b6151d5f9378497bb2fdd52c42194649bcc879f3260f5ac4R1-R109) [[2]](diffhunk://#diff-628009ca6e87146479d6d0c86680008db1f489b301d98f55ca64f8c828ef718aR23) [[3]](diffhunk://#diff-628009ca6e87146479d6d0c86680008db1f489b301d98f55ca64f8c828ef718aR53) [[4]](diffhunk://#diff-cae1d5fb496ff335e72129fb79782365f7f977991d0e3cdb2f7bc062f2e060ceR125) [[5]](diffhunk://#diff-cae1d5fb496ff335e72129fb79782365f7f977991d0e3cdb2f7bc062f2e060ceR955-R966) [[6]](diffhunk://#diff-cae1d5fb496ff335e72129fb79782365f7f977991d0e3cdb2f7bc062f2e060ceR1008-R1010) [[7]](diffhunk://#diff-cae1d5fb496ff335e72129fb79782365f7f977991d0e3cdb2f7bc062f2e060ceR1036) [[8]](diffhunk://#diff-cae1d5fb496ff335e72129fb79782365f7f977991d0e3cdb2f7bc062f2e060ceR1057)

**OffRamp Discovery Improvements:**

* Enhanced OffRamp discovery to use the `offramp` field from OnRamp v2.0 config when available, and improved error reporting by including context when OffRamp discovery fails (`ccip-sdk/src/execution.ts`). [[1]](diffhunk://#diff-cdce02e49926edff8518f8d5fb4751b33353c96f27ed023a94a68d67f09fe1bbR128-R144) [[2]](diffhunk://#diff-cdce02e49926edff8518f8d5fb4751b33353c96f27ed023a94a68d67f09fe1bbL206-R226)

**Error Handling and Output:**

* Refactored error parsing to delegate to `decodeMessageV1` for hex strings, and improved pretty-printing of error tables with network names and better diagnostics for certain error fields (`ccip-sdk/src/evm/errors.ts`, `ccip-cli/src/commands/utils.ts`). [[1]](diffhunk://#diff-0d03cad19a7111895ec1b19a47d2d242dc179cc8171ec45d6b0a649c72ef1282L16-R17) [[2]](diffhunk://#diff-0d03cad19a7111895ec1b19a47d2d242dc179cc8171ec45d6b0a649c72ef1282L159-L168) [[3]](diffhunk://#diff-0d03cad19a7111895ec1b19a47d2d242dc179cc8171ec45d6b0a649c72ef1282L201-R205) [[4]](diffhunk://#diff-01ab7935dc8f869b479e3f537db8d2de2d9801bb7f744aff8f7ccde47725738eR492-R500)

**Network Selector Updates:**

* Added support for new chain selectors: `mova-testnet` and `mova-mainnet` in the selectors registry (`ccip-sdk/src/selectors.ts`). [[1]](diffhunk://#diff-c19620a355f5029b2d629dda476b3e2e3a50700e171588d0972cc375c8916078R946-R951) [[2]](diffhunk://#diff-c19620a355f5029b2d629dda476b3e2e3a50700e171588d0972cc375c8916078R1243-R1248)

These updates collectively improve the SDK's support for new chain versions, error handling, and cross-chain contract interactions.