### PR TITLE
feat(cct-sdk): Add get supported tokens evm query

### DIFF
--- a/ccip-sdk/src/cct/evm/index.test.ts
+++ b/ccip-sdk/src/cct/evm/index.test.ts
@@ -668,4 +668,58 @@ describe('EVMTokenManager (cct/evm)', () => {
       assert.equal(called, false, 'validation fails before TAR discovery')
     })
   })
+  describe('getSupportedTokens', () => {
+    it('resolves the TAR and lists its configured tokens', async () => {
+      const tokens = [TOKEN, POOL]
+      let seenOpts: { page?: number } | undefined
+      const cct = EVMTokenManager.fromChain(
+        stubChain({
+          getSupportedTokens: async (registry: string, opts?: { page?: number }) => {
+            assert.equal(registry, TAR)
+            seenOpts = opts
+            return tokens
+          },
+        }),
+      )
+
+      const result = await cct.getSupportedTokens({ address: ROUTER })
+      assert.deepEqual(result, tokens)
+      assert.deepEqual(seenOpts, { page: undefined })
+    })
+
+    it('forwards `page` to the wrapped chain', async () => {
+      let seenPage: number | undefined
+      const cct = EVMTokenManager.fromChain(
+        stubChain({
+          getSupportedTokens: async (_registry: string, opts?: { page?: number }) => {
+            seenPage = opts?.page
+            return []
+          },
+        }),
+      )
+
+      await cct.getSupportedTokens({ address: ROUTER, page: 25 })
+      assert.equal(seenPage, 25)
+    })
+
+    it('rejects an invalid address before any RPC, tagged with the operation', async () => {
+      let called = false
+      const cct = EVMTokenManager.fromChain(
+        stubChain({
+          getTokenAdminRegistryFor: () => {
+            called = true
+            return Promise.resolve(TAR)
+          },
+        }),
+      )
+      await assert.rejects(
+        () => cct.getSupportedTokens({ address: 'not-an-address' }),
+        (err: unknown) =>
+          err instanceof CCTParamsInvalidError &&
+          err.context.operation === 'getSupportedTokens' &&
+          err.context.param === 'address',
+      )
+      assert.equal(called, false, 'validation fails before TAR discovery')
+    })
+  })
 })

