### PR TITLE
feat(cct-sdk): Add get token admin registry config evm query

### DIFF
--- a/ccip-sdk/src/cct/evm/index.test.ts
+++ b/ccip-sdk/src/cct/evm/index.test.ts
@@ -600,4 +600,72 @@ describe('EVMTokenManager (cct/evm)', () => {
       )
     })
   })
+  describe('getTokenAdminRegistry', () => {
+    const GET_TOKEN_CONFIG_IFACE = new Interface([
+      'function getTokenConfig(address token) view returns (tuple(address administrator, address pendingAdministrator, address tokenPool))',
+    ])
+    const ADMINISTRATOR = '0x' + '77'.repeat(20)
+
+    /**
+     * Chain stub whose provider answers `getTokenConfig` with `administrator`/zeroed others —
+     * but only for a call to `TAR` decoding to `TOKEN`. Mirrors the target/argument assertions in
+     * `token-admin-registry/operations/get-token-admin-registry.test.ts`'s `stubChain`: matching
+     * on the selector alone can't tell a correct read from one with the call target or decoded
+     * token swapped, since both would still reach this branch and get `encoded` back.
+     */
+    function stubTarChain(administrator: string) {
+      const selector = GET_TOKEN_CONFIG_IFACE.getFunction('getTokenConfig')!.selector
+      const encoded = GET_TOKEN_CONFIG_IFACE.encodeFunctionResult('getTokenConfig', [
+        [administrator, ZeroAddress, ZeroAddress],
+      ])
+      return stubChain({
+        provider: {
+          call: async ({ to, data }: { to?: string; data: string }) => {
+            if (data.slice(0, 10) !== selector) return '0x'
+            assert.equal(to, TAR, 'calls the resolved TAR, not `address`')
+            const [token] = GET_TOKEN_CONFIG_IFACE.decodeFunctionData('getTokenConfig', data)
+            assert.equal(token, TOKEN, 'reads the config for `tokenAddress`')
+            return encoded
+          },
+        } as never,
+      })
+    }
+
+    it('reads through the wrapped chain, resolving the TAR from `address`', async () => {
+      const config = await EVMTokenManager.fromChain(
+        stubTarChain(ADMINISTRATOR),
+      ).getTokenAdminRegistry({
+        address: ROUTER,
+        tokenAddress: TOKEN,
+      })
+      assert.deepEqual(config, { administrator: ADMINISTRATOR })
+    })
+
+    it('reports a zero administrator rather than throwing', async () => {
+      const config = await EVMTokenManager.fromChain(
+        stubTarChain(ZeroAddress),
+      ).getTokenAdminRegistry({ address: ROUTER, tokenAddress: TOKEN })
+      assert.equal(config.administrator, ZeroAddress)
+    })
+
+    it('rejects an invalid token address before any RPC, tagged with the operation', async () => {
+      let called = false
+      const cct = EVMTokenManager.fromChain(
+        stubChain({
+          getTokenAdminRegistryFor: () => {
+            called = true
+            return Promise.resolve(TAR)
+          },
+        }),
+      )
+      await assert.rejects(
+        () => cct.getTokenAdminRegistry({ address: ROUTER, tokenAddress: 'not-an-address' }),
+        (err: unknown) =>
+          err instanceof CCTParamsInvalidError &&
+          err.context.operation === 'getTokenAdminRegistry' &&
+          err.context.param === 'tokenAddress',
+      )
+      assert.equal(called, false, 'validation fails before TAR discovery')
+    })
+  })
 })

--- a/ccip-sdk/src/cct/evm/index.test.ts
+++ b/ccip-sdk/src/cct/evm/index.test.ts
@@ -668,4 +668,58 @@ describe('EVMTokenManager (cct/evm)', () => {
       assert.equal(called, false, 'validation fails before TAR discovery')
     })
   })
