### PR TITLE
feat(cct-sdk): Add accept admin evm op

### DIFF
--- a/ccip-sdk/src/cct/evm/index.test.ts
+++ b/ccip-sdk/src/cct/evm/index.test.ts
@@ -600,4 +600,126 @@ describe('EVMTokenManager (cct/evm)', () => {
       )
     })
   })
+  describe('getTokenAdminRegistry', () => {
+    const GET_TOKEN_CONFIG_IFACE = new Interface([
+      'function getTokenConfig(address token) view returns (tuple(address administrator, address pendingAdministrator, address tokenPool))',
+    ])
+    const ADMINISTRATOR = '0x' + '77'.repeat(20)
+
+    /**
+     * Chain stub whose provider answers `getTokenConfig` with `administrator`/zeroed others —
+     * but only for a call to `TAR` decoding to `TOKEN`. Mirrors the target/argument assertions in
+     * `token-admin-registry/operations/get-token-admin-registry.test.ts`'s `stubChain`: matching
+     * on the selector alone can't tell a correct read from one with the call target or decoded
+     * token swapped, since both would still reach this branch and get `encoded` back.
+     */
+    function stubTarChain(administrator: string) {
+      const selector = GET_TOKEN_CONFIG_IFACE.getFunction('getTokenConfig')!.selector
+      const encoded = GET_TOKEN_CONFIG_IFACE.encodeFunctionResult('getTokenConfig', [
+        [administrator, ZeroAddress, ZeroAddress],
+      ])
+      return stubChain({
+        provider: {
+          call: async ({ to, data }: { to?: string; data: string }) => {
+            if (data.slice(0, 10) !== selector) return '0x'
+            assert.equal(to, TAR, 'calls the resolved TAR, not `address`')
+            const [token] = GET_TOKEN_CONFIG_IFACE.decodeFunctionData('getTokenConfig', data)
+            assert.equal(token, TOKEN, 'reads the config for `tokenAddress`')
+            return encoded
+          },
+        } as never,
+      })
+    }
+
+    it('reads through the wrapped chain, resolving the TAR from `address`', async () => {
+      const config = await EVMTokenManager.fromChain(
+        stubTarChain(ADMINISTRATOR),
+      ).getTokenAdminRegistry({
+        address: ROUTER,
+        tokenAddress: TOKEN,
+      })
+      assert.deepEqual(config, { administrator: ADMINISTRATOR })
+    })
+
+    it('reports a zero administrator rather than throwing', async () => {
+      const config = await EVMTokenManager.fromChain(
+        stubTarChain(ZeroAddress),
+      ).getTokenAdminRegistry({ address: ROUTER, tokenAddress: TOKEN })
+      assert.equal(config.administrator, ZeroAddress)
+    })
+
+    it('rejects an invalid token address before any RPC, tagged with the operation', async () => {
+      let called = false
+      const cct = EVMTokenManager.fromChain(
+        stubChain({
+          getTokenAdminRegistryFor: () => {
+            called = true
+            return Promise.resolve(TAR)
+          },
+        }),
+      )
+      await assert.rejects(
+        () => cct.getTokenAdminRegistry({ address: ROUTER, tokenAddress: 'not-an-address' }),
+        (err: unknown) =>
+          err instanceof CCTParamsInvalidError &&
+          err.context.operation === 'getTokenAdminRegistry' &&
+          err.context.param === 'tokenAddress',
+      )
+      assert.equal(called, false, 'validation fails before TAR discovery')
+    })
+  })
+  describe('getSupportedTokens', () => {
+    it('resolves the TAR and lists its configured tokens', async () => {
+      const tokens = [TOKEN, POOL]
+      let seenOpts: { page?: number } | undefined
+      const cct = EVMTokenManager.fromChain(
+        stubChain({
+          getSupportedTokens: async (registry: string, opts?: { page?: number }) => {
+            assert.equal(registry, TAR)
+            seenOpts = opts
+            return tokens
+          },
+        }),
+      )
+
+      const result = await cct.getSupportedTokens({ address: ROUTER })
+      assert.deepEqual(result, tokens)
+      assert.deepEqual(seenOpts, { page: undefined })
+    })
+
+    it('forwards `page` to the wrapped chain', async () => {
+      let seenPage: number | undefined
+      const cct = EVMTokenManager.fromChain(
+        stubChain({
+          getSupportedTokens: async (_registry: string, opts?: { page?: number }) => {
+            seenPage = opts?.page
+            return []
+          },
+        }),
+      )
+
+      await cct.getSupportedTokens({ address: ROUTER, page: 25 })
+      assert.equal(seenPage, 25)
+    })
+
+    it('rejects an invalid address before any RPC, tagged with the operation', async () => {
+      let called = false
+      const cct = EVMTokenManager.fromChain(
+        stubChain({
+          getTokenAdminRegistryFor: () => {
+            called = true
+            return Promise.resolve(TAR)
+          },
+        }),
+      )
+      await assert.rejects(
+        () => cct.getSupportedTokens({ address: 'not-an-address' }),
+        (err: unknown) =>
+          err instanceof CCTParamsInvalidError &&
+          err.context.operation === 'getSupportedTokens' &&
+          err.context.param === 'address',
+      )
+      assert.equal(called, false, 'validation fails before TAR discovery')
+    })
+  })
 })