--- a/ccip-sdk/src/cct/evm/index.ts
+++ b/ccip-sdk/src/cct/evm/index.ts
@@ -26,6 +26,10 @@ import {
   AcceptAdmin,
 } from './token-admin-registry/operations/accept-admin.ts'
 import {
+  type GetSupportedTokensParams,
+  GetSupportedTokens,
+} from './token-admin-registry/operations/get-supported-tokens.ts'
+import {
   type GetTokenAdminRegistryParams,
   type GetTokenAdminRegistryResult,
   GetTokenAdminRegistry,
@@ -65,6 +69,7 @@ export class EVMTokenManager extends TokenManager<typeof ChainFamily.EVM> {
   readonly #transferAdmin = new TransferAdmin()
   readonly #acceptAdmin = new AcceptAdmin()
   readonly #getTokenAdminRegistry = new GetTokenAdminRegistry()
+  readonly #getSupportedTokens = new GetSupportedTokens()
 
   // Token pool operations
   readonly #deployTokenPool = new DeployTokenPool()
@@ -323,6 +328,21 @@ export class EVMTokenManager extends TokenManager<typeof ChainFamily.EVM> {
   }
 
   /**
+   * Lists every token configured in the TokenAdminRegistry resolved from `address`.
+   * @remarks The registry paginates via `getAllConfiguredTokens` — `opts.page` sets the batch size per call; omit it to read the
+   * whole registry in one round trip per 1000 tokens.
+   * @throws {@link CCTParamsInvalidError} if `address` is not a valid address, or `page` is given
+   * and is not a positive integer
+   * @example
+   * ```typescript
+   * const tokens = await cct.getSupportedTokens({ address: '0xTokenAdminRegistry...' })
+   * ```
+   */
+  getSupportedTokens(opts: GetSupportedTokensParams): Promise<string[]> {
+    return this.#getSupportedTokens.query(this.chain, opts)
+  }
+
+  /**
    * Builds an unsigned pool `transferOwnership` tx (for multisig / offline signing). Probes the
    * pool's on-chain `typeAndVersion` to resolve its interface + encoder; the `transferOwnership`
    * calldata is stable across pool versions, so the resolved encoding is version/type-independent.
@@ -578,6 +598,7 @@ export type {
 } from './token-admin-registry/operations/get-token-admin-registry.ts'
 export type { SetPoolParams } from './token-admin-registry/operations/set-pool.ts'
 export type { TransferAdminParams } from './token-admin-registry/operations/transfer-admin.ts'
+export type { GetSupportedTokensParams } from './token-admin-registry/operations/get-supported-tokens.ts'
 export type { DeployTokenParams } from './token/operations/deploy-token.ts'
 export type {
   DeployTokenPoolParams,

--- a/ccip-sdk/src/cct/evm/index.ts
+++ b/ccip-sdk/src/cct/evm/index.ts
@@ -27,6 +27,7 @@ import {
 } from './token-admin-registry/operations/accept-admin.ts'
 import {
   type GetSupportedTokensParams,
+  type GetSupportedTokensResult,
   GetSupportedTokens,
 } from './token-admin-registry/operations/get-supported-tokens.ts'
 import {
@@ -598,7 +599,10 @@ export type {
 } from './token-admin-registry/operations/get-token-admin-registry.ts'
 export type { SetPoolParams } from './token-admin-registry/operations/set-pool.ts'
 export type { TransferAdminParams } from './token-admin-registry/operations/transfer-admin.ts'
-export type { GetSupportedTokensParams } from './token-admin-registry/operations/get-supported-tokens.ts'
+export type {
+  GetSupportedTokensParams,
+  GetSupportedTokensResult,
+} from './token-admin-registry/operations/get-supported-tokens.ts'
 export type { DeployTokenParams } from './token/operations/deploy-token.ts'
 export type {
   DeployTokenPoolParams,

--- a/ccip-sdk/src/cct/evm/index.ts
+++ b/ccip-sdk/src/cct/evm/index.ts
@@ -339,7 +339,7 @@ export class EVMTokenManager extends TokenManager<typeof ChainFamily.EVM> {
    * const tokens = await cct.getSupportedTokens({ address: '0xTokenAdminRegistry...' })
    * ```
    */
-  getSupportedTokens(opts: GetSupportedTokensParams): Promise<string[]> {
+  getSupportedTokens(opts: GetSupportedTokensParams): Promise<GetSupportedTokensResult> {
     return this.#getSupportedTokens.query(this.chain, opts)
   }
 

--- a/ccip-sdk/src/cct/evm/token-admin-registry/operations/get-supported-tokens.test.ts
+++ b/ccip-sdk/src/cct/evm/token-admin-registry/operations/get-supported-tokens.test.ts
@@ -1,0 +1,126 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import { GetSupportedTokens } from './get-supported-tokens.ts'
+import { interfaces } from '../../../../evm/const.ts'
+import { EVMChain } from '../../../../evm/index.ts'
+import { CCTParamsInvalidError } from '../../../errors.ts'
+
+const OFF_RAMP = '0x' + '11'.repeat(20)
+const TAR = '0x' + '22'.repeat(20)
+const TOKENS = ['0x' + '33'.repeat(20), '0x' + '44'.repeat(20)]
+
+describe('GetSupportedTokens (cct/evm)', () => {
+  describe('query', () => {
+    it('resolves the TAR and lists its configured tokens', async () => {
+      let resolvedAddress: string | undefined
+      let seenOpts: { page?: number } | undefined
+      const chain = {
+        getTokenAdminRegistryFor: async (address: string) => {
+          resolvedAddress = address
+          return TAR
+        },
+        getSupportedTokens: async (registry: string, opts?: { page?: number }) => {
+          assert.equal(registry, TAR)
+          seenOpts = opts
+          return TOKENS
+        },
+      } as unknown as EVMChain
+
+      const result = await new GetSupportedTokens().query(chain, { address: OFF_RAMP })
+      assert.deepEqual(result, TOKENS)
+      assert.equal(resolvedAddress, OFF_RAMP)
+      assert.deepEqual(seenOpts, { page: undefined })
+    })
+
+    it('forwards `page` to chain.getSupportedTokens, which owns the pagination loop', async () => {
+      let seenPage: number | undefined
+      const chain = {
+        getTokenAdminRegistryFor: async () => TAR,
+        getSupportedTokens: async (_registry: string, opts?: { page?: number }) => {
+          seenPage = opts?.page
+          return TOKENS
+        },
+      } as unknown as EVMChain
+
+      await new GetSupportedTokens().query(chain, { address: OFF_RAMP, page: 50 })
+      assert.equal(seenPage, 50)
+    })
+
+    it('paginates `getAllConfiguredTokens` through the real EVMChain.getSupportedTokens loop', async () => {
+      // The two tests above stub `chain.getSupportedTokens` wholesale, so they only pin that this
+      // op forwards `page` — they cannot catch a startIndex/maxCount swap or a dropped final page
+      // in the loop itself. This test runs the *real* `EVMChain.prototype.getSupportedTokens`
+      // (bound to a stub with just `provider.call`) against three tokens with `page: 2`, so a full
+      // first page (0,2) must be followed by a short second page (2,2) that ends the scan.
+      const allTokens = [...TOKENS, '0x' + '55'.repeat(20)]
+      const seenCalls: Array<{ startIndex: bigint; maxCount: bigint }> = []
+      const chain = {
+        getTokenAdminRegistryFor: async () => TAR,
+        provider: {
+          call: async ({ data }: { data: string }) => {
+            const [startIndex, maxCount] = interfaces.TokenAdminRegistry.decodeFunctionData(
+              'getAllConfiguredTokens',
+              data,
+            ) as unknown as [bigint, bigint]
+            seenCalls.push({ startIndex, maxCount })
+            const page = allTokens.slice(Number(startIndex), Number(startIndex + maxCount))
+            return interfaces.TokenAdminRegistry.encodeFunctionResult('getAllConfiguredTokens', [
+              page,
+            ])
+          },
+        },
+      } as unknown as EVMChain
+      chain.getSupportedTokens = EVMChain.prototype.getSupportedTokens.bind(chain)
+
+      const result = await new GetSupportedTokens().query(chain, { address: OFF_RAMP, page: 2 })
+
+      assert.deepEqual(result, allTokens, 'pages are concatenated in order')
+      assert.deepEqual(
+        seenCalls,
+        [
+          { startIndex: 0n, maxCount: 2n },
+          { startIndex: 2n, maxCount: 2n },
+        ],
+        'startIndex advances by the previous page length and maxCount stays pinned to `page`',
+      )
+    })
+  })
+
+  describe('validation', () => {
+    it('rejects an invalid address before any RPC', async () => {
+      let called = false
+      const chain = {
+        getTokenAdminRegistryFor: async () => {
+          called = true
+          return TAR
+        },
+      } as unknown as EVMChain
+
+      await assert.rejects(
+        () => new GetSupportedTokens().query(chain, { address: 'not-an-address' }),
+        (error: unknown) =>
+          error instanceof CCTParamsInvalidError &&
+          error.context.operation === 'getSupportedTokens' &&
+          error.context.param === 'address',
+      )
+      assert.equal(called, false, 'validation fails before TAR discovery')
+    })
+
+    it('rejects a non-positive `page`', async () => {
+      await assert.rejects(
+        () => new GetSupportedTokens().query({} as EVMChain, { address: OFF_RAMP, page: 0 }),
+        (error: unknown) =>
+          error instanceof CCTParamsInvalidError && error.context.param === 'page',
+      )
+    })
+
+    it('rejects a non-integer `page`', async () => {
+      await assert.rejects(
+        () => new GetSupportedTokens().query({} as EVMChain, { address: OFF_RAMP, page: 1.5 }),
+        (error: unknown) =>
+          error instanceof CCTParamsInvalidError && error.context.param === 'page',
+      )
+    })
+  })
+})

--- a/ccip-sdk/src/cct/evm/token-admin-registry/operations/get-supported-tokens.ts
+++ b/ccip-sdk/src/cct/evm/token-admin-registry/operations/get-supported-tokens.ts
@@ -1,0 +1,65 @@
+/**
+ * getSupportedTokens — lists the ERC-20 tokens configured in a TokenAdminRegistry. Version-independent
+ * (`getAllConfiguredTokens` is byte-identical from v1.5.0 through latest).
+ *
+ * @packageDocumentation
+ */
+
+import type { EVMChain } from '../../../../evm/index.ts'
+import { CCTParamsInvalidError } from '../../../errors.ts'
+import { EVMQuery } from '../../query.ts'
+import { validateAddress } from '../../validate.ts'
+
+/** Parameters for {@link GetSupportedTokens}. */
+export type GetSupportedTokensParams = {
+  /**
+   * Contract to resolve the TokenAdminRegistry from. Pass the registry itself for a
+   * direct lookup; a Router, OnRamp, OffRamp, or TokenPool also work but add hops and
+   * need a configured lane.
+   */
+  address: string
+  /**
+   * Batch size `chain.getSupportedTokens` requests per `getAllConfiguredTokens` call while it
+   * paginates. Optional — a very large registry may need a smaller batch to stay under an RPC's
+   * response-size limit.
+   */
+  page?: number
+}
+
+/**
+ * Lists every token configured in the TokenAdminRegistry resolved from `address`, paginating
+ * through `getAllConfiguredTokens` until exhausted.
+ */
+export class GetSupportedTokens extends EVMQuery<GetSupportedTokensParams, string[]> {
+  readonly name = 'getSupportedTokens'
+
+  /**
+   * Validates the resolution address and, when given, `page`; nothing to convert for {@link read}.
+   * @throws {@link CCTParamsInvalidError} if `address` is not a valid address, or `page` is given
+   * and is not a positive integer
+   */
+  protected prepare(params: GetSupportedTokensParams): GetSupportedTokensParams {
+    validateAddress(this.name, 'address', params.address)
+    if (params.page !== undefined && !(Number.isInteger(params.page) && params.page > 0))
+      throw new CCTParamsInvalidError(
+        this.name,
+        'page',
+        `must be a positive integer, got ${String(params.page)}`,
+      )
+    return params
+  }
+
+  /**
+   * Resolves the TAR and lists its configured tokens.
+   * @remarks Delegates pagination to {@link EVMChain.getSupportedTokens}, which already loops
+   * `getAllConfiguredTokens(startIndex, maxCount)` until a short page ends the scan — this op does
+   * not reimplement that loop.
+   */
+  protected async read(
+    chain: EVMChain,
+    { address, page }: GetSupportedTokensParams,
+  ): Promise<string[]> {
+    const registry = await chain.getTokenAdminRegistryFor(address)
+    return chain.getSupportedTokens(registry, { page })
+  }
+}

--- a/ccip-sdk/src/cct/evm/token-admin-registry/operations/get-supported-tokens.ts
+++ b/ccip-sdk/src/cct/evm/token-admin-registry/operations/get-supported-tokens.ts
@@ -20,11 +20,14 @@ export type GetSupportedTokensParams = {
   address: string
   /**
    * Batch size `chain.getSupportedTokens` requests per `getAllConfiguredTokens` call while it
-   * paginates. Optional — a very large registry may need a smaller batch to stay under an RPC's
-   * response-size limit.
+   * paginates. Defaults to 1000. Optional — a very large registry may need a smaller batch to
+   * stay under an RPC's response-size limit.
    */
   page?: number
 }
+
+/** Result of {@link GetSupportedTokens}: array of token addresses. */
+export type GetSupportedTokensResult = string[]
 
 /**
  * Lists every token configured in the TokenAdminRegistry resolved from `address`, paginating


### PR DESCRIPTION
## What

- Add `getSupportedTokens` to EVMTokenManager. Lists every token configured in the TokenAdminRegistry, paging through getAllConfiguredTokens internally (read-only, takes an optional page to set the batch size per call)

## Why

- Completes the read side of the registry work. Answers "which tokens are configured here" without the caller having to
  page manually

## Testing

-  Unit tests cover the lookup and checks