### PR TITLE
fix(sdk): normalize finality via encodeFinality before CCTP fast/standard tier comparison

### DIFF
--- a/ccip-sdk/src/evm/cctp-fee-tier.test.ts
+++ b/ccip-sdk/src/evm/cctp-fee-tier.test.ts
@@ -1,0 +1,115 @@
+import assert from 'node:assert/strict'
+import { afterEach, beforeEach, describe, it, mock } from 'node:test'
+
+import { getAddress, hexlify, randomBytes } from 'ethers'
+
+import { interfaces } from './const.ts'
+import { EVMChain } from './index.ts'
+import { ChainFamily, NetworkType } from '../networks.ts'
+import { CCIPVersion } from '../types.ts'
+
+// Regression test: `finality !== 0` breaks on the string form of finality ('finalized'
+// defaults to Fast instead of Standard), because 'finalized' !== 0 is trivially true.
+// encodeFinality(finality) !== 0 normalizes both the string and number forms before the
+// comparison, matching the mapping already used for on-the-wire encoding.
+const onRampIface = interfaces.OnRamp_v2_0
+const GET_POOL_SEL = onRampIface.getFunction('getPoolBySourceToken')!.selector
+
+const DEST_SELECTOR = 10344971235874465080n // base-sepolia
+
+// Two-tier fixture mirroring Circle's CCTP fee schedule: Fast charges 1 bp, Standard is free.
+const TWO_TIER_BURN_FEES = [
+  { finalityThreshold: 1000, minimumFee: 1 },
+  { finalityThreshold: 2000, minimumFee: 0 },
+]
+
+function makeChain(poolAddress: string) {
+  const provider = {
+    call: mock.fn(async (tx: { data?: string }) => {
+      const data = tx.data ?? '0x'
+      const sel = data.slice(0, 10)
+      if (sel === GET_POOL_SEL)
+        return onRampIface.encodeFunctionResult('getPoolBySourceToken', [poolAddress])
+      throw new Error(`unexpected call, selector=${sel}`)
+    }),
+  }
+
+  const chain = Object.create(EVMChain.prototype) as EVMChain
+  Object.assign(chain, {
+    provider,
+    logger: { debug() {}, info() {}, warn() {}, error() {} },
+    network: {
+      name: 'base-sepolia',
+      chainId: 84532,
+      chainSelector: DEST_SELECTOR,
+      family: ChainFamily.EVM,
+      networkType: NetworkType.Testnet,
+    },
+    getOnRampForRouter: mock.fn(async () => getAddress(hexlify(randomBytes(20)))),
+    typeAndVersion: mock.fn(async () => [
+      'OnRamp',
+      CCIPVersion.V2_0,
+      'OnRamp 2.0.0',
+    ]) as unknown as EVMChain['typeAndVersion'],
+    getFee: mock.fn(async () => 1_000_000_000_000n),
+    getTokenPoolConfig: mock.fn(async () => ({ tokenTransferFeeConfig: {} })),
+    detectUsdcDomains: mock.fn(async () => ({ sourceDomain: 0, destDomain: 1 })),
+  })
+  return chain
+}
+
+describe('getTotalFeesEstimate CCTP fast/standard tier selection', () => {
+  const originalFetch = globalThis.fetch
+
+  beforeEach(() => {
+    globalThis.fetch = mock.fn(
+      async () => new Response(JSON.stringify(TWO_TIER_BURN_FEES), { status: 200 }),
+    )
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  it("finality: 'finalized' (string, the default) selects the free Standard tier", async () => {
+    const chain = makeChain(getAddress(hexlify(randomBytes(20))))
+    const estimate = await chain.getTotalFeesEstimate({
+      router: getAddress(hexlify(randomBytes(20))),
+      destChainSelector: DEST_SELECTOR,
+      message: {
+        receiver: getAddress(hexlify(randomBytes(20))),
+        tokenAmounts: [{ token: getAddress(hexlify(randomBytes(20))), amount: 1_000_000n }],
+        extraArgs: { finality: 'finalized' },
+      },
+    })
+    assert.equal(estimate.tokenTransferFee, undefined)
+  })
+
+  it('finality: 0 (number, same meaning) selects the free Standard tier', async () => {
+    const chain = makeChain(getAddress(hexlify(randomBytes(20))))
+    const estimate = await chain.getTotalFeesEstimate({
+      router: getAddress(hexlify(randomBytes(20))),
+      destChainSelector: DEST_SELECTOR,
+      message: {
+        receiver: getAddress(hexlify(randomBytes(20))),
+        tokenAmounts: [{ token: getAddress(hexlify(randomBytes(20))), amount: 1_000_000n }],
+        extraArgs: { finality: 0 },
+      },
+    })
+    assert.equal(estimate.tokenTransferFee, undefined)
+  })
+
+  it("finality: 'safe' selects the Fast tier and quotes its fee", async () => {
+    const chain = makeChain(getAddress(hexlify(randomBytes(20))))
+    const estimate = await chain.getTotalFeesEstimate({
+      router: getAddress(hexlify(randomBytes(20))),
+      destChainSelector: DEST_SELECTOR,
+      message: {
+        receiver: getAddress(hexlify(randomBytes(20))),
+        tokenAmounts: [{ token: getAddress(hexlify(randomBytes(20))), amount: 1_000_000n }],
+        extraArgs: { finality: 'safe' },
+      },
+    })
+    assert.equal(estimate.tokenTransferFee?.bps, 1)
+  })
+})

--- a/ccip-sdk/src/evm/index.ts
+++ b/ccip-sdk/src/evm/index.ts
@@ -1543,7 +1543,7 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
         usdcDomains.destDomain,
         this.network.networkType,
       )
-      const fast = finality !== 0
+      const fast = encodeFinality(finality) !== 0
       // Tiers are sorted ascending by finalityThreshold; findLast for fast ensures
       // we pick the highest tier still within the fast threshold.
       const tier = fast


### PR DESCRIPTION
This pull request adds regression tests and fixes a bug in how finality tiers are selected for CCTP fee estimation in the `EVMChain` class. The main issue addressed is ensuring that both string and numeric forms of the `finality` argument are normalized before comparison, preventing incorrect fee tier selection.

Bug fix for finality tier selection:

* Updated the `EVMChain.getTotalFeesEstimate` logic to use `encodeFinality(finality) !== 0` instead of a direct comparison, ensuring both string (e.g., `'finalized'`) and number (e.g., `0`) forms are handled consistently.

Test coverage improvements:

* Added a new regression test file `cctp-fee-tier.test.ts` that verifies correct fee tier selection for different forms of the `finality` argument, covering both string and number inputs and ensuring they select the proper (free or paid) tier.