+  describe('getSupportedTokens', () => {
+    it('resolves the TAR and lists its configured tokens', async () => {
+      const tokens = [TOKEN, POOL]
+      let seenOpts: { page?: number } | undefined
+      const cct = EVMTokenManager.fromChain(
+        stubChain({
+          getSupportedTokens: async (registry: string, opts?: { page?: number }) => {
+            assert.equal(registry, TAR)
+            seenOpts = opts
+            return tokens
+          },
+        }),
+      )
+
+      const result = await cct.getSupportedTokens({ address: ROUTER })
+      assert.deepEqual(result, tokens)
+      assert.deepEqual(seenOpts, { page: undefined })
+    })
+
+    it('forwards `page` to the wrapped chain', async () => {
+      let seenPage: number | undefined
+      const cct = EVMTokenManager.fromChain(
+        stubChain({
+          getSupportedTokens: async (_registry: string, opts?: { page?: number }) => {
+            seenPage = opts?.page
+            return []
+          },
+        }),
+      )
+
+      await cct.getSupportedTokens({ address: ROUTER, page: 25 })
+      assert.equal(seenPage, 25)
+    })
+
+    it('rejects an invalid address before any RPC, tagged with the operation', async () => {
+      let called = false
+      const cct = EVMTokenManager.fromChain(
+        stubChain({
+          getTokenAdminRegistryFor: () => {
+            called = true
+            return Promise.resolve(TAR)
+          },
+        }),
+      )
+      await assert.rejects(
+        () => cct.getSupportedTokens({ address: 'not-an-address' }),
+        (err: unknown) =>
+          err instanceof CCTParamsInvalidError &&
+          err.context.operation === 'getSupportedTokens' &&
+          err.context.param === 'address',
+      )
+      assert.equal(called, false, 'validation fails before TAR discovery')
+    })
+  })
 })

--- a/ccip-sdk/src/cct/evm/index.ts
+++ b/ccip-sdk/src/cct/evm/index.ts
@@ -26,6 +26,11 @@ import {
   AcceptAdmin,
 } from './token-admin-registry/operations/accept-admin.ts'
 import {
+  type GetTokenAdminRegistryParams,
+  type GetTokenAdminRegistryResult,
+  GetTokenAdminRegistry,
+} from './token-admin-registry/operations/get-token-admin-registry.ts'
+import {
   type RegisterAdminParams,
   RegisterAdmin,
 } from './token-admin-registry/operations/register-admin.ts'