--- a/ccip-sdk/src/cct/evm/index.test.ts
+++ b/ccip-sdk/src/cct/evm/index.test.ts
@@ -103,6 +103,22 @@ const EXPECTED_DATA = new Interface([
 const EXPECTED_TRANSFER = new Interface([
   'function transferOwnership(address to)',
 ]).encodeFunctionData('transferOwnership', [TOKEN])
+const ACCEPT_ADMIN_SELECTOR = id('acceptAdminRole(address)').slice(0, 10)
+const EXPECTED_ACCEPT_ADMIN = new Interface([
+  'function acceptAdminRole(address localToken)',
+]).encodeFunctionData('acceptAdminRole', [TOKEN])
+
+/** Fake provider whose `call` answers `getTokenConfig` with `pendingAdministrator = TOKEN`. */
+function acceptAdminProvider(pendingAdministrator: string) {
+  return {
+    call: () =>
+      Promise.resolve(
+        interfaces.TokenAdminRegistry.encodeFunctionResult('getTokenConfig', [
+          [ZeroAddress, pendingAdministrator, ZeroAddress],
+        ]),
+      ),
+  }
+}
 
 describe('EVMTokenManager (cct/evm)', () => {
   describe('construction', () => {
@@ -464,6 +480,124 @@ describe('EVMTokenManager (cct/evm)', () => {
           err.context.param === 'poolAddress',
       )
       assert.equal(probed, false, 'validation fails before the typeAndVersion probe')
+    })
+  })
+  describe('generateUnsignedAcceptAdmin', () => {
+    it('encodes acceptAdminRole(token) to the discovered TAR when sender is pending', async () => {
+      const cct = EVMTokenManager.fromChain(
+        stubChain({ provider: acceptAdminProvider(TOKEN) as never }),
+      )
+      const unsigned = await cct.generateUnsignedAcceptAdmin({
+        tokenAddress: TOKEN,
+        address: ROUTER,
+        sender: TOKEN,
+      })
+
+      assert.equal(unsigned.family, ChainFamily.EVM)
+      assert.equal(unsigned.transactions.length, 1)
+
+      const tx = unsigned.transactions[0]!
+      assert.equal(tx.to, TAR)
+      assert.equal(tx.from, TOKEN)
+      assert.ok(
+        tx.data!.startsWith(ACCEPT_ADMIN_SELECTOR),
+        'data starts with acceptAdminRole selector',
+      )
+      assert.equal(tx.data, EXPECTED_ACCEPT_ADMIN)
+    })
+
+    it('rejects an invalid address before any RPC, tagged with the operation', async () => {
+      let called = false
+      const cct = EVMTokenManager.fromChain(
+        stubChain({
+          getTokenAdminRegistryFor: () => {
+            called = true
+            return Promise.resolve(TAR)
+          },
+        }),
+      )
+      await assert.rejects(
+        () =>
+          cct.generateUnsignedAcceptAdmin({
+            tokenAddress: 'not-an-address',
+            address: ROUTER,
+            sender: TOKEN,
+          }),
+        (err: unknown) =>
+          err instanceof CCTParamsInvalidError &&
+          err.context.operation === 'acceptAdmin' &&
+          err.context.param === 'tokenAddress',
+      )
+      assert.equal(called, false, 'validation fails before TAR discovery')
+    })
+
+    it('rejects when sender is not the pending administrator', async () => {
+      const cct = EVMTokenManager.fromChain(
+        stubChain({ provider: acceptAdminProvider(POOL) as never }),
+      )
+      await assert.rejects(
+        cct.generateUnsignedAcceptAdmin({
+          tokenAddress: TOKEN,
+          address: ROUTER,
+          sender: TOKEN,
+        }),
+        (err: unknown) =>
+          err instanceof CCTParamsInvalidError &&
+          err.context.operation === 'acceptAdmin' &&
+          err.context.param === 'sender',
+      )
+    })
+  })
+
+  describe('acceptAdmin', () => {
+    it('signs and submits, resolving to the confirmed tx hash', async () => {
+      const cct = EVMTokenManager.fromChain(
+        stubChain({ provider: acceptAdminProvider(TOKEN) as never }),
+      )
+      const result = await cct.acceptAdmin({
+        tokenAddress: TOKEN,
+        address: ROUTER,
+        sender: TOKEN,
+        wallet: fakeSigner(),
+      })
+      assert.deepEqual(result, { hash: HASH })
+    })
+
+    it('rejects a non-signer wallet', async () => {
+      const cct = EVMTokenManager.fromChain(
+        stubChain({ provider: acceptAdminProvider(TOKEN) as never }),
+      )
+      await assert.rejects(
+        () =>
+          cct.acceptAdmin({
+            tokenAddress: TOKEN,
+            address: ROUTER,
+            sender: TOKEN,
+            wallet: {},
+          }),
+        (err: unknown) => err instanceof CCIPWalletInvalidError,
+      )
+    })
+
+    it('rejects a sender that does not match the executing wallet', async () => {
+      // fakeSigner().getAddress() resolves to TOKEN; a `sender` other than TOKEN must be
+      // rejected rather than silently accepted and broadcast from the mismatched wallet.
+      const cct = EVMTokenManager.fromChain(
+        stubChain({ provider: acceptAdminProvider(TOKEN) as never }),
+      )
+      await assert.rejects(
+        () =>
+          cct.acceptAdmin({
+            tokenAddress: TOKEN,
+            address: ROUTER,
+            sender: POOL,
+            wallet: fakeSigner(),
+          }),
+        (err: unknown) =>
+          err instanceof CCTParamsInvalidError &&
+          err.context.operation === 'acceptAdmin' &&
+          err.context.param === 'sender',
+      )
     })
   })
 })

--- a/ccip-sdk/src/cct/evm/index.ts
+++ b/ccip-sdk/src/cct/evm/index.ts
@@ -26,6 +26,16 @@ import {
   AcceptAdmin,
 } from './token-admin-registry/operations/accept-admin.ts'
 import {
+  type GetSupportedTokensParams,
+  type GetSupportedTokensResult,
+  GetSupportedTokens,
+} from './token-admin-registry/operations/get-supported-tokens.ts'
+import {
+  type GetTokenAdminRegistryParams,
+  type GetTokenAdminRegistryResult,
+  GetTokenAdminRegistry,
+} from './token-admin-registry/operations/get-token-admin-registry.ts'
+import {
   type RegisterAdminParams,
   RegisterAdmin,
 } from './token-admin-registry/operations/register-admin.ts'
@@ -59,6 +69,8 @@ export class EVMTokenManager extends TokenManager<typeof ChainFamily.EVM> {
   readonly #setPool = new SetPool()
   readonly #transferAdmin = new TransferAdmin()
   readonly #acceptAdmin = new AcceptAdmin()
+  readonly #getTokenAdminRegistry = new GetTokenAdminRegistry()
+  readonly #getSupportedTokens = new GetSupportedTokens()
 
   // Token pool operations
   readonly #deployTokenPool = new DeployTokenPool()
@@ -289,6 +301,46 @@ export class EVMTokenManager extends TokenManager<typeof ChainFamily.EVM> {
    */
   acceptAdmin(opts: EVMExecuteParams<AcceptAdminParams>): Promise<TransactionResult> {
     return this.#acceptAdmin.execute(this.chain, opts)
+  }
+
+  /**
+   * Reads a token's TokenAdminRegistry entry: its `administrator`, any `pendingAdministrator`,
+   * and its registered `tokenPool`.
+   * @remarks Deliberately diverges from `cct.chain.getRegistryTokenConfig()`, which throws when
+   * `administrator` is the zero address — exactly the post-`registerAdmin`, pre-`acceptAdmin`
+   * state. This op reports `{ administrator: ZeroAddress, pendingAdministrator }` faithfully
+   * instead, so a pending registration is observable; see
+   * {@link GetTokenAdminRegistry} for the full rationale. `pendingAdministrator` and `tokenPool`
+   * are still omitted when zero.
+   * @throws {@link CCTParamsInvalidError} if any param is invalid
+   * @example
+   * ```typescript
+   * const config = await cct.getTokenAdminRegistry({
+   *   address: '0xTokenAdminRegistry...', // or a Router/OnRamp/OffRamp/pool to resolve it from
+   *   tokenAddress: '0xToken...',
+   * })
+   * if (config.administrator === ZeroAddress) {
+   *   console.log('pending acceptance by', config.pendingAdministrator)
+   * }
+   * ```
+   */
+  getTokenAdminRegistry(opts: GetTokenAdminRegistryParams): Promise<GetTokenAdminRegistryResult> {
+    return this.#getTokenAdminRegistry.query(this.chain, opts)
+  }
+
+  /**
+   * Lists every token configured in the TokenAdminRegistry resolved from `address`.
+   * @remarks The registry paginates via `getAllConfiguredTokens` — `opts.page` sets the batch size per call; omit it to read the
+   * whole registry in one round trip per 1000 tokens.
+   * @throws {@link CCTParamsInvalidError} if `address` is not a valid address, or `page` is given
+   * and is not a positive integer
+   * @example
+   * ```typescript
+   * const tokens = await cct.getSupportedTokens({ address: '0xTokenAdminRegistry...' })
+   * ```
+   */
+  getSupportedTokens(opts: GetSupportedTokensParams): Promise<GetSupportedTokensResult> {
+    return this.#getSupportedTokens.query(this.chain, opts)
   }
 
   /**
@@ -541,8 +593,16 @@ export type {
   RegisterAdminMethod,
   RegisterAdminParams,
 } from './token-admin-registry/operations/register-admin.ts'
+export type {
+  GetTokenAdminRegistryParams,
+  GetTokenAdminRegistryResult,
+} from './token-admin-registry/operations/get-token-admin-registry.ts'
 export type { SetPoolParams } from './token-admin-registry/operations/set-pool.ts'
 export type { TransferAdminParams } from './token-admin-registry/operations/transfer-admin.ts'
+export type {
+  GetSupportedTokensParams,
+  GetSupportedTokensResult,
+} from './token-admin-registry/operations/get-supported-tokens.ts'
 export type { DeployTokenParams } from './token/operations/deploy-token.ts'
 export type {
   DeployTokenPoolParams,

--- a/ccip-sdk/src/cct/evm/index.ts
+++ b/ccip-sdk/src/cct/evm/index.ts
@@ -22,6 +22,10 @@ import { type DeployLockboxParams, DeployLockbox } from './lockbox/operations/de
 import type { DeployResult, EVMExecuteParams } from './operation.ts'
 import { type DeployTokenParams, DeployToken } from './token/operations/deploy-token.ts'
 import {
+  type AcceptAdminParams,
+  AcceptAdmin,
+} from './token-admin-registry/operations/accept-admin.ts'
+import {
   type RegisterAdminParams,
   RegisterAdmin,
 } from './token-admin-registry/operations/register-admin.ts'
@@ -54,6 +58,7 @@ export class EVMTokenManager extends TokenManager<typeof ChainFamily.EVM> {
   readonly #registerAdmin = new RegisterAdmin()
   readonly #setPool = new SetPool()
   readonly #transferAdmin = new TransferAdmin()
+  readonly #acceptAdmin = new AcceptAdmin()
 
   // Token pool operations
   readonly #deployTokenPool = new DeployTokenPool()
@@ -240,6 +245,50 @@ export class EVMTokenManager extends TokenManager<typeof ChainFamily.EVM> {
    */
   transferAdmin(opts: EVMExecuteParams<TransferAdminParams>): Promise<TransactionResult> {
     return this.#transferAdmin.execute(this.chain, opts)
+  }
+
+  /**
+   * Builds an unsigned `acceptAdminRole` tx (for multisig / offline signing). Second half of
+   * the two-step admin handshake: a registry module's `registerAdmin` (fresh registration) or
+   * the current admin's `transferAdmin` (hand-off) proposes `opts.sender` as
+   * `pendingAdministrator`; `acceptAdmin` then confirms it on-chain before encoding, after which
+   * {@link setPool} becomes callable by the new administrator.
+   * @throws {@link CCTParamsInvalidError} if any param is invalid, or `sender` is not the
+   *   pending administrator
+   * @example
+   * ```typescript
+   * // `sender` must be the pending administrator proposed by registerAdmin/transferAdmin
+   * const unsigned = await cct.generateUnsignedAcceptAdmin({
+   *   tokenAddress: '0xToken...',
+   *   address: '0xTokenAdminRegistry...', // the TAR, or a Router/pool to resolve it from
+   *   sender: '0xPendingAdmin...',
+   * })
+   * ```
+   */
+  generateUnsignedAcceptAdmin(opts: AcceptAdminParams): Promise<UnsignedEVMTx> {
+    return this.#acceptAdmin.generate(this.chain, opts)
+  }
+
+  /**
+   * Accepts a pending TokenAdminRegistry administrator role, signing + submitting with
+   * `opts.wallet` (the pending administrator). Completes the `registerAdmin`/`transferAdmin` →
+   * `acceptAdmin` handshake, after which {@link setPool} becomes callable.
+   * @throws {@link CCIPWalletInvalidError} if `wallet` is not a valid signer
+   * @throws {@link CCTParamsInvalidError} if any param is invalid, or `sender` is not the
+   *   pending administrator
+   * @throws {@link CCTTxFailedError} if the tx reverts or fails
+   * @example
+   * ```typescript
+   * // `wallet` must sign as the pending administrator
+   * const { hash } = await cct.acceptAdmin({
+   *   tokenAddress: '0xToken...',
+   *   address: '0xTokenAdminRegistry...',
+   *   wallet,
+   * })
+   * ```
+   */
+  acceptAdmin(opts: EVMExecuteParams<AcceptAdminParams>): Promise<TransactionResult> {
+    return this.#acceptAdmin.execute(this.chain, opts)
   }
 
   /**
@@ -487,6 +536,7 @@ export class EVMTokenManager extends TokenManager<typeof ChainFamily.EVM> {
 }
 
 export * from '../errors.ts'
+export type { AcceptAdminParams } from './token-admin-registry/operations/accept-admin.ts'
 export type {
   RegisterAdminMethod,
   RegisterAdminParams,

--- a/ccip-sdk/src/cct/evm/token-admin-registry/operations/accept-admin.test.ts
+++ b/ccip-sdk/src/cct/evm/token-admin-registry/operations/accept-admin.test.ts
@@ -1,0 +1,357 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import { ZeroAddress, getAddress, getIcapAddress, id, makeError } from 'ethers'
+
+import { AcceptAdmin } from './accept-admin.ts'
+import { CCIPExecTxRevertedError, CCIPWalletInvalidError } from '../../../../errors/index.ts'
+import { interfaces } from '../../../../evm/const.ts'
+import type { EVMChain } from '../../../../evm/index.ts'
+import { ChainFamily } from '../../../../networks.ts'
+import { CCTParamsInvalidError } from '../../../errors.ts'
+
+// SENDER and OTHER carry hex letters so their checksummed and lowercase spellings differ. That
+// difference is what makes the `getAddress()` normalisation in the pending-admin and wallet-binding
+// comparisons observable: with all-digit fixtures both spellings are identical, so dropping the
+// normalisation would pass every test while locking a legitimate admin out in production (a
+// lowercase address from an indexer vs a checksummed one decoded from the chain).
+const SENDER = getAddress('0x' + 'ab'.repeat(20))
+const OTHER = getAddress('0x' + 'cd'.repeat(20))
+const TOKEN = '0x' + '33'.repeat(20)
+const TAR = '0x' + '44'.repeat(20)
+const ADDRESS = '0x' + '55'.repeat(20)
+const HASH = '0x' + 'ab'.repeat(32)
+
+// acceptAdminRole(address) selector, per the vendored ABI (spec-pinned).
+const SELECTOR = id('acceptAdminRole(address)').slice(0, 10)
+// 20-byte address left-padded to a 32-byte word; lowercased, since ABI encoding emits lowercase hex
+// regardless of how the caller spelled the address.
+const word = (addr: string) => '000000000000000000000000' + addr.slice(2).toLowerCase()
+
+/** Encodes a `getTokenConfig` return value against the vendored TokenAdminRegistry ABI. */
+function encodeTokenConfig(config: {
+  administrator?: string
+  pendingAdministrator?: string
+  tokenPool?: string
+}): string {
+  return interfaces.TokenAdminRegistry.encodeFunctionResult('getTokenConfig', [
+    [
+      config.administrator ?? ZeroAddress,
+      config.pendingAdministrator ?? ZeroAddress,
+      config.tokenPool ?? ZeroAddress,
+    ],
+  ])
+}
+
+/**
+ * Fake provider whose `call` answers `getTokenConfig` with a fixed config, recording every
+ * `tx` it was called with so tests can assert the read hit the resolved TAR with the
+ * expected calldata (the read is this op's only authorization gate, so it earns its own
+ * assertion rather than passing implicitly whenever the config happens to come back right).
+ */
+function stubProvider(config: {
+  administrator?: string
+  pendingAdministrator?: string
+  tokenPool?: string
+}) {
+  const calls: { to?: string; data?: string }[] = []
+  return {
+    calls,
+    call: (tx: { to?: string; data?: string }) => {
+      calls.push(tx)
+      return Promise.resolve(encodeTokenConfig(config))
+    },
+  }
+}
+
+/** Minimal EVMChain stub — the build path resolves the TAR, then reads `getTokenConfig` off `provider`. */
+function stubChain(overrides: Partial<EVMChain> = {}): EVMChain {
+  return {
+    provider: stubProvider({ pendingAdministrator: SENDER }),
+    logger: { debug() {}, info() {}, warn() {}, error() {} },
+    getTokenAdminRegistryFor: (_address: string) => Promise.resolve(TAR),
+    nextNonce: async () => 0,
+    rollbackNonce: () => {},
+    ...overrides,
+  } as unknown as EVMChain
+}
+
+/** Fake ethers Signer for a plain (non-deployment) tx. */
+function fakeSigner(opts: { waitError?: Error } = {}) {
+  return {
+    signTransaction: () => Promise.resolve('0x'),
+    getAddress: () => Promise.resolve(SENDER),
+    populateTransaction: (tx: unknown) => Promise.resolve({ ...(tx as object) }),
+    sendTransaction: () =>
+      Promise.resolve({
+        hash: HASH,
+        wait: () =>
+          opts.waitError
+            ? Promise.reject(opts.waitError)
+            : Promise.resolve({ status: 1, contractAddress: null }),
+      }),
+  }
+}
+
+describe('AcceptAdmin (cct/evm token-admin-registry operation)', () => {
+  describe('generate (golden vectors)', () => {
+    it('encodes acceptAdminRole(token) to the discovered TAR when sender is pending', async () => {
+      const provider = stubProvider({ pendingAdministrator: SENDER })
+      const unsigned = await new AcceptAdmin().generate(
+        stubChain({ provider: provider as never }),
+        {
+          tokenAddress: TOKEN,
+          address: ADDRESS,
+          sender: SENDER,
+        },
+      )
+
+      assert.equal(unsigned.family, ChainFamily.EVM)
+      assert.equal(unsigned.transactions.length, 1)
+      const tx = unsigned.transactions[0]!
+      assert.equal(tx.to, TAR)
+      assert.equal(tx.from, SENDER)
+      assert.ok(tx.data!.startsWith(SELECTOR), 'data carries the acceptAdminRole selector')
+      assert.equal(tx.data, SELECTOR + word(TOKEN))
+
+      // The read is this op's only authorization gate — assert it actually hit the resolved
+      // TAR with `getTokenConfig(tokenAddress)`, not just that some read returned a config
+      // that happened to satisfy the pending-admin check.
+      assert.equal(provider.calls.length, 1)
+      assert.equal(provider.calls[0]!.to, TAR)
+      assert.equal(
+        provider.calls[0]!.data,
+        interfaces.TokenAdminRegistry.encodeFunctionData('getTokenConfig', [TOKEN]),
+      )
+    })
+
+    it('discovers the TAR from the given address', async () => {
+      let seen: string | undefined
+      const unsigned = await new AcceptAdmin().generate(
+        stubChain({
+          getTokenAdminRegistryFor: (address: string) => {
+            seen = address
+            return Promise.resolve(TAR)
+          },
+        }),
+        { tokenAddress: TOKEN, address: ADDRESS, sender: SENDER },
+      )
+      assert.equal(seen, ADDRESS)
+      assert.equal(unsigned.transactions[0]!.to, TAR)
+    })
+
+    it('matches a checksum-insensitive sender against the pending administrator', async () => {
+      // pendingAdministrator decodes checksummed off-chain; a lowercase sender must still match.
+      const unsigned = await new AcceptAdmin().generate(
+        stubChain({ provider: stubProvider({ pendingAdministrator: SENDER }) as never }),
+        { tokenAddress: TOKEN, address: ADDRESS, sender: SENDER.toLowerCase() },
+      )
+      assert.equal(unsigned.transactions[0]!.data, SELECTOR + word(TOKEN))
+    })
+  })
+
+  describe('validation', () => {
+    it('rejects an invalid tokenAddress before any RPC', async () => {
+      let called = false
+      await assert.rejects(
+        () =>
+          new AcceptAdmin().generate(
+            stubChain({
+              getTokenAdminRegistryFor: () => {
+                called = true
+                return Promise.resolve(TAR)
+              },
+            }),
+            { tokenAddress: 'not-an-address', address: ADDRESS, sender: SENDER },
+          ),
+        (err: unknown) =>
+          err instanceof CCTParamsInvalidError &&
+          err.context.operation === 'acceptAdmin' &&
+          err.context.param === 'tokenAddress',
+      )
+      assert.equal(called, false, 'validation fails before TAR discovery')
+    })
+
+    it('rejects an invalid address', async () => {
+      await assert.rejects(
+        () =>
+          new AcceptAdmin().generate(stubChain(), {
+            tokenAddress: TOKEN,
+            address: 'not-an-address',
+            sender: SENDER,
+          }),
+        (err: unknown) => err instanceof CCTParamsInvalidError && err.context.param === 'address',
+      )
+    })
+
+    it('rejects a missing sender', async () => {
+      await assert.rejects(
+        () => new AcceptAdmin().generate(stubChain(), { tokenAddress: TOKEN, address: ADDRESS }),
+        (err: unknown) => err instanceof CCTParamsInvalidError && err.context.param === 'sender',
+      )
+    })
+
+    it('rejects an invalid sender', async () => {
+      await assert.rejects(
+        () =>
+          new AcceptAdmin().generate(stubChain(), {
+            tokenAddress: TOKEN,
+            address: ADDRESS,
+            sender: 'not-an-address',
+          }),
+        (err: unknown) => err instanceof CCTParamsInvalidError && err.context.param === 'sender',
+      )
+    })
+
+    it('rejects the zero address written in ICAP form as sender', async () => {
+      // isAddress() accepts ICAP, and this never equals ZeroAddress literally
+      await assert.rejects(
+        () =>
+          new AcceptAdmin().generate(stubChain(), {
+            tokenAddress: TOKEN,
+            address: ADDRESS,
+            sender: getIcapAddress(ZeroAddress),
+          }),
+        (err: unknown) => err instanceof CCTParamsInvalidError && err.context.param === 'sender',
+      )
+    })
+
+    it('rejects when no administrator is pending', async () => {
+      await assert.rejects(
+        () =>
+          new AcceptAdmin().generate(
+            stubChain({
+              provider: stubProvider({ administrator: OTHER }) as never, // pendingAdministrator omitted -> zero
+            }),
+            { tokenAddress: TOKEN, address: ADDRESS, sender: SENDER },
+          ),
+        (err: unknown) =>
+          err instanceof CCTParamsInvalidError &&
+          err.context.operation === 'acceptAdmin' &&
+          err.context.param === 'sender' &&
+          /nothing to accept/.test(err.message),
+      )
+    })
+
+    it('rejects when sender is not the pending administrator', async () => {
+      await assert.rejects(
+        () =>
+          new AcceptAdmin().generate(
+            stubChain({ provider: stubProvider({ pendingAdministrator: OTHER }) as never }),
+            { tokenAddress: TOKEN, address: ADDRESS, sender: SENDER },
+          ),
+        (err: unknown) =>
+          err instanceof CCTParamsInvalidError &&
+          err.context.param === 'sender' &&
+          /must be the pending token administrator/.test(err.message),
+      )
+    })
+  })
+
+  describe('execute', () => {
+    it('signs, submits, and returns the tx hash', async () => {
+      const result = await new AcceptAdmin().execute(stubChain(), {
+        tokenAddress: TOKEN,
+        address: ADDRESS,
+        sender: SENDER,
+        wallet: fakeSigner(),
+      })
+      assert.deepEqual(result, { hash: HASH })
+    })
+
+    it('throws CCIPExecTxRevertedError when the tx reverts on-chain', async () => {
+      await assert.rejects(
+        () =>
+          new AcceptAdmin().execute(stubChain(), {
+            tokenAddress: TOKEN,
+            address: ADDRESS,
+            sender: SENDER,
+            wallet: fakeSigner({ waitError: makeError('execution reverted', 'CALL_EXCEPTION') }),
+          }),
+        (err: unknown) =>
+          err instanceof CCIPExecTxRevertedError && err.context.operation === 'acceptAdmin',
+      )
+    })
+
+    it('rejects a non-signer wallet', async () => {
+      await assert.rejects(
+        () =>
+          new AcceptAdmin().execute(stubChain(), {
+            tokenAddress: TOKEN,
+            address: ADDRESS,
+            sender: SENDER,
+            wallet: {},
+          }),
+        (err: unknown) => err instanceof CCIPWalletInvalidError,
+      )
+    })
+
+    it('defaults sender to the executing wallet address when omitted', async () => {
+      // fakeSigner().getAddress() resolves to SENDER, which stubChain()'s provider also
+      // reports as pendingAdministrator — so an omitted `sender` must still pass the
+      // pending-administrator pre-check by binding to the wallet.
+      const result = await new AcceptAdmin().execute(stubChain(), {
+        tokenAddress: TOKEN,
+        address: ADDRESS,
+        wallet: fakeSigner(),
+      })
+      assert.deepEqual(result, { hash: HASH })
+    })
+
+    it('binds a lowercase sender to a checksummed wallet address', async () => {
+      // The wallet-binding comparison normalises both sides with getAddress(). Without that, a
+      // lowercase `sender` — the shape that comes out of indexers, subgraphs and `toLowerCase()`
+      // pipelines — would read as a different address from the checksummed one the signer reports,
+      // and the legitimate pending administrator would be rejected as "not the executing wallet".
+      // fakeSigner() reports the checksummed SENDER.
+      const result = await new AcceptAdmin().execute(stubChain(), {
+        tokenAddress: TOKEN,
+        address: ADDRESS,
+        sender: SENDER.toLowerCase(),
+        wallet: fakeSigner(),
+      })
+      assert.deepEqual(result, { hash: HASH })
+    })
+
+    it('rejects a malformed sender with CCTParamsInvalidError, not a raw ethers error', async () => {
+      // The execute override compares addresses before the base generate()'s validate() runs,
+      // so it must validate first — otherwise getAddress() leaks an ethers TypeError.
+      await assert.rejects(
+        () =>
+          new AcceptAdmin().execute(stubChain(), {
+            tokenAddress: TOKEN,
+            address: ADDRESS,
+            sender: 'not-an-address',
+            wallet: fakeSigner(),
+          }),
+        (err: unknown) =>
+          err instanceof CCTParamsInvalidError &&
+          err.context.operation === 'acceptAdmin' &&
+          err.context.param === 'sender',
+      )
+    })
+
+    it('rejects a sender that does not match the executing wallet', async () => {
+      // Regression guard: a caller-supplied `sender` must bind to the address that actually
+      // signs. `fakeSigner()` resolves to SENDER, which stubChain()'s provider also reports as
+      // pendingAdministrator — so absent this check, `sender: OTHER` would sail through the
+      // pending-administrator pre-check (SENDER === SENDER) yet broadcast from a signer whose
+      // on-chain `msg.sender` doesn't match, reverting with `OnlyPendingAdministrator` instead
+      // of failing fast here.
+      await assert.rejects(
+        () =>
+          new AcceptAdmin().execute(stubChain(), {
+            tokenAddress: TOKEN,
+            address: ADDRESS,
+            sender: OTHER,
+            wallet: fakeSigner(),
+          }),
+        (err: unknown) =>
+          err instanceof CCTParamsInvalidError &&
+          err.context.operation === 'acceptAdmin' &&
+          err.context.param === 'sender' &&
+          /executing wallet address/.test(err.message),
+      )
+    })
+  })
+})

--- a/ccip-sdk/src/cct/evm/token-admin-registry/operations/accept-admin.ts
+++ b/ccip-sdk/src/cct/evm/token-admin-registry/operations/accept-admin.ts
@@ -1,0 +1,114 @@
+/**
+ * acceptAdmin — accepts a pending TokenAdminRegistry administrator role for a token.
+ * Second half of the two-step admin handshake: `registerAdmin` (fresh registration) or
+ * `transferAdmin` (existing-admin hand-off) first proposes an address as
+ * `pendingAdministrator`; that address then calls `acceptAdmin` to become `administrator`,
+ * after which `setPool` is callable. Version-independent (v1.5–v2.0 share one encoding).
+ *
+ * @packageDocumentation
+ */
+
+import { ZeroAddress, getAddress } from 'ethers'
+
+import type { EVMChain } from '../../../../evm/index.ts'
+import type { UnsignedEVMTx } from '../../../../evm/types.ts'
+import { CCTParamsInvalidError } from '../../../errors.ts'
+import type { TransactionResult } from '../../../operation.ts'
+import { type EVMExecuteParams, EVMOperation, callTx } from '../../operation.ts'
+import { validateAddress } from '../../validate.ts'
+import { getTokenAdminRegistryInterface, readTokenAdminRegistryConfig } from '../contracts.ts'
+
+/**
+ * Parameters for `acceptAdmin`.
+ * @remarks `sender` is typed optional to satisfy `EVMOperation`'s shared shape, but is required
+ * for {@link AcceptAdmin.generate}: the pre-tx check below has nothing to compare
+ * `pendingAdministrator` against without it, so an omitted `sender` is rejected in
+ * {@link AcceptAdmin.validate}. {@link AcceptAdmin.execute} relaxes this — it defaults `sender`
+ * to the signing wallet's own address, since that is the only address that can ever satisfy
+ * the pending-administrator check for a signed submission (see {@link AcceptAdmin.execute}).
+ */
+export type AcceptAdminParams = {
+  /** Token whose pending registry admin role is being accepted. */
+  tokenAddress: string
+  /**
+   * Contract to resolve the TokenAdminRegistry from. Pass the registry itself for a
+   * direct lookup; a Router, OnRamp, OffRamp, or TokenPool also work but add hops and
+   * need a configured lane.
+   */
+  address: string
+  /**
+   * Pending administrator accepting the role. Required for {@link AcceptAdmin.generate}
+   * (unsigned/offline flows); optional for {@link AcceptAdmin.execute}, which defaults it to
+   * the wallet's address — see the remarks above.
+   */
+  sender?: string
+}
+
+/** Accepts a pending TokenAdminRegistry administrator role for a token. */
+export class AcceptAdmin extends EVMOperation<AcceptAdminParams> {
+  readonly name = 'acceptAdmin'
+
+  /**
+   * Validates all addresses before any RPC. `sender` is required here (unlike the base
+   * `EVMOperation` shape) — see the {@link AcceptAdminParams} remarks.
+   */
+  protected validate(p: AcceptAdminParams): void {
+    validateAddress(this.name, 'tokenAddress', p.tokenAddress)
+    validateAddress(this.name, 'address', p.address)
+    validateAddress(this.name, 'sender', p.sender)
+  }
+
+  /**
+   * Confirms `sender` is the pending administrator, then builds `acceptAdminRole` calldata
+   * against the TokenAdminRegistry resolved from `address`.
+   */
+  protected async buildUnsigned(chain: EVMChain, p: AcceptAdminParams): Promise<UnsignedEVMTx> {
+    // Asserts and narrows in one step — `sender` is optional on EVMOperation's shared shape, and
+    // `validate()`'s guarantee doesn't survive the hop into this method.
+    validateAddress(this.name, 'sender', p.sender)
+    const sender = getAddress(p.sender)
+    const to = await chain.getTokenAdminRegistryFor(p.address)
+    const { administrator, pendingAdministrator } = await readTokenAdminRegistryConfig(
+      chain,
+      to,
+      p.tokenAddress,
+    )
+
+    if (pendingAdministrator === ZeroAddress) {
+      throw new CCTParamsInvalidError(
+        this.name,
+        'sender',
+        `no administrator is pending for this token (current administrator: ${administrator}) — nothing to accept`,
+      )
+    }
+    if (pendingAdministrator !== sender) {
+      throw new CCTParamsInvalidError(
+        this.name,
+        'sender',
+        `must be the pending token administrator (${pendingAdministrator})`,
+      )
+    }
+
+    // TAR.acceptAdminRole encoding is version-stable across v1.5–v2.0; no version dispatch needed.
+    const data = getTokenAdminRegistryInterface().encodeFunctionData('acceptAdminRole', [
+      p.tokenAddress,
+    ])
+    return callTx(to, data)
+  }
+
+  /**
+   * Signs and submits as the pending administrator, defaulting `sender` to the signing wallet —
+   * the only address that can satisfy {@link buildUnsigned}'s pending-administrator check for a
+   * broadcast tx. See {@link EVMOperation.senderBoundToWallet} for why a divergent `sender` is
+   * rejected rather than signed.
+   * @throws {@link CCIPWalletInvalidError} if `wallet` is not a valid signer
+   * @throws {@link CCTParamsInvalidError} if `sender` is given and is not the wallet's address
+   */
+  override async execute(
+    chain: EVMChain,
+    params: EVMExecuteParams<AcceptAdminParams>,
+  ): Promise<TransactionResult> {
+    const sender = await this.senderBoundToWallet(params.wallet, params.sender)
+    return super.execute(chain, { ...params, sender })
+  }
+}

--- a/ccip-sdk/src/cct/evm/token-admin-registry/operations/get-supported-tokens.test.ts
+++ b/ccip-sdk/src/cct/evm/token-admin-registry/operations/get-supported-tokens.test.ts
@@ -1,0 +1,126 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import { GetSupportedTokens } from './get-supported-tokens.ts'
+import { interfaces } from '../../../../evm/const.ts'
+import { EVMChain } from '../../../../evm/index.ts'
+import { CCTParamsInvalidError } from '../../../errors.ts'
+
+const OFF_RAMP = '0x' + '11'.repeat(20)
+const TAR = '0x' + '22'.repeat(20)
+const TOKENS = ['0x' + '33'.repeat(20), '0x' + '44'.repeat(20)]
+
+describe('GetSupportedTokens (cct/evm)', () => {
+  describe('query', () => {
+    it('resolves the TAR and lists its configured tokens', async () => {
+      let resolvedAddress: string | undefined
+      let seenOpts: { page?: number } | undefined
+      const chain = {
+        getTokenAdminRegistryFor: async (address: string) => {
+          resolvedAddress = address
+          return TAR
+        },
+        getSupportedTokens: async (registry: string, opts?: { page?: number }) => {
+          assert.equal(registry, TAR)
+          seenOpts = opts
+          return TOKENS
+        },
+      } as unknown as EVMChain
+
+      const result = await new GetSupportedTokens().query(chain, { address: OFF_RAMP })
+      assert.deepEqual(result, TOKENS)
+      assert.equal(resolvedAddress, OFF_RAMP)
+      assert.deepEqual(seenOpts, { page: undefined })
+    })
+
+    it('forwards `page` to chain.getSupportedTokens, which owns the pagination loop', async () => {
+      let seenPage: number | undefined
+      const chain = {
+        getTokenAdminRegistryFor: async () => TAR,
+        getSupportedTokens: async (_registry: string, opts?: { page?: number }) => {
+          seenPage = opts?.page
+          return TOKENS
+        },
+      } as unknown as EVMChain
+
+      await new GetSupportedTokens().query(chain, { address: OFF_RAMP, page: 50 })
+      assert.equal(seenPage, 50)
+    })
+
+    it('paginates `getAllConfiguredTokens` through the real EVMChain.getSupportedTokens loop', async () => {
+      // The two tests above stub `chain.getSupportedTokens` wholesale, so they only pin that this
+      // op forwards `page` — they cannot catch a startIndex/maxCount swap or a dropped final page
+      // in the loop itself. This test runs the *real* `EVMChain.prototype.getSupportedTokens`
+      // (bound to a stub with just `provider.call`) against three tokens with `page: 2`, so a full
+      // first page (0,2) must be followed by a short second page (2,2) that ends the scan.
+      const allTokens = [...TOKENS, '0x' + '55'.repeat(20)]
+      const seenCalls: Array<{ startIndex: bigint; maxCount: bigint }> = []
+      const chain = {
+        getTokenAdminRegistryFor: async () => TAR,
+        provider: {
+          call: async ({ data }: { data: string }) => {
+            const [startIndex, maxCount] = interfaces.TokenAdminRegistry.decodeFunctionData(
+              'getAllConfiguredTokens',
+              data,
+            ) as unknown as [bigint, bigint]
+            seenCalls.push({ startIndex, maxCount })
+            const page = allTokens.slice(Number(startIndex), Number(startIndex + maxCount))
+            return interfaces.TokenAdminRegistry.encodeFunctionResult('getAllConfiguredTokens', [
+              page,
+            ])
+          },
+        },
+      } as unknown as EVMChain
+      chain.getSupportedTokens = EVMChain.prototype.getSupportedTokens.bind(chain)
+
+      const result = await new GetSupportedTokens().query(chain, { address: OFF_RAMP, page: 2 })
+
+      assert.deepEqual(result, allTokens, 'pages are concatenated in order')
+      assert.deepEqual(
+        seenCalls,
+        [
+          { startIndex: 0n, maxCount: 2n },
+          { startIndex: 2n, maxCount: 2n },
+        ],
+        'startIndex advances by the previous page length and maxCount stays pinned to `page`',
+      )
+    })
+  })
+
+  describe('validation', () => {
+    it('rejects an invalid address before any RPC', async () => {
+      let called = false
+      const chain = {
+        getTokenAdminRegistryFor: async () => {
+          called = true
+          return TAR
+        },
+      } as unknown as EVMChain
+
+      await assert.rejects(
+        () => new GetSupportedTokens().query(chain, { address: 'not-an-address' }),
+        (error: unknown) =>
+          error instanceof CCTParamsInvalidError &&
+          error.context.operation === 'getSupportedTokens' &&
+          error.context.param === 'address',
+      )
+      assert.equal(called, false, 'validation fails before TAR discovery')
+    })
+
+    it('rejects a non-positive `page`', async () => {
+      await assert.rejects(
+        () => new GetSupportedTokens().query({} as EVMChain, { address: OFF_RAMP, page: 0 }),
+        (error: unknown) =>
+          error instanceof CCTParamsInvalidError && error.context.param === 'page',
+      )
+    })
+
+    it('rejects a non-integer `page`', async () => {
+      await assert.rejects(
+        () => new GetSupportedTokens().query({} as EVMChain, { address: OFF_RAMP, page: 1.5 }),
+        (error: unknown) =>
+          error instanceof CCTParamsInvalidError && error.context.param === 'page',
+      )
+    })
+  })
+})

--- a/ccip-sdk/src/cct/evm/token-admin-registry/operations/get-supported-tokens.ts
+++ b/ccip-sdk/src/cct/evm/token-admin-registry/operations/get-supported-tokens.ts
@@ -1,0 +1,68 @@
+/**
+ * getSupportedTokens — lists the ERC-20 tokens configured in a TokenAdminRegistry. Version-independent
+ * (`getAllConfiguredTokens` is byte-identical from v1.5.0 through latest).
+ *
+ * @packageDocumentation
+ */
+
+import type { EVMChain } from '../../../../evm/index.ts'
+import { CCTParamsInvalidError } from '../../../errors.ts'
+import { EVMQuery } from '../../query.ts'
+import { validateAddress } from '../../validate.ts'
+
+/** Parameters for {@link GetSupportedTokens}. */
+export type GetSupportedTokensParams = {
+  /**
+   * Contract to resolve the TokenAdminRegistry from. Pass the registry itself for a
+   * direct lookup; a Router, OnRamp, OffRamp, or TokenPool also work but add hops and
+   * need a configured lane.
+   */
+  address: string
+  /**
+   * Batch size `chain.getSupportedTokens` requests per `getAllConfiguredTokens` call while it
+   * paginates. Defaults to 1000. Optional — a very large registry may need a smaller batch to
+   * stay under an RPC's response-size limit.
+   */
+  page?: number
+}
+
+/** Result of {@link GetSupportedTokens}: array of token addresses. */
+export type GetSupportedTokensResult = string[]
+
+/**
+ * Lists every token configured in the TokenAdminRegistry resolved from `address`, paginating
+ * through `getAllConfiguredTokens` until exhausted.
+ */
+export class GetSupportedTokens extends EVMQuery<GetSupportedTokensParams, string[]> {
+  readonly name = 'getSupportedTokens'
+
+  /**
+   * Validates the resolution address and, when given, `page`; nothing to convert for {@link read}.
+   * @throws {@link CCTParamsInvalidError} if `address` is not a valid address, or `page` is given
+   * and is not a positive integer
+   */
+  protected prepare(params: GetSupportedTokensParams): GetSupportedTokensParams {
+    validateAddress(this.name, 'address', params.address)
+    if (params.page !== undefined && !(Number.isInteger(params.page) && params.page > 0))
+      throw new CCTParamsInvalidError(
+        this.name,
+        'page',
+        `must be a positive integer, got ${String(params.page)}`,
+      )
+    return params
+  }
+
+  /**
+   * Resolves the TAR and lists its configured tokens.
+   * @remarks Delegates pagination to {@link EVMChain.getSupportedTokens}, which already loops
+   * `getAllConfiguredTokens(startIndex, maxCount)` until a short page ends the scan — this op does
+   * not reimplement that loop.
+   */
+  protected async read(
+    chain: EVMChain,
+    { address, page }: GetSupportedTokensParams,
+  ): Promise<string[]> {
+    const registry = await chain.getTokenAdminRegistryFor(address)
+    return chain.getSupportedTokens(registry, { page })
+  }
+}

--- a/ccip-sdk/src/cct/evm/token-admin-registry/operations/get-token-admin-registry.test.ts
+++ b/ccip-sdk/src/cct/evm/token-admin-registry/operations/get-token-admin-registry.test.ts
@@ -1,0 +1,181 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import { Interface, ZeroAddress, getAddress, makeError } from 'ethers'
+
+import { GetTokenAdminRegistry } from './get-token-admin-registry.ts'
+import type { EVMChain } from '../../../../evm/index.ts'
+import { CCTParamsInvalidError } from '../../../errors.ts'
+
+const TOKEN = '0x' + '11'.repeat(20)
+const ROUTER = '0x' + '22'.repeat(20)
+const TAR = '0x' + '33'.repeat(20)
+// Mixed-case hex, unlike TOKEN/ROUTER/TAR above: their EIP-55 checksums re-case letters, so
+// asserting `getAddress(FIXTURE)` below only proves normalization happens if the raw fixture
+// isn't already in checksummed form. A digit-only fixture would pass even if the op forgot to
+// checksum (or lowercased) its output.
+const ADMINISTRATOR = '0xabcdef1234567890abcdef1234567890abcdef12'
+const PENDING_ADMINISTRATOR = '0x1234567890abcdef1234567890abcdef12345678'
+const POOL = '0xfedcba9876543210fedcba9876543210fedcba98'
+
+const IFACE = new Interface([
+  'function getTokenConfig(address token) view returns (tuple(address administrator, address pendingAdministrator, address tokenPool))',
+])
+
+/**
+ * EVMChain stub: `getTokenAdminRegistryFor` reports `registry`, and the provider answers
+ * `eth_call` with `getTokenConfig` encoded as `(administrator, pendingAdministrator, tokenPool)` —
+ * but only for a call to `registry` decoding to `TOKEN`; any other call, target, or argument
+ * reverts (or fails the assertion), so a read that mixes up its target or argument is caught
+ * rather than silently returning the fixture data.
+ */
+function stubChain({
+  registry = TAR,
+  administrator = ADMINISTRATOR,
+  pendingAdministrator = PENDING_ADMINISTRATOR,
+  tokenPool = POOL,
+}: {
+  registry?: string
+  administrator?: string
+  pendingAdministrator?: string
+  tokenPool?: string
+} = {}): EVMChain {
+  const encoded = IFACE.encodeFunctionResult('getTokenConfig', [
+    [administrator, pendingAdministrator, tokenPool],
+  ])
+  const selector = IFACE.getFunction('getTokenConfig')!.selector
+
+  return {
+    provider: {
+      call: async ({ to, data }: { to?: string; data: string }) => {
+        if (data.slice(0, 10) !== selector)
+          throw makeError('execution reverted', 'CALL_EXCEPTION', {
+            action: 'call',
+            data: '0x',
+            reason: null,
+            transaction: { to: null, data },
+            invocation: null,
+            revert: null,
+          })
+        // Selector-only matching can't tell a correct read from one with the call target or the
+        // decoded token argument swapped (e.g. reading a different contract's, or a different
+        // token's, config) — both would still hit this branch and get `encoded` back. Assert the
+        // resolved registry and the decoded argument so either mix-up fails loudly instead of
+        // silently returning the fixture data.
+        assert.equal(to, getAddress(registry), 'calls the resolved TAR, not `address`')
+        const [token] = IFACE.decodeFunctionData('getTokenConfig', data)
+        assert.equal(token, getAddress(TOKEN), 'reads the config for `tokenAddress`')
+        return encoded
+      },
+    },
+    logger: { debug() {}, info() {}, warn() {}, error() {} },
+    getTokenAdminRegistryFor: () => Promise.resolve(registry),
+  } as unknown as EVMChain
+}
+
+describe('GetTokenAdminRegistry (cct/evm token-admin-registry query)', () => {
+  it('reads administrator, pendingAdministrator, and tokenPool', async () => {
+    const config = await new GetTokenAdminRegistry().query(stubChain(), {
+      address: ROUTER,
+      tokenAddress: TOKEN,
+    })
+
+    assert.deepEqual(config, {
+      administrator: getAddress(ADMINISTRATOR),
+      pendingAdministrator: getAddress(PENDING_ADMINISTRATOR),
+      tokenPool: getAddress(POOL),
+    })
+  })
+
+  it('resolves the TAR from `address` before reading', async () => {
+    let seen: string | undefined
+    const chain = stubChain()
+    chain.getTokenAdminRegistryFor = (address: string) => {
+      seen = address
+      return Promise.resolve(TAR)
+    }
+
+    await new GetTokenAdminRegistry().query(chain, { address: ROUTER, tokenAddress: TOKEN })
+
+    assert.equal(seen, ROUTER)
+  })
+
+  it(
+    'reports a zero administrator rather than throwing — the pending-registration state ' +
+      'EVMChain.getRegistryTokenConfig cannot observe',
+    async () => {
+      const config = await new GetTokenAdminRegistry().query(
+        stubChain({ administrator: ZeroAddress }),
+        { address: ROUTER, tokenAddress: TOKEN },
+      )
+
+      assert.equal(config.administrator, ZeroAddress)
+      assert.equal(config.pendingAdministrator, getAddress(PENDING_ADMINISTRATOR))
+    },
+  )
+
+  it('omits pendingAdministrator when zero', async () => {
+    const config = await new GetTokenAdminRegistry().query(
+      stubChain({ pendingAdministrator: ZeroAddress }),
+      { address: ROUTER, tokenAddress: TOKEN },
+    )
+
+    assert.ok(!('pendingAdministrator' in config))
+  })
+
+  it('omits tokenPool when zero', async () => {
+    const config = await new GetTokenAdminRegistry().query(stubChain({ tokenPool: ZeroAddress }), {
+      address: ROUTER,
+      tokenAddress: TOKEN,
+    })
+
+    assert.ok(!('tokenPool' in config))
+  })
+
+  it('omits both optional fields for an unregistered token', async () => {
+    const config = await new GetTokenAdminRegistry().query(
+      stubChain({
+        administrator: ZeroAddress,
+        pendingAdministrator: ZeroAddress,
+        tokenPool: ZeroAddress,
+      }),
+      { address: ROUTER, tokenAddress: TOKEN },
+    )
+
+    assert.deepEqual(config, { administrator: ZeroAddress })
+  })
+
+  describe('validation', () => {
+    it('rejects an invalid `address` before any RPC', async () => {
+      let called = false
+      const chain = stubChain()
+      chain.getTokenAdminRegistryFor = () => {
+        called = true
+        return Promise.resolve(TAR)
+      }
+
+      await assert.rejects(
+        () => new GetTokenAdminRegistry().query(chain, { address: 'nope', tokenAddress: TOKEN }),
+        (err: unknown) =>
+          err instanceof CCTParamsInvalidError &&
+          err.context.operation === 'getTokenAdminRegistry' &&
+          err.context.param === 'address',
+      )
+      assert.equal(called, false, 'validation fails before TAR discovery')
+    })
+
+    it('rejects an invalid `tokenAddress` before any RPC', async () => {
+      await assert.rejects(
+        () =>
+          new GetTokenAdminRegistry().query(stubChain(), {
+            address: ROUTER,
+            tokenAddress: 'nope',
+          }),
+        (err: unknown) =>
+          err instanceof CCTParamsInvalidError &&
+          err.context.operation === 'getTokenAdminRegistry' &&
+          err.context.param === 'tokenAddress',
+      )
+    })
+  })
+})

--- a/ccip-sdk/src/cct/evm/token-admin-registry/operations/get-token-admin-registry.ts
+++ b/ccip-sdk/src/cct/evm/token-admin-registry/operations/get-token-admin-registry.ts
@@ -1,0 +1,84 @@
+/**
+ * getTokenAdminRegistry — reads a token's TokenAdminRegistry entry: its administrator, any
+ * pending administrator, and its registered pool. Version-independent (v1.5–v2.0 share one
+ * `getTokenConfig` encoding).
+ *
+ * @packageDocumentation
+ */
+
+import { ZeroAddress } from 'ethers'
+
+import type { RegistryTokenConfig } from '../../../../chain.ts'
+import type { EVMChain } from '../../../../evm/index.ts'
+import { EVMQuery } from '../../query.ts'
+import { validateAddress } from '../../validate.ts'
+import { readTokenAdminRegistryConfig } from '../contracts.ts'
+
+/** Parameters for {@link GetTokenAdminRegistry}. */
+export type GetTokenAdminRegistryParams = {
+  /**
+   * Contract to resolve the TokenAdminRegistry from. Pass the registry itself for a
+   * direct lookup; a Router, OnRamp, OffRamp, or TokenPool also work but add hops and
+   * need a configured lane.
+   */
+  address: string
+  /** Token to read the registry entry for. */
+  tokenAddress: string
+}
+
+/**
+ * Result of {@link GetTokenAdminRegistry}: the TAR entry for one token.
+ * @remarks `administrator` may be {@link ZeroAddress} for a token pending acceptance;
+ * test with `=== ZeroAddress`, not truthiness.
+ */
+export type GetTokenAdminRegistryResult = RegistryTokenConfig
+
+/**
+ * Reads a token's TokenAdminRegistry entry directly through `getTokenConfig`, reporting a zero
+ * `administrator` rather than throwing.
+ * @remarks Deliberately diverges from `EVMChain.getRegistryTokenConfig`, which throws
+ * `CCIPTokenNotConfiguredError` whenever `administrator === ZeroAddress` — exactly the
+ * post-`registerAdmin`, pre-`acceptAdmin` state, which made a pending registration
+ * unobservable through the public read API. This op reads `getTokenConfig` through
+ * {@link readTokenAdminRegistryConfig} instead of delegating to that helper, so
+ * `{ administrator: ZeroAddress, pendingAdministrator }` is reported faithfully.
+ * `pendingAdministrator` and `tokenPool` are still omitted when zero (nothing pending, no pool
+ * registered) — only `administrator` survives as the zero address, since that is the one state
+ * this op exists to surface.
+ */
+export class GetTokenAdminRegistry extends EVMQuery<
+  GetTokenAdminRegistryParams,
+  GetTokenAdminRegistryResult
+> {
+  readonly name = 'getTokenAdminRegistry'
+
+  /**
+   * Validates both addresses; nothing to convert for {@link read}.
+   * @throws {@link CCTParamsInvalidError} if `address` or `tokenAddress` is not a valid address
+   */
+  protected prepare(params: GetTokenAdminRegistryParams): GetTokenAdminRegistryParams {
+    validateAddress(this.name, 'address', params.address)
+    validateAddress(this.name, 'tokenAddress', params.tokenAddress)
+    return params
+  }
+
+  /** Resolves the TAR from `address`, then reads and normalizes `getTokenConfig(tokenAddress)`. */
+  protected async read(
+    chain: EVMChain,
+    { address, tokenAddress }: GetTokenAdminRegistryParams,
+  ): Promise<GetTokenAdminRegistryResult> {
+    const registry = await chain.getTokenAdminRegistryFor(address)
+    const config = await readTokenAdminRegistryConfig(chain, registry, tokenAddress)
+
+    return {
+      // unlike EVMChain.getRegistryTokenConfig, a zero administrator is reported, not thrown —
+      // that's the whole point of this op (see the class @remarks). The two optional fields are
+      // dropped when zero, so callers can test presence rather than compare against ZeroAddress.
+      administrator: config.administrator,
+      ...(config.pendingAdministrator !== ZeroAddress && {
+        pendingAdministrator: config.pendingAdministrator,
+      }),
+      ...(config.tokenPool !== ZeroAddress && { tokenPool: config.tokenPool }),
+    }
+  }
+}


### PR DESCRIPTION
## What

- Add `acceptAdmin `to EVMTokenManager, encoding `acceptAdminRole`. Completes the two-step admin transfer flow.

## Why

- Closes the registry flow on Token Admin Registry

## Testing
- Unit tests cover the encoding, the cases where nothing is pending or the caller is not the pending administrator + wallet binding