### PR TITLE
docs: explain JSON integer precision loss in --format=json and how to read it correctly

### DIFF
--- a/ccip-api-ref/docs-cli/configuration.mdx
+++ b/ccip-api-ref/docs-cli/configuration.mdx
@@ -215,11 +215,11 @@ These options are available on all commands:
 
 **Output formats:**
 
-| Format   | Use Case                                 |
-| -------- | ---------------------------------------- |
-| `pretty` | Human-readable tables (default)          |
-| `log`    | Console output with additional details   |
-| `json`   | Machine-readable, suitable for scripting |
+| Format   | Use Case                                                                                               |
+| -------- | ------------------------------------------------------------------------------------------------------ |
+| `pretty` | Human-readable tables (default)                                                                        |
+| `log`    | Console output with additional details                                                                 |
+| `json`   | Machine-readable, suitable for scripting — see [Reading JSON Output](./guides/reading-json-output.mdx) |
 
 ## Network Identifiers
 

--- a/ccip-api-ref/docs-cli/guides/reading-json-output.mdx
+++ b/ccip-api-ref/docs-cli/guides/reading-json-output.mdx
@@ -1,0 +1,91 @@
+---
+id: reading-json-output
+title: 'Reading JSON Output'
+description: 'How to parse --format=json output without losing precision on chain selectors, amounts, and fees.'
+sidebar_label: Reading JSON Output
+sidebar_position: 5
+---
+
+# Reading JSON Output
+
+`--format=json` writes CCIP integer fields (`chainSelector`, token amounts, fees, gas limits) as
+plain JSON numbers. These are `uint64` and `uint256` values, so they routinely exceed 2^53.
+
+Python, and Go with `json.Number`, read such values at full precision. JavaScript does not:
+`JSON.parse` represents every JSON number as an IEEE-754 double, which holds 53 bits of integer
+precision, so larger values come back rounded, with no error raised.
+
+```js
+JSON.parse('{"chainSelector":11344663589394136015}').chainSelector
+// => 11344663589394135000   (expected 11344663589394136015)
+```
+
+This is deliberate: the format targets engines with native big-integer support. The requirement is
+on the reader.
+
+## JavaScript and TypeScript
+
+Use `jsonParse` from `@chainlink/ccip-sdk`. It returns large integers as `bigint`. Pass a type
+parameter for the shape you expect; it returns `unknown` by default:
+
+```typescript
+import { jsonParse } from '@chainlink/ccip-sdk'
+
+type ShowOutput = { request: { lane: { sourceChainSelector: bigint } } }
+
+const parsed = jsonParse<ShowOutput>(stdout)
+parsed.request.lane.sourceChainSelector
+// => 16015286601757825753n
+```
+
+If you're not importing the SDK, [`lossless-json`](https://www.npmjs.com/package/lossless-json)
+solves the same problem.
+
+## jq
+
+jq 1.7 and later keep large integers as literal text through passthrough and field selection. Any
+numeric operation converts the value to a double and rounds it. jq 1.6 and earlier round these
+values even on plain `jq .`, so check your version first:
+
+```sh
+jq --version   # jq-1.7 or later required for the passthrough behavior below
+
+ccip-cli show <tx> --format=json | jq '.request.lane.sourceChainSelector'
+# 16015286601757825753
+
+ccip-cli show <tx> --format=json | jq '.request.lane.sourceChainSelector + 0'
+# 16015286601757825000
+```
+
+Use `| tostring` when a shell variable is needed instead of a numeric operation.
+
+## Python, Go
+
+Python's `json.loads` returns arbitrary-precision `int` and needs no special handling.
+
+In Go, the default decode produces `float64`. Use `json.Decoder.UseNumber()`, or unmarshal into a
+`string` or `*big.Int` field:
+
+```go
+dec := json.NewDecoder(r)
+dec.UseNumber()
+```
+
+## The rule
+
+**Keep CCIP integer fields as text or `bigint` in every language.** Converting them to a native
+floating-point number loses precision.
+
+## Testing your pipeline
+
+Round values such as `1e18` are exactly representable as doubles and survive `JSON.parse`
+unchanged, so a "1 token" test passes while the pipeline is still broken. Test with a non-round
+value:
+
+```js
+JSON.parse('{"amount":1234567890123456789}').amount
+// => 1234567890123456800
+```
+
+For the `jsonStringify`/`jsonParse` pair and how they round-trip, see the SDK's
+[JSON Integer Precision guide](https://docs.chain.link/ccip/tools/sdk/guides/json-integer-precision).

--- a/ccip-api-ref/docs-cli/troubleshooting.mdx
+++ b/ccip-api-ref/docs-cli/troubleshooting.mdx
@@ -391,6 +391,9 @@ Redirect stderr:
 ccip-cli show 0x... --format json 2>/dev/null | jq '.'
 ```
 
+If parsing succeeds but a `chainSelector`, amount, or fee looks wrong, see
+[Reading JSON Output](./guides/reading-json-output.mdx).
+
 ### Interactive features not working
 
 Non-TTY environment (scripts, CI).

--- a/ccip-api-ref/docs-sdk/guides/json-integer-precision.mdx
+++ b/ccip-api-ref/docs-sdk/guides/json-integer-precision.mdx
@@ -1,0 +1,84 @@
+---
+id: json-integer-precision
+title: 'JSON Integer Precision'
+description: 'Why chain selectors, amounts, and fees look wrong after JSON.parse, and how to read them correctly.'
+sidebar_label: JSON Integer Precision
+sidebar_position: 16
+---
+
+# JSON Integer Precision
+
+CCIP fields like `chainSelector`, token amounts, and fees are `uint64`/`uint256` values, bigger
+than the 53 bits of integer precision a JSON number can safely hold in most languages.
+`--format json` and `jsonStringify` emit these as plain JSON numbers. Python, Postgres `JSONB`,
+and Go with `json.Number` read them at full precision. JavaScript does not: `JSON.parse`
+represents every JSON number as an IEEE-754 double, which holds 53 bits of integer precision, so
+larger values come back rounded, with no error raised. This is a deliberate design choice, not a
+bug. The requirement is on the reader.
+
+## The failure
+
+```typescript
+// CLI/SDK output, correct on the wire
+const output = '{"chainSelector":11344663589394136015}'
+
+JSON.parse(output).chainSelector
+// => 11344663589394135000   (expected 11344663589394136015)
+```
+
+This affects every `--format json` command (`show`, `search`, `parse`, `send --only-get-fee`,
+`lane`, `token`, …) and any bigint field above `2^53` (~9 × 10^15). Round token amounts like `1e18`
+happen to survive because they're exactly representable. Use a non-round value when testing your
+own pipeline.
+
+## Reading the output in JavaScript
+
+The SDK exports `jsonParse`, which reads large integers as `bigint`. Pass a type parameter for the
+shape you expect; it returns `unknown` by default:
+
+```typescript
+import { jsonParse } from '@chainlink/ccip-sdk'
+
+const output = '{"chainSelector":11344663589394136015}'
+
+jsonParse<{ chainSelector: bigint }>(output).chainSelector
+// => 11344663589394136015n
+```
+
+If you're parsing your own object with `jsonStringify`, `jsonParse` is the matching reader:
+
+```typescript
+import { jsonParse, jsonStringify } from '@chainlink/ccip-sdk'
+
+const encoded = jsonStringify({ amount: 1234567890123456789n, note: 'not a bigint' })
+// => '{"amount":1234567890123456789,"note":"not a bigint"}'
+
+jsonParse<{ amount: bigint; note: string }>(encoded)
+// => { amount: 1234567890123456789n, note: 'not a bigint' }
+```
+
+`jsonParse` distinguishes a `bigint` (bare integer) from a plain `number` integer (tagged with a
+`.0` suffix by `jsonStringify`, e.g. `2.0`), so `{"a":1,"b":2.0}` round-trips as `{ a: 1n, b: 2 }`,
+not `{ a: 1n, b: 2n }`.
+
+## Other consumers
+
+- Python: `json.loads` parses JSON integers as arbitrary-precision `int` natively. No special
+  handling needed.
+- Go: use `json.Decoder.UseNumber()` (or unmarshal into a `*big.Int`/`string` field) to avoid Go's
+  default `float64` decoding, which has the same precision limit as JS.
+- Postgres: a `JSONB` column stores JSON numbers at full precision. Cast to `numeric` on read,
+  keeping the extraction in parentheses. `payload->>'amount'::numeric` is a precedence error and
+  fails with `invalid input syntax for type numeric`, since `::` binds tighter than `->>`. Never
+  cast to `float8`; it rounds the value the same way `JSON.parse` does:
+  ```sql
+  SELECT (payload->>'amount')::numeric FROM messages;
+  ```
+- jq: jq 1.7 and later preserve big integers as literal text through pure passthrough or field
+  selection (`jq .`, `jq '{amount: .amount}'`). Any arithmetic (`jq '.amount + 0'`) forces the
+  value through a `double` and corrupts it the same way `JSON.parse` does. jq 1.6 and earlier round
+  these values even on plain `jq .`, so check `jq --version` before relying on passthrough. Treat
+  these fields as opaque text in jq pipelines; use `| tostring` rather than any numeric operation.
+
+**Keep CCIP integer fields as text or `bigint` in every language.** Converting them to a native
+floating-point number loses precision.

--- a/ccip-api-ref/sidebars-cli.ts
+++ b/ccip-api-ref/sidebars-cli.ts
@@ -41,6 +41,11 @@ const sidebars: SidebarsConfig = {
           id: 'guides/debugging-workflow',
           label: 'Debugging Failed Messages',
         },
+        {
+          type: 'doc',
+          id: 'guides/reading-json-output',
+          label: 'Reading JSON Output',
+        },
       ],
     },
     {

--- a/ccip-api-ref/sidebars-sdk.ts
+++ b/ccip-api-ref/sidebars-sdk.ts
@@ -41,6 +41,7 @@ const sidebars: SidebarsConfig = {
         'guides/browser-setup',
         'guides/error-handling',
         'guides/error-reference',
+        'guides/json-integer-precision',
       ],
     },
     {

--- a/ccip-cli/README.md
+++ b/ccip-cli/README.md
@@ -141,7 +141,10 @@ ccip-cli send --<TAB>  # lists all send options
 - `-v`: Verbose/debug output
 - `--format=pretty` (default): Human-readable tabular output
 - `--format=log`: Basic console logging, may show some more details (e.g. token addresses)
-- `--format=json`: Machine-readable JSON
+- `--format=json`: Machine-readable JSON. Large integers (`chainSelector`, amounts, fees) are
+  plain JSON numbers and lose precision in JavaScript's `JSON.parse`. Use `jsonParse` from
+  `@chainlink/ccip-sdk`, or see
+  [Reading JSON Output](https://docs.chain.link/ccip/tools/cli/guides/reading-json-output).
 - `--no-api`: Disable CCIP API integration (fully decentralized mode, RPC-only)
 - `--api=<url>`: Use a custom CCIP API URL instead of the default `api.ccip.chain.link`
 

--- a/ccip-cli/src/index.ts
+++ b/ccip-cli/src/index.ts
@@ -2,9 +2,12 @@
 
 // Redirect console.log/debug/info to stderr before any imports. Third-party libraries (notably
 // ethers.js v6) use bare console.log for retry/diagnostic messages, which would pollute stdout
-// and break JSON.parse(stdout) for agents. Our own code uses ctx.output (stdout) and ctx.logger (stderr).
-// Using `new Console(process.stderr)` preserves Node's exact formatting (util.format, util.inspect,
-// format specifiers like %s/%d, color support, etc.) — only the destination stream changes.
+// and break JSON.parse(stdout) for agents. Our own code uses ctx.output (stdout) and ctx.logger
+// (stderr). Using `new Console(process.stderr)` preserves Node's exact formatting (util.format,
+// util.inspect, format specifiers like %s/%d, color support, etc.) — only the destination stream
+// changes. Agents should still parse stdout with `jsonParse` from `@chainlink/ccip-sdk`, not raw
+// `JSON.parse` — --format=json emits large integers (chainSelector, amounts, fees) as plain JSON
+// numbers, which loses precision above 2^53 in plain `JSON.parse` (see --format's --help text).
 
 const stderrConsole = new console.Console(process.stderr)
 console.log = stderrConsole.log.bind(stderrConsole)
@@ -78,7 +81,9 @@ const globalOpts = {
   },
   format: {
     alias: 'f',
-    describe: "Output to console format: pretty tables, node's console.log or JSON",
+    describe:
+      "Output to console format: pretty tables, node's console.log or JSON " +
+      '(large ints are plain JSON numbers; parse with jsonParse from @chainlink/ccip-sdk, not JSON.parse)',
     choices: Object.values(Format),
     default: Format.pretty,
   },


### PR DESCRIPTION
This pull request improves documentation and developer guidance around handling large integer fields in CCIP JSON output, especially for JavaScript/TypeScript users. It adds a new SDK guide, enhances CLI documentation, and clarifies best practices for parsing JSON with large integers, to prevent silent precision loss in JavaScript and other languages with limited integer precision.

**Documentation improvements for JSON integer precision:**

* Added a new guide, `json-integer-precision`, to the SDK docs explaining why fields like `chainSelector`, token amounts, and fees are emitted as plain JSON numbers, the risks of using `JSON.parse` in JavaScript, and how to use `jsonParse` from `@chainlink/ccip-sdk` to safely handle large integers. The guide also covers handling in Python, Go, Postgres, and jq.
* Included the new guide in the SDK documentation sidebar for easier discovery.

**CLI documentation updates:**

* Updated the CLI README to clarify that `--format=json` emits large integers as plain JSON numbers, not quoted strings, and warns users about precision loss when using `JSON.parse`, `jq`, or other parsers.
* Added a new "Scripting & Automation" section to the CLI README, providing concrete examples of the precision issue, correct parsing strategies in various languages, and a reference to the new SDK guide.

**Code comments for agent developers:**

* Improved comments in `ccip-cli/src/index.ts` to explicitly warn that agents should use `jsonParse` instead of `JSON.parse` when consuming CLI JSON output, due to the risk of integer corruption above 2^53.