@@ -59,6 +64,7 @@ export class EVMTokenManager extends TokenManager<typeof ChainFamily.EVM> {
   readonly #setPool = new SetPool()
   readonly #transferAdmin = new TransferAdmin()
   readonly #acceptAdmin = new AcceptAdmin()
+  readonly #getTokenAdminRegistry = new GetTokenAdminRegistry()
 
   // Token pool operations
   readonly #deployTokenPool = new DeployTokenPool()
@@ -289,6 +295,31 @@ export class EVMTokenManager extends TokenManager<typeof ChainFamily.EVM> {
    */
   acceptAdmin(opts: EVMExecuteParams<AcceptAdminParams>): Promise<TransactionResult> {
     return this.#acceptAdmin.execute(this.chain, opts)
+  }
+
+  /**
+   * Reads a token's TokenAdminRegistry entry: its `administrator`, any `pendingAdministrator`,
+   * and its registered `tokenPool`.
+   * @remarks Deliberately diverges from `cct.chain.getRegistryTokenConfig()`, which throws when
+   * `administrator` is the zero address — exactly the post-`registerAdmin`, pre-`acceptAdmin`
+   * state. This op reports `{ administrator: ZeroAddress, pendingAdministrator }` faithfully
+   * instead, so a pending registration is observable; see
+   * {@link GetTokenAdminRegistry} for the full rationale. `pendingAdministrator` and `tokenPool`
+   * are still omitted when zero.
+   * @throws {@link CCTParamsInvalidError} if any param is invalid
+   * @example
+   * ```typescript
+   * const config = await cct.getTokenAdminRegistry({
+   *   address: '0xTokenAdminRegistry...', // or a Router/OnRamp/OffRamp/pool to resolve it from
+   *   tokenAddress: '0xToken...',
+   * })
+   * if (config.administrator === ZeroAddress) {
+   *   console.log('pending acceptance by', config.pendingAdministrator)
+   * }
+   * ```
+   */
+  getTokenAdminRegistry(opts: GetTokenAdminRegistryParams): Promise<GetTokenAdminRegistryResult> {
+    return this.#getTokenAdminRegistry.query(this.chain, opts)
   }
 
   /**
@@ -541,6 +572,10 @@ export type {
   RegisterAdminMethod,
   RegisterAdminParams,
 } from './token-admin-registry/operations/register-admin.ts'
+export type {
+  GetTokenAdminRegistryParams,
+  GetTokenAdminRegistryResult,
+} from './token-admin-registry/operations/get-token-admin-registry.ts'
 export type { SetPoolParams } from './token-admin-registry/operations/set-pool.ts'
 export type { TransferAdminParams } from './token-admin-registry/operations/transfer-admin.ts'
 export type { DeployTokenParams } from './token/operations/deploy-token.ts'

--- a/ccip-sdk/src/cct/evm/index.ts
+++ b/ccip-sdk/src/cct/evm/index.ts
@@ -26,6 +26,11 @@ import {
   AcceptAdmin,
 } from './token-admin-registry/operations/accept-admin.ts'
 import {
+  type GetSupportedTokensParams,
+  type GetSupportedTokensResult,
+  GetSupportedTokens,
+} from './token-admin-registry/operations/get-supported-tokens.ts'
+import {
   type GetTokenAdminRegistryParams,
   type GetTokenAdminRegistryResult,
   GetTokenAdminRegistry,
@@ -65,6 +70,7 @@ export class EVMTokenManager extends TokenManager<typeof ChainFamily.EVM> {
   readonly #transferAdmin = new TransferAdmin()
   readonly #acceptAdmin = new AcceptAdmin()
   readonly #getTokenAdminRegistry = new GetTokenAdminRegistry()
+  readonly #getSupportedTokens = new GetSupportedTokens()
 
   // Token pool operations
   readonly #deployTokenPool = new DeployTokenPool()
@@ -323,6 +329,21 @@ export class EVMTokenManager extends TokenManager<typeof ChainFamily.EVM> {
   }
 
   /**
+   * Lists every token configured in the TokenAdminRegistry resolved from `address`.
+   * @remarks The registry paginates via `getAllConfiguredTokens` — `opts.page` sets the batch size per call; omit it to read the
+   * whole registry in one round trip per 1000 tokens.
+   * @throws {@link CCTParamsInvalidError} if `address` is not a valid address, or `page` is given
+   * and is not a positive integer
+   * @example
+   * ```typescript
+   * const tokens = await cct.getSupportedTokens({ address: '0xTokenAdminRegistry...' })
+   * ```
+   */
+  getSupportedTokens(opts: GetSupportedTokensParams): Promise<GetSupportedTokensResult> {
+    return this.#getSupportedTokens.query(this.chain, opts)
+  }
+
+  /**
    * Builds an unsigned pool `transferOwnership` tx (for multisig / offline signing). Probes the
    * pool's on-chain `typeAndVersion` to resolve its interface + encoder; the `transferOwnership`
    * calldata is stable across pool versions, so the resolved encoding is version/type-independent.
@@ -578,6 +599,10 @@ export type {
 } from './token-admin-registry/operations/get-token-admin-registry.ts'
 export type { SetPoolParams } from './token-admin-registry/operations/set-pool.ts'
 export type { TransferAdminParams } from './token-admin-registry/operations/transfer-admin.ts'
+export type {
+  GetSupportedTokensParams,
+  GetSupportedTokensResult,
+} from './token-admin-registry/operations/get-supported-tokens.ts'
 export type { DeployTokenParams } from './token/operations/deploy-token.ts'
 export type {
   DeployTokenPoolParams,

--- a/ccip-sdk/src/cct/evm/token-admin-registry/operations/get-supported-tokens.test.ts
+++ b/ccip-sdk/src/cct/evm/token-admin-registry/operations/get-supported-tokens.test.ts
@@ -1,0 +1,126 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import { GetSupportedTokens } from './get-supported-tokens.ts'
+import { interfaces } from '../../../../evm/const.ts'
+import { EVMChain } from '../../../../evm/index.ts'
+import { CCTParamsInvalidError } from '../../../errors.ts'
+
+const OFF_RAMP = '0x' + '11'.repeat(20)
+const TAR = '0x' + '22'.repeat(20)
+const TOKENS = ['0x' + '33'.repeat(20), '0x' + '44'.repeat(20)]
+
+describe('GetSupportedTokens (cct/evm)', () => {
+  describe('query', () => {
+    it('resolves the TAR and lists its configured tokens', async () => {
+      let resolvedAddress: string | undefined
+      let seenOpts: { page?: number } | undefined
+      const chain = {
+        getTokenAdminRegistryFor: async (address: string) => {
+          resolvedAddress = address
+          return TAR
+        },
+        getSupportedTokens: async (registry: string, opts?: { page?: number }) => {
+          assert.equal(registry, TAR)
+          seenOpts = opts
+          return TOKENS
+        },
+      } as unknown as EVMChain
+
+      const result = await new GetSupportedTokens().query(chain, { address: OFF_RAMP })
+      assert.deepEqual(result, TOKENS)
+      assert.equal(resolvedAddress, OFF_RAMP)
+      assert.deepEqual(seenOpts, { page: undefined })
+    })
+
+    it('forwards `page` to chain.getSupportedTokens, which owns the pagination loop', async () => {
+      let seenPage: number | undefined
+      const chain = {
+        getTokenAdminRegistryFor: async () => TAR,
+        getSupportedTokens: async (_registry: string, opts?: { page?: number }) => {
+          seenPage = opts?.page
+          return TOKENS
+        },
+      } as unknown as EVMChain
+
+      await new GetSupportedTokens().query(chain, { address: OFF_RAMP, page: 50 })
+      assert.equal(seenPage, 50)
+    })
+
+    it('paginates `getAllConfiguredTokens` through the real EVMChain.getSupportedTokens loop', async () => {
+      // The two tests above stub `chain.getSupportedTokens` wholesale, so they only pin that this
+      // op forwards `page` — they cannot catch a startIndex/maxCount swap or a dropped final page
+      // in the loop itself. This test runs the *real* `EVMChain.prototype.getSupportedTokens`
+      // (bound to a stub with just `provider.call`) against three tokens with `page: 2`, so a full
+      // first page (0,2) must be followed by a short second page (2,2) that ends the scan.
+      const allTokens = [...TOKENS, '0x' + '55'.repeat(20)]
+      const seenCalls: Array<{ startIndex: bigint; maxCount: bigint }> = []
+      const chain = {
+        getTokenAdminRegistryFor: async () => TAR,
+        provider: {
+          call: async ({ data }: { data: string }) => {
+            const [startIndex, maxCount] = interfaces.TokenAdminRegistry.decodeFunctionData(
+              'getAllConfiguredTokens',
+              data,
+            ) as unknown as [bigint, bigint]
+            seenCalls.push({ startIndex, maxCount })
+            const page = allTokens.slice(Number(startIndex), Number(startIndex + maxCount))
+            return interfaces.TokenAdminRegistry.encodeFunctionResult('getAllConfiguredTokens', [
+              page,
+            ])
+          },
+        },
+      } as unknown as EVMChain
+      chain.getSupportedTokens = EVMChain.prototype.getSupportedTokens.bind(chain)
+
+      const result = await new GetSupportedTokens().query(chain, { address: OFF_RAMP, page: 2 })
+
+      assert.deepEqual(result, allTokens, 'pages are concatenated in order')
+      assert.deepEqual(
+        seenCalls,
+        [
+          { startIndex: 0n, maxCount: 2n },
+          { startIndex: 2n, maxCount: 2n },
+        ],
+        'startIndex advances by the previous page length and maxCount stays pinned to `page`',
+      )
+    })
+  })
+
+  describe('validation', () => {
+    it('rejects an invalid address before any RPC', async () => {
+      let called = false
+      const chain = {
+        getTokenAdminRegistryFor: async () => {
+          called = true
+          return TAR
+        },
+      } as unknown as EVMChain
+
+      await assert.rejects(
+        () => new GetSupportedTokens().query(chain, { address: 'not-an-address' }),
+        (error: unknown) =>
+          error instanceof CCTParamsInvalidError &&
+          error.context.operation === 'getSupportedTokens' &&
+          error.context.param === 'address',
+      )
+      assert.equal(called, false, 'validation fails before TAR discovery')
+    })
+
+    it('rejects a non-positive `page`', async () => {
+      await assert.rejects(
+        () => new GetSupportedTokens().query({} as EVMChain, { address: OFF_RAMP, page: 0 }),
+        (error: unknown) =>
+          error instanceof CCTParamsInvalidError && error.context.param === 'page',
+      )
+    })
+
+    it('rejects a non-integer `page`', async () => {
+      await assert.rejects(
+        () => new GetSupportedTokens().query({} as EVMChain, { address: OFF_RAMP, page: 1.5 }),
+        (error: unknown) =>
+          error instanceof CCTParamsInvalidError && error.context.param === 'page',
+      )
+    })
+  })
+})

--- a/ccip-sdk/src/cct/evm/token-admin-registry/operations/get-supported-tokens.ts
+++ b/ccip-sdk/src/cct/evm/token-admin-registry/operations/get-supported-tokens.ts
@@ -1,0 +1,68 @@
+/**
+ * getSupportedTokens — lists the ERC-20 tokens configured in a TokenAdminRegistry. Version-independent
+ * (`getAllConfiguredTokens` is byte-identical from v1.5.0 through latest).
+ *
+ * @packageDocumentation
+ */
+
+import type { EVMChain } from '../../../../evm/index.ts'
+import { CCTParamsInvalidError } from '../../../errors.ts'
+import { EVMQuery } from '../../query.ts'
+import { validateAddress } from '../../validate.ts'
+
+/** Parameters for {@link GetSupportedTokens}. */
+export type GetSupportedTokensParams = {
+  /**
+   * Contract to resolve the TokenAdminRegistry from. Pass the registry itself for a
+   * direct lookup; a Router, OnRamp, OffRamp, or TokenPool also work but add hops and
+   * need a configured lane.
+   */
+  address: string
+  /**
+   * Batch size `chain.getSupportedTokens` requests per `getAllConfiguredTokens` call while it
+   * paginates. Defaults to 1000. Optional — a very large registry may need a smaller batch to
+   * stay under an RPC's response-size limit.
+   */
+  page?: number
+}
+
+/** Result of {@link GetSupportedTokens}: array of token addresses. */
+export type GetSupportedTokensResult = string[]
+
+/**
+ * Lists every token configured in the TokenAdminRegistry resolved from `address`, paginating
+ * through `getAllConfiguredTokens` until exhausted.
+ */
+export class GetSupportedTokens extends EVMQuery<GetSupportedTokensParams, string[]> {
+  readonly name = 'getSupportedTokens'
+
+  /**
+   * Validates the resolution address and, when given, `page`; nothing to convert for {@link read}.
+   * @throws {@link CCTParamsInvalidError} if `address` is not a valid address, or `page` is given
+   * and is not a positive integer
+   */
+  protected prepare(params: GetSupportedTokensParams): GetSupportedTokensParams {
+    validateAddress(this.name, 'address', params.address)
+    if (params.page !== undefined && !(Number.isInteger(params.page) && params.page > 0))
+      throw new CCTParamsInvalidError(
+        this.name,
+        'page',
+        `must be a positive integer, got ${String(params.page)}`,
+      )
+    return params
+  }
+
+  /**
+   * Resolves the TAR and lists its configured tokens.
+   * @remarks Delegates pagination to {@link EVMChain.getSupportedTokens}, which already loops
+   * `getAllConfiguredTokens(startIndex, maxCount)` until a short page ends the scan — this op does
+   * not reimplement that loop.
+   */
+  protected async read(
+    chain: EVMChain,
+    { address, page }: GetSupportedTokensParams,
+  ): Promise<string[]> {
+    const registry = await chain.getTokenAdminRegistryFor(address)
+    return chain.getSupportedTokens(registry, { page })
+  }
+}

--- a/ccip-sdk/src/cct/evm/token-admin-registry/operations/get-token-admin-registry.test.ts
+++ b/ccip-sdk/src/cct/evm/token-admin-registry/operations/get-token-admin-registry.test.ts
@@ -1,0 +1,181 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import { Interface, ZeroAddress, getAddress, makeError } from 'ethers'
+
+import { GetTokenAdminRegistry } from './get-token-admin-registry.ts'
+import type { EVMChain } from '../../../../evm/index.ts'
+import { CCTParamsInvalidError } from '../../../errors.ts'
+
+const TOKEN = '0x' + '11'.repeat(20)
+const ROUTER = '0x' + '22'.repeat(20)
+const TAR = '0x' + '33'.repeat(20)
+// Mixed-case hex, unlike TOKEN/ROUTER/TAR above: their EIP-55 checksums re-case letters, so
+// asserting `getAddress(FIXTURE)` below only proves normalization happens if the raw fixture
+// isn't already in checksummed form. A digit-only fixture would pass even if the op forgot to
+// checksum (or lowercased) its output.
+const ADMINISTRATOR = '0xabcdef1234567890abcdef1234567890abcdef12'
+const PENDING_ADMINISTRATOR = '0x1234567890abcdef1234567890abcdef12345678'
+const POOL = '0xfedcba9876543210fedcba9876543210fedcba98'
+
+const IFACE = new Interface([
+  'function getTokenConfig(address token) view returns (tuple(address administrator, address pendingAdministrator, address tokenPool))',
+])
+
+/**
+ * EVMChain stub: `getTokenAdminRegistryFor` reports `registry`, and the provider answers
+ * `eth_call` with `getTokenConfig` encoded as `(administrator, pendingAdministrator, tokenPool)` —
+ * but only for a call to `registry` decoding to `TOKEN`; any other call, target, or argument
+ * reverts (or fails the assertion), so a read that mixes up its target or argument is caught
+ * rather than silently returning the fixture data.
+ */
+function stubChain({
+  registry = TAR,
+  administrator = ADMINISTRATOR,
+  pendingAdministrator = PENDING_ADMINISTRATOR,
+  tokenPool = POOL,
+}: {
+  registry?: string
+  administrator?: string
+  pendingAdministrator?: string
+  tokenPool?: string
+} = {}): EVMChain {
+  const encoded = IFACE.encodeFunctionResult('getTokenConfig', [
+    [administrator, pendingAdministrator, tokenPool],
+  ])
+  const selector = IFACE.getFunction('getTokenConfig')!.selector
+
+  return {
+    provider: {
+      call: async ({ to, data }: { to?: string; data: string }) => {
+        if (data.slice(0, 10) !== selector)
+          throw makeError('execution reverted', 'CALL_EXCEPTION', {
+            action: 'call',
+            data: '0x',
+            reason: null,
+            transaction: { to: null, data },
+            invocation: null,
+            revert: null,
+          })
+        // Selector-only matching can't tell a correct read from one with the call target or the
+        // decoded token argument swapped (e.g. reading a different contract's, or a different
+        // token's, config) — both would still hit this branch and get `encoded` back. Assert the
+        // resolved registry and the decoded argument so either mix-up fails loudly instead of
+        // silently returning the fixture data.
+        assert.equal(to, getAddress(registry), 'calls the resolved TAR, not `address`')
+        const [token] = IFACE.decodeFunctionData('getTokenConfig', data)
+        assert.equal(token, getAddress(TOKEN), 'reads the config for `tokenAddress`')
+        return encoded
+      },
+    },
+    logger: { debug() {}, info() {}, warn() {}, error() {} },
+    getTokenAdminRegistryFor: () => Promise.resolve(registry),
+  } as unknown as EVMChain
+}
+
+describe('GetTokenAdminRegistry (cct/evm token-admin-registry query)', () => {
+  it('reads administrator, pendingAdministrator, and tokenPool', async () => {
+    const config = await new GetTokenAdminRegistry().query(stubChain(), {
+      address: ROUTER,
+      tokenAddress: TOKEN,
+    })
+
+    assert.deepEqual(config, {
+      administrator: getAddress(ADMINISTRATOR),
+      pendingAdministrator: getAddress(PENDING_ADMINISTRATOR),
+      tokenPool: getAddress(POOL),
+    })
+  })
+
+  it('resolves the TAR from `address` before reading', async () => {
+    let seen: string | undefined
+    const chain = stubChain()
+    chain.getTokenAdminRegistryFor = (address: string) => {
+      seen = address
+      return Promise.resolve(TAR)
+    }
+
+    await new GetTokenAdminRegistry().query(chain, { address: ROUTER, tokenAddress: TOKEN })
+
+    assert.equal(seen, ROUTER)
+  })
+
+  it(
+    'reports a zero administrator rather than throwing — the pending-registration state ' +
+      'EVMChain.getRegistryTokenConfig cannot observe',
+    async () => {
+      const config = await new GetTokenAdminRegistry().query(
+        stubChain({ administrator: ZeroAddress }),
+        { address: ROUTER, tokenAddress: TOKEN },
+      )
+
+      assert.equal(config.administrator, ZeroAddress)
+      assert.equal(config.pendingAdministrator, getAddress(PENDING_ADMINISTRATOR))
+    },
+  )
+
+  it('omits pendingAdministrator when zero', async () => {
+    const config = await new GetTokenAdminRegistry().query(
+      stubChain({ pendingAdministrator: ZeroAddress }),
+      { address: ROUTER, tokenAddress: TOKEN },
+    )
+
+    assert.ok(!('pendingAdministrator' in config))
+  })
+
+  it('omits tokenPool when zero', async () => {
+    const config = await new GetTokenAdminRegistry().query(stubChain({ tokenPool: ZeroAddress }), {
+      address: ROUTER,
+      tokenAddress: TOKEN,
+    })
+
+    assert.ok(!('tokenPool' in config))
+  })
+
+  it('omits both optional fields for an unregistered token', async () => {
+    const config = await new GetTokenAdminRegistry().query(
+      stubChain({
+        administrator: ZeroAddress,
+        pendingAdministrator: ZeroAddress,
+        tokenPool: ZeroAddress,
+      }),
+      { address: ROUTER, tokenAddress: TOKEN },
+    )
+
+    assert.deepEqual(config, { administrator: ZeroAddress })
+  })
+
+  describe('validation', () => {
+    it('rejects an invalid `address` before any RPC', async () => {
+      let called = false
+      const chain = stubChain()
+      chain.getTokenAdminRegistryFor = () => {
+        called = true
+        return Promise.resolve(TAR)
+      }
+
+      await assert.rejects(
+        () => new GetTokenAdminRegistry().query(chain, { address: 'nope', tokenAddress: TOKEN }),
+        (err: unknown) =>
+          err instanceof CCTParamsInvalidError &&
+          err.context.operation === 'getTokenAdminRegistry' &&
+          err.context.param === 'address',
+      )
+      assert.equal(called, false, 'validation fails before TAR discovery')
+    })
+
+    it('rejects an invalid `tokenAddress` before any RPC', async () => {
+      await assert.rejects(
+        () =>
+          new GetTokenAdminRegistry().query(stubChain(), {
+            address: ROUTER,
+            tokenAddress: 'nope',
+          }),
+        (err: unknown) =>
+          err instanceof CCTParamsInvalidError &&
+          err.context.operation === 'getTokenAdminRegistry' &&
+          err.context.param === 'tokenAddress',
+      )
+    })
+  })
+})

--- a/ccip-sdk/src/cct/evm/token-admin-registry/operations/get-token-admin-registry.ts
+++ b/ccip-sdk/src/cct/evm/token-admin-registry/operations/get-token-admin-registry.ts
@@ -26,7 +26,11 @@ export type GetTokenAdminRegistryParams = {
   tokenAddress: string
 }
 
-/** Result of {@link GetTokenAdminRegistry}: the TAR entry for one token. */
+/**
+ * Result of {@link GetTokenAdminRegistry}: the TAR entry for one token.
+ * @remarks `administrator` may be {@link ZeroAddress} for a token pending acceptance;
+ * test with `=== ZeroAddress`, not truthiness.
+ */
 export type GetTokenAdminRegistryResult = RegistryTokenConfig
 
 /**

--- a/ccip-sdk/src/cct/evm/token-admin-registry/operations/get-token-admin-registry.ts
+++ b/ccip-sdk/src/cct/evm/token-admin-registry/operations/get-token-admin-registry.ts
@@ -1,0 +1,80 @@
+/**
+ * getTokenAdminRegistry — reads a token's TokenAdminRegistry entry: its administrator, any
+ * pending administrator, and its registered pool. Version-independent (v1.5–v2.0 share one
+ * `getTokenConfig` encoding).
+ *
+ * @packageDocumentation
+ */
+
+import { ZeroAddress } from 'ethers'
+
+import type { RegistryTokenConfig } from '../../../../chain.ts'
+import type { EVMChain } from '../../../../evm/index.ts'
+import { EVMQuery } from '../../query.ts'
+import { validateAddress } from '../../validate.ts'
+import { readTokenAdminRegistryConfig } from '../contracts.ts'
+
+/** Parameters for {@link GetTokenAdminRegistry}. */
+export type GetTokenAdminRegistryParams = {
+  /**
+   * Contract to resolve the TokenAdminRegistry from. Pass the registry itself for a
+   * direct lookup; a Router, OnRamp, OffRamp, or TokenPool also work but add hops and
+   * need a configured lane.
+   */
+  address: string
+  /** Token to read the registry entry for. */
+  tokenAddress: string
+}
+
+/** Result of {@link GetTokenAdminRegistry}: the TAR entry for one token. */
+export type GetTokenAdminRegistryResult = RegistryTokenConfig
+
+/**
+ * Reads a token's TokenAdminRegistry entry directly through `getTokenConfig`, reporting a zero
+ * `administrator` rather than throwing.
+ * @remarks Deliberately diverges from `EVMChain.getRegistryTokenConfig`, which throws
+ * `CCIPTokenNotConfiguredError` whenever `administrator === ZeroAddress` — exactly the
+ * post-`registerAdmin`, pre-`acceptAdmin` state, which made a pending registration
+ * unobservable through the public read API. This op reads `getTokenConfig` through
+ * {@link readTokenAdminRegistryConfig} instead of delegating to that helper, so
+ * `{ administrator: ZeroAddress, pendingAdministrator }` is reported faithfully.
+ * `pendingAdministrator` and `tokenPool` are still omitted when zero (nothing pending, no pool
+ * registered) — only `administrator` survives as the zero address, since that is the one state
+ * this op exists to surface.
+ */
+export class GetTokenAdminRegistry extends EVMQuery<
+  GetTokenAdminRegistryParams,
+  GetTokenAdminRegistryResult
+> {
+  readonly name = 'getTokenAdminRegistry'
+
+  /**
+   * Validates both addresses; nothing to convert for {@link read}.
+   * @throws {@link CCTParamsInvalidError} if `address` or `tokenAddress` is not a valid address
+   */
+  protected prepare(params: GetTokenAdminRegistryParams): GetTokenAdminRegistryParams {
+    validateAddress(this.name, 'address', params.address)
+    validateAddress(this.name, 'tokenAddress', params.tokenAddress)
+    return params
+  }
+
+  /** Resolves the TAR from `address`, then reads and normalizes `getTokenConfig(tokenAddress)`. */
+  protected async read(
+    chain: EVMChain,
+    { address, tokenAddress }: GetTokenAdminRegistryParams,
+  ): Promise<GetTokenAdminRegistryResult> {
+    const registry = await chain.getTokenAdminRegistryFor(address)
+    const config = await readTokenAdminRegistryConfig(chain, registry, tokenAddress)
+
+    return {
+      // unlike EVMChain.getRegistryTokenConfig, a zero administrator is reported, not thrown —
+      // that's the whole point of this op (see the class @remarks). The two optional fields are
+      // dropped when zero, so callers can test presence rather than compare against ZeroAddress.
+      administrator: config.administrator,
+      ...(config.pendingAdministrator !== ZeroAddress && {
+        pendingAdministrator: config.pendingAdministrator,
+      }),
+      ...(config.tokenPool !== ZeroAddress && { tokenPool: config.tokenPool }),
+    }
+  }
+}


### PR DESCRIPTION
## What

- Add `getTokenAdminRegistry` query to EVMTokenManager. Reads a token's entry in the TokenAdminRegistry and returns its administrator, any pending administrator, and its registered pool (read-only, so there is no wallet and no tx)

## Why

- Gives callers a way to see the registry state before acting on it

## Testing

- Unit tests cover the read

## Notes

- `chain.getRegistryTokenConfig` cannot be used for this, because it throws when the administrator is the zero address, which is exactly the state a token sits in after registerAdmin and before acceptAdmin