### PR TITLE
Ton, Sui<->Solana, Solana v2 fixes

### DIFF
--- a/ccip-sdk/src/aptos/index.ts
+++ b/ccip-sdk/src/aptos/index.ts
@@ -47,6 +47,7 @@ import {
   type EVMExtraArgsV2,
   type ExtraArgs,
   type SVMExtraArgsV1,
+  type SuiExtraArgsV1,
   EVMExtraArgsV2Tag,
   SVMExtraArgsV1Tag,
 } from '../extra-args.ts'
@@ -530,6 +531,7 @@ export class AptosChain extends Chain<typeof ChainFamily.Aptos> {
   ):
     | (EVMExtraArgsV2 & { _tag: 'EVMExtraArgsV2' })
     | (SVMExtraArgsV1 & { _tag: 'SVMExtraArgsV1' })
+    | (SuiExtraArgsV1 & { _tag: 'SuiExtraArgsV1' })
     | undefined {
     return decodeMoveExtraArgs(extraArgs)
   }

--- a/ccip-sdk/src/execution.ts
+++ b/ccip-sdk/src/execution.ts
@@ -167,7 +167,15 @@ export const discoverOffRamp = memoize(
         )
         continue
       }
-      for (const destOnRamp of destOnRamps) {
+      for (let destOnRamp of destOnRamps) {
+        // The source chain's offramp config stores onRamp addresses in the
+        // source chain's format (e.g. raw Sui package ID without `::onramp`).
+        // Normalize to the dest chain's format before using it there.
+        try {
+          destOnRamp = decodeOnRampAddress(destOnRamp, dest.network.family)
+        } catch {
+          // keep as-is if normalization fails
+        }
         let destOffRamps
         try {
           const destRouter = await dest.getRouterForOnRamp(destOnRamp, source.network.chainSelector)
@@ -229,6 +237,17 @@ export const discoverOffRamp = memoize(
                 )
                 if (offRampsOnRamp === onRamp) {
                   return offRamp
+                }
+                // Normalize both sides: the source onRamp was normalized with
+                // decodeOnRampAddress (adds `::onramp` for Sui/Aptos), but the
+                // offRamp's registered onRamp may be the raw package address
+                // without the module suffix. Compare normalized forms.
+                try {
+                  if (decodeOnRampAddress(offRampsOnRamp, source.network.family) === onRamp) {
+                    return offRamp
+                  }
+                } catch {
+                  // decodeOnRampAddress may throw on invalid address; skip
                 }
               }
             }

--- a/ccip-sdk/src/shared/bcs-codecs.ts
+++ b/ccip-sdk/src/shared/bcs-codecs.ts
@@ -19,12 +19,15 @@ import {
 import { CCIPDataFormatUnsupportedError } from '../errors/index.ts'
 import {
   type EVMExtraArgsV2,
+  type ExtraArgs,
   type SVMExtraArgsV1,
+  type SuiExtraArgsV1,
   EVMExtraArgsV2Tag,
   SVMExtraArgsV1Tag,
+  SuiExtraArgsV1Tag,
 } from '../extra-args.ts'
 import { ChainFamily } from '../networks.ts'
-import { decodeAddress, getDataBytes } from '../utils.ts'
+import { decodeAddress, getAddressBytes, getDataBytes, toLeArray } from '../utils.ts'
 
 /**
  * BCS codec for decoding EVM extra args on Move chains (Aptos/Sui).
@@ -48,8 +51,52 @@ export const BcsSVMExtraArgsV1Codec = bcs.struct('SVMExtraArgsV1', {
 })
 
 /**
+ * BCS codec for decoding Sui extra args on Sui.
+ * Used for Sui → Sui messages.
+ */
+export const BcsSuiExtraArgsV1Codec = bcs.struct('SuiExtraArgsV1', {
+  gasLimit: bcs.u64(),
+  allowOutOfOrderExecution: bcs.bool(),
+  tokenReceiver: bcs.vector(bcs.u8()),
+  receiverObjectIds: bcs.vector(bcs.vector(bcs.u8())),
+})
+
+/**
+ * Decodes BCS-encoded `SVMExtraArgsV1` (from Move-based sources: Sui/Aptos).
+ * Used by `SolanaChain.decodeExtraArgs` when receiving messages from Sui/Aptos.
+ * @param data - Full extraArgs bytes including the 4-byte tag.
+ * @returns Decoded SVMExtraArgsV1 with `_tag`, or `undefined` if parsing fails.
+ */
+export function decodeBcsSVMExtraArgsV1(
+  data: Uint8Array,
+): (SVMExtraArgsV1 & { _tag: 'SVMExtraArgsV1' }) | undefined {
+  try {
+    const parsed = BcsSVMExtraArgsV1Codec.parse(getBytes(dataSlice(data, 4)))
+    return {
+      _tag: 'SVMExtraArgsV1',
+      ...parsed,
+      computeUnits: BigInt(parsed.computeUnits),
+      accountIsWritableBitmap: BigInt(parsed.accountIsWritableBitmap),
+      tokenReceiver: decodeAddress(new Uint8Array(parsed.tokenReceiver), ChainFamily.Solana),
+      accounts: parsed.accounts.map((account) =>
+        decodeAddress(new Uint8Array(account), ChainFamily.Solana),
+      ),
+    }
+  } catch {
+    return undefined
+  }
+}
+
+/**
  * Decodes extra arguments from Move-based chain CCIP messages.
  * Works for both Aptos and Sui since they share the same BCS encoding.
+ *
+ * Also handles Borsh-encoded `GenericExtraArgsV2` from Solana sources, which
+ * shares the same tag (`0x181dcf10`) but uses a different binary layout:
+ * Borsh serializes `gasLimit` as a 16-byte LE `u128` (21 bytes total), while
+ * BCS serializes it as a 32-byte LE `u256` (37 bytes total). The length check
+ * distinguishes the two formats.
+ *
  * @param extraArgs - Encoded extra arguments bytes.
  * @returns Decoded extra arguments or undefined if unknown format.
  */
@@ -58,31 +105,68 @@ export function decodeMoveExtraArgs(
 ):
   | (EVMExtraArgsV2 & { _tag: 'EVMExtraArgsV2' })
   | (SVMExtraArgsV1 & { _tag: 'SVMExtraArgsV1' })
+  | (SuiExtraArgsV1 & { _tag: 'SuiExtraArgsV1' })
   | undefined {
   const data = getDataBytes(extraArgs),
     tag = dataSlice(data, 0, 4)
   switch (tag) {
     case EVMExtraArgsV2Tag: {
-      const parsed = BcsEVMExtraArgsV2Codec.parse(getBytes(dataSlice(data, 4)))
-      // Move serialization of EVMExtraArgsV2: 37 bytes total: 4 tag + 32 LE gasLimit + 1 allowOOOE
-      return {
-        _tag: 'EVMExtraArgsV2',
-        ...parsed,
-        gasLimit: BigInt(parsed.gasLimit),
+      const payload = getBytes(dataSlice(data, 4))
+      // BCS-encoded GenericExtraArgsV2 from Move (Aptos/Sui) source.
+      // BCS payload: 32-byte u256 gasLimit + 1-byte bool = 33 bytes.
+      // EVM ABI-encoded EVMExtraArgsV2 has a different payload length (64 bytes);
+      // return undefined so the EVM decoder can handle it.
+      // Borsh-encoded (Solana source, 17 bytes) is handled by SolanaChain.
+      if (payload.length !== 33) return undefined
+      try {
+        const parsed = BcsEVMExtraArgsV2Codec.parse(payload)
+        return {
+          _tag: 'EVMExtraArgsV2',
+          ...parsed,
+          gasLimit: BigInt(parsed.gasLimit),
+        }
+      } catch {
+        return undefined
       }
     }
     case SVMExtraArgsV1Tag: {
-      const parsed = BcsSVMExtraArgsV1Codec.parse(getBytes(dataSlice(data, 4)))
-      // Move serialization of SVMExtraArgsV1: 13 bytes total: 4 tag + 8 LE computeUnits
-      return {
-        _tag: 'SVMExtraArgsV1',
-        ...parsed,
-        computeUnits: BigInt(parsed.computeUnits),
-        accountIsWritableBitmap: BigInt(parsed.accountIsWritableBitmap),
-        tokenReceiver: decodeAddress(new Uint8Array(parsed.tokenReceiver), ChainFamily.Solana),
-        accounts: parsed.accounts.map((account) =>
-          decodeAddress(new Uint8Array(account), ChainFamily.Solana),
-        ),
+      try {
+        const parsed = BcsSVMExtraArgsV1Codec.parse(getBytes(dataSlice(data, 4)))
+        return {
+          _tag: 'SVMExtraArgsV1',
+          ...parsed,
+          computeUnits: BigInt(parsed.computeUnits),
+          accountIsWritableBitmap: BigInt(parsed.accountIsWritableBitmap),
+          tokenReceiver: decodeAddress(new Uint8Array(parsed.tokenReceiver), ChainFamily.Solana),
+          accounts: parsed.accounts.map((account) =>
+            decodeAddress(new Uint8Array(account), ChainFamily.Solana),
+          ),
+        }
+      } catch {
+        return undefined
+      }
+    }
+    case SuiExtraArgsV1Tag: {
+      // BCS-encoded SuiExtraArgsV1 from Move (Sui) source.
+      // EVM ABI-encoded SuiExtraArgsV1 also shares this tag but has a much
+      // larger payload (≥128 bytes: 4×32-byte ABI words minimum). BCS
+      // SuiExtraArgsV1 with empty receiverObjectIds is 49 bytes (8+1+4+32+4).
+      // Reject payloads that are clearly ABI-sized so the EVM decoder handles them.
+      const suiPayload = getBytes(dataSlice(data, 4))
+      if (suiPayload.length >= 128) return undefined
+      try {
+        const parsed = BcsSuiExtraArgsV1Codec.parse(suiPayload)
+        return {
+          _tag: 'SuiExtraArgsV1',
+          gasLimit: BigInt(parsed.gasLimit),
+          allowOutOfOrderExecution: parsed.allowOutOfOrderExecution,
+          tokenReceiver: getMoveAddress(new Uint8Array(parsed.tokenReceiver)),
+          receiverObjectIds: parsed.receiverObjectIds.map((id) =>
+            getMoveAddress(new Uint8Array(id)),
+          ),
+        }
+      } catch {
+        return undefined
       }
     }
   }
@@ -130,3 +214,64 @@ export const encodeRawBytes = (value: BytesLike): string =>
     encodeNumber(dataLength(value)),
     zeroPadBytes(value, Math.ceil(dataLength(value) / 32) * 32),
   ])
+
+// ─── BCS encoding for Move-source extraArgs ───────────────────────────────────
+
+/**
+ * Encodes `GenericExtraArgsV2` (EVMExtraArgsV2) in BCS format for Move sources.
+ * Layout: 4-byte tag + BCS `{gasLimit: u256, allowOutOfOrderExecution: bool}`.
+ * Used by Sui/Aptos onRamps for EVM destinations.
+ */
+export function encodeBcsGenericExtraArgsV2(args: EVMExtraArgsV2): string {
+  const gasLimitLe = toLeArray(BigInt(args.gasLimit), 32)
+  const allowOOOE = args.allowOutOfOrderExecution ? '0x01' : '0x00'
+  return concat([EVMExtraArgsV2Tag, hexlify(gasLimitLe), allowOOOE])
+}
+
+/**
+ * Encodes `SVMExtraArgsV1` in BCS format for Move sources.
+ * Layout: 4-byte tag + BCS `{computeUnits: u32, accountIsWritableBitmap: u64, allowOutOfOrderExecution: bool, tokenReceiver: vector<u8>, accounts: vector<vector<u8>>}`.
+ * Used by Sui/Aptos onRamps for Solana destinations.
+ */
+export function encodeBcsSVMExtraArgsV1(args: SVMExtraArgsV1): string {
+  const tokenReceiverBytes = getAddressBytes(args.tokenReceiver)
+  const accountBytes = args.accounts.map((acc) => getAddressBytes(acc))
+  const encoded = BcsSVMExtraArgsV1Codec.serialize({
+    computeUnits: Number(args.computeUnits),
+    accountIsWritableBitmap: args.accountIsWritableBitmap,
+    allowOutOfOrderExecution: args.allowOutOfOrderExecution,
+    tokenReceiver: Array.from(tokenReceiverBytes),
+    accounts: accountBytes.map((b) => Array.from(b)),
+  })
+  return concat([SVMExtraArgsV1Tag, hexlify(encoded.toBytes())])
+}
+
+/**
+ * Encodes `SuiExtraArgsV1` in BCS format for Move sources.
+ * Layout: 4-byte tag + BCS `{gasLimit: u64, allowOutOfOrderExecution: bool, tokenReceiver: vector<u8>, receiverObjectIds: vector<vector<u8>>}`.
+ * Used by Sui onRamps for Sui destinations.
+ */
+export function encodeBcsSuiExtraArgsV1(args: SuiExtraArgsV1): string {
+  const tokenReceiverBytes = getAddressBytes(args.tokenReceiver)
+  const receiverObjectIdsBytes = args.receiverObjectIds.map((id) => getAddressBytes(id))
+  const encoded = BcsSuiExtraArgsV1Codec.serialize({
+    gasLimit: args.gasLimit,
+    allowOutOfOrderExecution: args.allowOutOfOrderExecution,
+    tokenReceiver: Array.from(tokenReceiverBytes),
+    receiverObjectIds: receiverObjectIdsBytes.map((b) => Array.from(b)),
+  })
+  return concat([SuiExtraArgsV1Tag, hexlify(encoded.toBytes())])
+}
+
+/**
+ * Encodes extra arguments in BCS format for Move-based source chains (Sui/Aptos).
+ * Dispatches to the correct encoder based on the extraArgs fields.
+ * @param args - Extra arguments to encode.
+ * @returns Encoded extra arguments as hex string.
+ */
+export function encodeMoveExtraArgs(args: ExtraArgs): string {
+  if ('computeUnits' in args) return encodeBcsSVMExtraArgsV1(args)
+  if ('receiverObjectIds' in args) return encodeBcsSuiExtraArgsV1(args)
+  // Default: GenericExtraArgsV2 (EVMExtraArgsV2)
+  return encodeBcsGenericExtraArgsV2(args as EVMExtraArgsV2)
+}

--- a/ccip-sdk/src/solana/__tests__/index.test.ts
+++ b/ccip-sdk/src/solana/__tests__/index.test.ts
@@ -527,7 +527,8 @@ describe('SolanaChain.encodeExtraArgs', () => {
     const encoded = SolanaChain.encodeExtraArgs(args)
     const decoded = SolanaChain.decodeExtraArgs(encoded)
 
-    assert.equal(decoded?.gasLimit, 1n)
+    assert.equal(decoded?._tag, 'EVMExtraArgsV2')
+    assert.equal(decoded.gasLimit, 1n)
   })
 
   it('should encode empty args object by using defaults', () => {
@@ -540,6 +541,7 @@ describe('SolanaChain.encodeExtraArgs', () => {
     const decoded = SolanaChain.decodeExtraArgs(encoded)
 
     assert.ok(decoded)
+    assert.equal(decoded._tag, 'EVMExtraArgsV2')
     assert.equal(decoded.gasLimit, 200000n)
   })
 
@@ -586,6 +588,7 @@ describe('SolanaChain.encodeExtraArgs', () => {
     // Verify it can be decoded
     const decoded = SolanaChain.decodeExtraArgs(encoded)
     assert.ok(decoded)
+    assert.equal(decoded._tag, 'EVMExtraArgsV2')
     assert.equal(decoded.gasLimit, gasLimit)
     assert.equal(decoded.allowOutOfOrderExecution, allowOutOfOrder)
   })

--- a/ccip-sdk/src/solana/__tests__/integration.test.ts
+++ b/ccip-sdk/src/solana/__tests__/integration.test.ts
@@ -25,13 +25,13 @@ const SOLANA_DEVNET_RPC =
   process.env.SOLANA_RPC ?? process.env.RPC_SOLANA ?? 'https://devnet.rpcpool.com'
 const SOLANA_OFFRAMP = 'offqSMQWgQud6WJz694LRzkeN5kMYpCHTpXQr3Rkcjm'
 const SOLANA_V2_SEND_TX =
-  '5fLVsRpENWE5qmqhAdY8g88K26C9DZ7qiKRMhZiBxSuZSKyGBJj2EyqUF1b1DaPNPZbLxfP3ufFCYFK7EVcU1Hz'
+  '5RrQuDzcwPdVTKTTLVNhz31V5XzNLRZdxaGzLQddqePsu4TYycS6BMKP8V2WtuQ2VS9GdWTZfGt4WjnzKMBZFdM5'
 const EVM_TO_SOLANA_V2_TX = '0x8be479716729ff555e5ee7a1826af3bf571be820ab3080348f83b28a753cc472'
 const SOLANA_V2_EXEC_TX =
   '32Zj32Px5cxq7HSsLtCKEoecRbEoziWRjSxgBnABmmqLc4MLtQfD6csfFEEf2CKmLymTVmqNSSo51gBEHiXBS5E'
 const SOLANA_V2_OFFRAMP = 'offEFR9DhTdnPR43oBmnGJmoj13Y3n7sR93Vbph77TK'
 const SOLANA_V2_SEND_MESSAGE_ID =
-  '0x3067b270c81cd21f1b37150dd75f0af46ead2eaff405b390cd70e5df7d27e8b1'
+  '0x706918e7a9b62d8592733f7f790c520285661a7ddd0fbeaa6301660c8d32a722'
 const EVM_TO_SOLANA_V2_MESSAGE_ID =
   '0xaef01a07586289eaf1cc1e65d0281c20966c799a5be0d816295907abb2367826'
 
@@ -278,10 +278,13 @@ describe('Solana Devnet CCIP v2 Integration', { skip, timeout: 300_000 }, () => 
   it('should synthesize and decode CCIPMessageSentV2 from Anchor CPI event data', async () => {
     const tx = await solanaChain.getTransaction(SOLANA_V2_SEND_TX)
 
+    // Post-redeploy ccip-router 2.0.0-dev no longer logs a human-readable "Emitting CCIPMessageSentV2"
+    // line; the router's top-level entry log ("Instruction: CcipSendV2") is the human-readable
+    // marker that the SDK preserves at level 1.
     const humanLog = tx.logs.find(
-      (log) => typeof log.data === 'string' && log.data.includes('Emitting CCIPMessageSentV2'),
+      (log) => typeof log.data === 'string' && log.data.includes('Instruction: CcipSendV2'),
     )
-    assert.ok(humanLog, 'should preserve human-readable event log')
+    assert.ok(humanLog, 'should preserve human-readable router entry log')
     assert.equal(humanLog.type, 'log')
     assert.equal(humanLog.level, 1)
 
@@ -289,17 +292,17 @@ describe('Solana Devnet CCIP v2 Integration', { skip, timeout: 300_000 }, () => 
     assert.ok(eventLog, 'should synthesize data log from emit_cpi inner instruction')
     assert.equal(eventLog.type, 'data')
     assert.equal(eventLog.level, 2)
-    assert.equal(eventLog.index, 14)
+    assert.equal(eventLog.index, 37)
 
     const requests = await solanaChain.getMessagesInTx(tx)
     assert.equal(requests.length, 1)
     const request = requests[0]!
     assert.equal(request.message.messageId, SOLANA_V2_SEND_MESSAGE_ID)
-    assert.equal(request.message.sequenceNumber, 115n)
+    assert.equal(request.message.sequenceNumber, 4348n)
     assert.equal(request.message.sender, 'GVuEzxzvpVQr9RTwNguw4AcZSZmGiP9EWaRPkp8x6Xrx')
     assert.equal(request.message.receiver, '0x3aa5EbB10dC797Cac828524e59A333d0A371443d')
-    assert.equal(request.message.data, '0xdc1592f138fb77ec')
-    assert.equal(request.lane.onRamp, 'CcipE4LLPo7F6aVFgyvhVQi5DrKUhtgimsDwknaeLVDT')
+    assert.equal(request.message.data, '0xeac2e11afaf847db')
+    assert.equal(request.lane.onRamp, 'CcipP6NhMw34e7hNJXmNytvzmSYrwQ1TcFgfQAxJhNqm')
     assert.equal(request.lane.version, '2.0.0')
   })
 

--- a/ccip-sdk/src/solana/decodeMessage.test.ts
+++ b/ccip-sdk/src/solana/decodeMessage.test.ts
@@ -69,9 +69,10 @@ describe('SolanaChain.decodeMessage', () => {
   })
 
   it('should correctly decode CCIPMessageSentV2 event from Anchor emit_cpi log', () => {
-    // Solana devnet tx 5fLVsRpENWE5qmqhAdY8g88K26C9DZ7qiKRMhZiBxSuZSKyGBJj2EyqUF1b1DaPNPZbLxfP3ufFCYFK7EVcU1Hz
+    // Solana devnet tx 5RrQuDzcwPdVTKTTLVNhz31V5XzNLRZdxaGzLQddqePsu4TYycS6BMKP8V2WtuQ2VS9GdWTZfGt4WjnzKMBZFdM5
+    // (post-redeploy ccip-router 2.0.0-dev; Receipt layout = issuer/destGasLimit/destBytesOverhead/feeTokenAmount u64/extraArgs)
     const eventData =
-      'cCBd+B1cY7zZGtnJT7pB3uZGotRqLm/c9xg6PJjoT9mpXSrryUabGzrEiqt+4olhMGeycMgc0h8bNxUN118K9G6tLq/0BbOQzXDl330n6LEGm4hX/quBhPtof2NGGMA12sQ53BrrO1WYoPAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAvwAAAAHj7MfilOM3395Buk/J2RrZAAAAAAAAAHMAAw1AAAMNQAAAAAE7Ip8dm6pP5VWV4qg3Vq/oZR7HQXfcc1A2/Z9AGHO78yCslyn8KiIBZmHvz1BxsB5wpU/64/gE/oBCKg1cS4mTahTrpdeUWUhOVDvRVgemIezimynKmSDmRqLUai5v3PcYOjyY6E/ZqV0q68lGmxs6xIqrfuKJYRQ6peuxDceXysgoUk5ZozPQo3FEPQAAAAAACNwVkvE4+3fsAwAAAKqlPRgFCiGIwesKlHnQJT0Y/VrpdrPglfSNUVoRtM+4QA0DAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAz2kwNcN2B3jaUdwjudF2za6/qwnfyFcED6Twh69td14AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAACslyn8KiIBZmHvz1BxsB5wpU/64/gE/oBCKg1cS4mTagAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAEAAAAEAAAA6aBaIA=='
+      'cCBd+B1cY7zZGtnJT7pB3uZGotRqLm/c9xg6PJjoT9mpXSrryUabGzrEiqt+4olhcGkY56m2LYWScz9/eQxSAoVmGn3dD76qYwFmDI0ypyIGm4hX/quBhPtof2NGGMA12sQ53BrrO1WYoPAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAvwAAAAHj7MfilOM3395Buk/J2RrZAAAAAAAAEPwABqx4AAMNQAAAAAElSv9BQzl6WTDpPL90+mSQGyL+7o9WzlSZ6mNi5y9tXCCslyrDMMg7v+aUvMZVBAFGoXfs0FFUymjBxf/yEjwucBTrpdeUWUhOVDvRVgemIezimynKmSDmRqLUai5v3PcYOjyY6E/ZqV0q68lGmxs6xIqrfuKJYRQ6peuxDceXysgoUk5ZozPQo3FEPQAAAAAACOrC4Rr6+EfbAwAAAKqz/f8Y7X6B6P7jOtu2w5Dyzp9QA9Lt7tXp/NLDS9b8+CQBAEYCAAAAAAAAAAAAAAAAAADPabR6arpsQlBZ3Ze5iXZQu2nvnkiKNg8/zFv4fuYbhDBXBQC/AAAAagQBAAAAAAAAAAAArJcqwzDIO7/mlLzGVQQBRqF37NBRVMpowcX/8hI8LnAAAAAAAAAAACosCgAAAAAAAAAAAAEAAAAEAAAA6aBaIA=='
 
     const message = SolanaChain.decodeMessage({ data: eventData }) as CCIPMessage<
       typeof CCIPVersion.V1_6
@@ -80,17 +81,17 @@ describe('SolanaChain.decodeMessage', () => {
     assert.ok(message, 'should decode v2 event')
     assert.equal(
       message.messageId,
-      '0x3067b270c81cd21f1b37150dd75f0af46ead2eaff405b390cd70e5df7d27e8b1',
+      '0x706918e7a9b62d8592733f7f790c520285661a7ddd0fbeaa6301660c8d32a722',
     )
     assert.equal(message.sourceChainSelector, 16423721717087811551n)
     assert.equal(message.destChainSelector, 16015286601757825753n)
-    assert.equal(message.sequenceNumber, 115n)
+    assert.equal(message.sequenceNumber, 4348n)
     assert.equal(message.sender, 'GVuEzxzvpVQr9RTwNguw4AcZSZmGiP9EWaRPkp8x6Xrx')
     assert.equal(message.receiver, '0x3aa5EbB10dC797Cac828524e59A333d0A371443d')
-    assert.equal(message.data, '0xdc1592f138fb77ec')
+    assert.equal(message.data, '0xeac2e11afaf847db')
     assert.equal(message.tokenAmounts.length, 0)
     assert.equal(message.feeToken, 'So11111111111111111111111111111111111111112')
-    assert.equal(message.feeTokenAmount, 0n)
+    assert.equal(message.feeTokenAmount, 733332n)
   })
 
   it('should correctly decode ExecutionStateChangedV2 event from Solana OffRamp emit_cpi log', () => {

--- a/ccip-sdk/src/solana/extra-args.ts
+++ b/ccip-sdk/src/solana/extra-args.ts
@@ -1,9 +1,17 @@
-import { concat } from 'ethers'
+import { concat, getBytes, hexlify } from 'ethers'
 
 import { CCIPExtraArgsEncodingUnsupportedError } from '../errors/index.ts'
-import { type ExtraArgs, EVMExtraArgsV2Tag } from '../extra-args.ts'
+import {
+  type ExtraArgs,
+  type GenericExtraArgsV3,
+  type SuiExtraArgsV1,
+  EVMExtraArgsV2Tag,
+  GenericExtraArgsV3Tag,
+  SuiExtraArgsV1Tag,
+  encodeFinality,
+} from '../extra-args.ts'
 import { ChainFamily } from '../networks.ts'
-import { toLeArray } from '../utils.ts'
+import { decodeAddress, getAddressBytes, toLeArray } from '../utils.ts'
 
 /**
  * Pure Solana extra-args encoder, extracted from `SolanaChain.encodeExtraArgs`
@@ -13,15 +21,206 @@ import { toLeArray } from '../utils.ts'
  * `SolanaChain.encodeExtraArgs` remains as a thin static wrapper for the
  * `supportedChains`-based dispatch in `extra-args.ts` and for external callers.
  *
+ * Solana uses Borsh to encode extraArgs for all destination chain families.
+ * For basic types (integers, bools, vectors, fixed arrays) Borsh and BCS share
+ * the same wire format, so the on-chain Borsh serialization is byte-identical
+ * to BCS for these structs.
+ *
+ * Encodes `GenericExtraArgsV2` (EVMExtraArgsV2) in Borsh format for Solana
+ * sources targeting EVM (and other non-SVM, non-Sui) destinations.
+ *
+ * Layout: 4-byte tag + Borsh `{gasLimit: u128 LE, allowOutOfOrderExecution: bool}`.
+ *
  * @throws {@link CCIPExtraArgsEncodingUnsupportedError} if SVMExtraArgsV1 encoding is attempted
  */
 export function encodeSolanaExtraArgs(args: ExtraArgs): string {
   if ('computeUnits' in args)
     throw new CCIPExtraArgsEncodingUnsupportedError(ChainFamily.Solana, 'EVMExtraArgsV2 format')
+  if ('finality' in args) return encodeSolanaGenericExtraArgsV3(args)
+  if ('receiverObjectIds' in args) return encodeSolanaSuiExtraArgsV1(args)
   const gasLimitUint128Le = toLeArray(args.gasLimit ?? 0n, 16)
   return concat([
     EVMExtraArgsV2Tag,
     gasLimitUint128Le,
     'allowOutOfOrderExecution' in args && args.allowOutOfOrderExecution ? '0x01' : '0x00',
   ])
+}
+
+/**
+ * Encodes `SuiExtraArgsV1` in Borsh format for Solana sources targeting Sui
+ * destinations.
+ *
+ * Layout: 4-byte tag + Borsh `{gasLimit: u64 LE, allowOutOfOrderExecution: bool, tokenReceiver: [u8;32], receiverObjectIds: Vec<[u8;32]>}`.
+ *
+ * Borsh and BCS share the same wire format for these basic types, so this is
+ * byte-identical to the BCS encoding on Sui's on-chain `encode_sui_extra_args_v1`.
+ */
+export function encodeSolanaSuiExtraArgsV1(args: SuiExtraArgsV1): string {
+  const gasLimitLe = toLeArray(args.gasLimit, 8)
+  const allowOOOE = args.allowOutOfOrderExecution ? '0x01' : '0x00'
+  const tokenReceiver = getAddressBytes(args.tokenReceiver) // 32 bytes
+  const receiverObjectIdsCount = toLeArray(args.receiverObjectIds.length, 4)
+  const receiverObjectIds = args.receiverObjectIds.map((id) => getAddressBytes(id)) // each 32 bytes
+  return concat([
+    SuiExtraArgsV1Tag,
+    gasLimitLe,
+    allowOOOE,
+    tokenReceiver,
+    receiverObjectIdsCount,
+    ...receiverObjectIds,
+  ])
+}
+
+/**
+ * Encodes `GenericExtraArgsV3` in Borsh format for Solana sources targeting
+ * CCIP v2 EVM destinations.
+ *
+ * Layout: 4-byte tag + Borsh `{gas_limit: u32 LE, finality: {flags: u16 LE, block_depth: u16 LE}, ccvs: Vec<[u8;32]>, ccv_args: Vec<Vec<u8>>, executor: [u8;32], executor_args: Vec<u8>, token_receiver: Vec<u8>, token_args: Vec<u8>}`.
+ *
+ * `CrossChainGas` is a u32 newtype → serialized as 4 bytes LE.
+ * `FinalityConfig` → `{flags: u16, block_depth: u16}` (4 bytes total).
+ */
+export function encodeSolanaGenericExtraArgsV3(args: GenericExtraArgsV3): string {
+  const gasLimitLe = toLeArray(args.gasLimit, 4) // CrossChainGas = u32
+  const finalityEncoded = encodeFinality(args.finality)
+  const flagsLe = toLeArray((finalityEncoded >>> 16) & 0xffff, 2) // u16 LE
+  const blockDepthLe = toLeArray(finalityEncoded & 0xffff, 2) // u16 LE
+  // ccvs: Vec<Pubkey> — each Pubkey is [u8; 32]
+  const ccvBytes = args.ccvs.map((ccv) => getAddressBytes(ccv))
+  const ccvsCount = toLeArray(ccvBytes.length, 4)
+  // ccv_args: Vec<Vec<u8>>
+  const ccvArgsBytes = args.ccvArgs.map((a) => getBytes(a))
+  const ccvArgsCount = toLeArray(ccvArgsBytes.length, 4)
+  const ccvArgsEncoded = ccvArgsBytes.map((b) => concat([toLeArray(b.length, 4), b]))
+  // executor: Pubkey [u8; 32] — NO_EXECUTION_TAG → 32-byte zero-padded tag
+  const executorBytes = getAddressBytes(args.executor)
+  // executor_args: Vec<u8>
+  const executorArgsBytes = getBytes(args.executorArgs)
+  // token_receiver: Vec<u8>
+  const tokenReceiverBytes = getAddressBytes(args.tokenReceiver)
+  // token_args: Vec<u8>
+  const tokenArgsBytes = getBytes(args.tokenArgs)
+  return concat([
+    GenericExtraArgsV3Tag,
+    gasLimitLe,
+    flagsLe,
+    blockDepthLe,
+    ccvsCount,
+    ...ccvBytes,
+    ccvArgsCount,
+    ...ccvArgsEncoded,
+    executorBytes,
+    toLeArray(executorArgsBytes.length, 4),
+    executorArgsBytes,
+    toLeArray(tokenReceiverBytes.length, 4),
+    tokenReceiverBytes,
+    toLeArray(tokenArgsBytes.length, 4),
+    tokenArgsBytes,
+  ])
+}
+
+/**
+ * Decodes Borsh-encoded `GenericExtraArgsV3` from Solana sources targeting
+ * CCIP v2 EVM destinations.
+ *
+ * @param data - Full extraArgs bytes including the 4-byte tag.
+ * @returns Decoded GenericExtraArgsV3 with `_tag`.
+ */
+export function decodeSolanaGenericExtraArgsV3(
+  data: Uint8Array,
+): GenericExtraArgsV3 & { _tag: 'GenericExtraArgsV3' } {
+  const buf = Buffer.from(data)
+  let offset = 4 // skip 4-byte tag
+  const gasLimit = BigInt(buf.readUInt32LE(offset))
+  offset += 4
+  const flags = buf.readUInt16LE(offset)
+  offset += 2
+  const blockDepth = buf.readUInt16LE(offset)
+  offset += 2
+  const finality = (flags << 16) | blockDepth
+  // ccvs: Vec<Pubkey>
+  const ccvCount = buf.readUInt32LE(offset)
+  offset += 4
+  const ccvs: Buffer[] = []
+  for (let i = 0; i < ccvCount; i++) {
+    ccvs.push(buf.subarray(offset, offset + 32))
+    offset += 32
+  }
+  // ccv_args: Vec<Vec<u8>>
+  const ccvArgCount = buf.readUInt32LE(offset)
+  offset += 4
+  const ccvArgs: Buffer[] = []
+  for (let i = 0; i < ccvArgCount; i++) {
+    const len = buf.readUInt32LE(offset)
+    offset += 4
+    ccvArgs.push(buf.subarray(offset, offset + len))
+    offset += len
+  }
+  // executor: Pubkey [u8; 32]
+  const executor = buf.subarray(offset, offset + 32)
+  offset += 32
+  // executor_args: Vec<u8>
+  const executorArgsLen = buf.readUInt32LE(offset)
+  offset += 4
+  const executorArgs = buf.subarray(offset, offset + executorArgsLen)
+  offset += executorArgsLen
+  // token_receiver: Vec<u8>
+  const tokenReceiverLen = buf.readUInt32LE(offset)
+  offset += 4
+  const tokenReceiver = buf.subarray(offset, offset + tokenReceiverLen)
+  offset += tokenReceiverLen
+  // token_args: Vec<u8>
+  const tokenArgsLen = buf.readUInt32LE(offset)
+  offset += 4
+  const tokenArgs = buf.subarray(offset, offset + tokenArgsLen)
+  // offset += tokenArgsLen
+  return {
+    _tag: 'GenericExtraArgsV3',
+    gasLimit,
+    finality: finality === 0 ? 'finalized' : flags & 1 ? 'safe' : blockDepth,
+    ccvs: ccvs.map((ccv) => decodeAddress(ccv, ChainFamily.Solana)),
+    ccvArgs: ccvArgs.map((a) => hexlify(a)),
+    executor: decodeAddress(executor, ChainFamily.Solana),
+    executorArgs: hexlify(executorArgs),
+    tokenReceiver: hexlify(tokenReceiver),
+    tokenArgs: hexlify(tokenArgs),
+  }
+}
+
+/**
+ * Decodes Borsh-encoded `SuiExtraArgsV1` from Solana sources targeting Sui dest.
+ *
+ * Borsh layout after 4-byte tag:
+ * `gasLimit: u64 LE` + `bool` + `tokenReceiver: [u8;32]` +
+ * `receiverObjectIds: Vec<[u8;32]>` (u32 LE count + N×32 bytes).
+ *
+ * @param data - Full extraArgs bytes including the 4-byte tag.
+ * @returns Decoded SuiExtraArgsV1 with `_tag`.
+ * @throws if the data is too short or malformed.
+ */
+export function decodeSolanaSuiExtraArgsV1(
+  data: Uint8Array,
+): SuiExtraArgsV1 & { _tag: 'SuiExtraArgsV1' } {
+  const buf = Buffer.from(data)
+  let offset = 4 // skip 4-byte tag
+  const gasLimit = BigInt(buf.readUInt32LE(offset)) | (BigInt(buf.readUInt32LE(offset + 4)) << 32n)
+  offset += 8
+  const allowOutOfOrderExecution = buf[offset] === 1
+  offset += 1
+  const tokenReceiver = buf.subarray(offset, offset + 32)
+  offset += 32
+  const objectCount = buf.readUInt32LE(offset)
+  offset += 4
+  const receiverObjectIds: Buffer[] = []
+  for (let i = 0; i < objectCount; i++) {
+    receiverObjectIds.push(buf.subarray(offset, offset + 32))
+    offset += 32
+  }
+  return {
+    _tag: 'SuiExtraArgsV1',
+    gasLimit,
+    allowOutOfOrderExecution,
+    tokenReceiver: decodeAddress(tokenReceiver, ChainFamily.Sui),
+    receiverObjectIds: receiverObjectIds.map((id) => decodeAddress(id, ChainFamily.Sui)),
+  }
 }

--- a/ccip-sdk/src/solana/idl/2.0.0/CCIP_ROUTER.ts
+++ b/ccip-sdk/src/solana/idl/2.0.0/CCIP_ROUTER.ts
@@ -11,11 +11,11 @@
  * Anchor 0.29 IDL format. `UsdCents`/`CrossChainGas` are `u32` newtypes in the
  * upstream v2 IDL, inlined here as `u32` (identical borsh layout).
  *
- * NOTE: the upstream v2 IDL also has a trailing `baseExecutionGasCost` (CrossChainGas)
- * field on `DestChainConfigCcipV2`, but the currently-deployed devnet `-dev` accounts
- * don't carry it. We stop at `tokenTransferNetworkFee` so decoding matches on-chain
- * data — borsh ignores trailing bytes, so this stays forward-compatible if/when the
- * deployed accounts grow the extra field.
+ * As of the latest devnet redeploy, `DestChainConfigCcipV2` carries the full upstream
+ * layout: `addressBytesLength` (after `laneCodeVersion`) and the trailing
+ * `baseExecutionGasCost` (CrossChainGas) + `maxFeePerMessage` (UsdCents) fields.
+ * Borsh does NOT skip trailing bytes on a too-short layout (it errors on offset
+ * overflow), so the IDL must match the on-chain account exactly.
  */
 export type CcipRouterV2 = {
   version: '2.0.0'
@@ -90,17 +90,16 @@ export type CcipRouterV2 = {
     },
     {
       name: 'Receipt'
-      docs: ['CCIP 2.0 fee/gas receipt for a single entity.']
+      docs: [
+        'CCIP 2.0 fee/gas receipt for a single entity (verifier, token pool, executor, network).',
+      ]
       type: {
         kind: 'struct'
         fields: [
           { name: 'issuer'; type: 'publicKey' },
           { name: 'destGasLimit'; type: 'u32' },
           { name: 'destBytesOverhead'; type: 'u32' },
-          { name: 'feeTokenAmount'; type: { defined: 'ProtocolAmount' } },
-          { name: 'fee'; type: 'u32' },
-          { name: 'tokenFeeBps'; type: 'u16' },
-          { name: 'isEnabled'; type: 'bool' },
+          { name: 'feeTokenAmount'; type: 'u64' },
           { name: 'extraArgs'; type: 'bytes' },
         ]
       }
@@ -110,8 +109,8 @@ export type CcipRouterV2 = {
       type: {
         kind: 'struct'
         fields: [
-          { name: 'sequenceNumber'; type: 'u64' },
-          { name: 'sequenceNumberToRestore'; type: 'u64' },
+          { name: 'messageNumber'; type: 'u64' },
+          { name: 'messageNumberToRestore'; type: 'u64' },
           { name: 'restoreOnAction'; type: { defined: 'RestoreOnAction' } },
         ]
       }
@@ -122,6 +121,7 @@ export type CcipRouterV2 = {
         kind: 'struct'
         fields: [
           { name: 'laneCodeVersion'; type: { defined: 'CodeVersion' } },
+          { name: 'addressBytesLength'; type: 'u8' },
           { name: 'allowedSenders'; type: { vec: 'publicKey' } },
           { name: 'allowListEnabled'; type: 'bool' },
           { name: 'defaultCcvs'; type: { vec: 'publicKey' } },
@@ -130,6 +130,8 @@ export type CcipRouterV2 = {
           { name: 'offramp'; type: 'bytes' },
           { name: 'messageNetworkFee'; type: 'u32' },
           { name: 'tokenTransferNetworkFee'; type: 'u32' },
+          { name: 'baseExecutionGasCost'; type: 'u32' },
+          { name: 'maxFeePerMessage'; type: 'u32' },
         ]
       }
     },
@@ -217,17 +219,16 @@ export const IDL: CcipRouterV2 = {
     },
     {
       name: 'Receipt',
-      docs: ['CCIP 2.0 fee/gas receipt for a single entity.'],
+      docs: [
+        'CCIP 2.0 fee/gas receipt for a single entity (verifier, token pool, executor, network).',
+      ],
       type: {
         kind: 'struct',
         fields: [
           { name: 'issuer', type: 'publicKey' },
           { name: 'destGasLimit', type: 'u32' },
           { name: 'destBytesOverhead', type: 'u32' },
-          { name: 'feeTokenAmount', type: { defined: 'ProtocolAmount' } },
-          { name: 'fee', type: 'u32' },
-          { name: 'tokenFeeBps', type: 'u16' },
-          { name: 'isEnabled', type: 'bool' },
+          { name: 'feeTokenAmount', type: 'u64' },
           { name: 'extraArgs', type: 'bytes' },
         ],
       },
@@ -237,8 +238,8 @@ export const IDL: CcipRouterV2 = {
       type: {
         kind: 'struct',
         fields: [
-          { name: 'sequenceNumber', type: 'u64' },
-          { name: 'sequenceNumberToRestore', type: 'u64' },
+          { name: 'messageNumber', type: 'u64' },
+          { name: 'messageNumberToRestore', type: 'u64' },
           { name: 'restoreOnAction', type: { defined: 'RestoreOnAction' } },
         ],
       },
@@ -249,6 +250,7 @@ export const IDL: CcipRouterV2 = {
         kind: 'struct',
         fields: [
           { name: 'laneCodeVersion', type: { defined: 'CodeVersion' } },
+          { name: 'addressBytesLength', type: 'u8' },
           { name: 'allowedSenders', type: { vec: 'publicKey' } },
           { name: 'allowListEnabled', type: 'bool' },
           { name: 'defaultCcvs', type: { vec: 'publicKey' } },
@@ -257,6 +259,8 @@ export const IDL: CcipRouterV2 = {
           { name: 'offramp', type: 'bytes' },
           { name: 'messageNetworkFee', type: 'u32' },
           { name: 'tokenTransferNetworkFee', type: 'u32' },
+          { name: 'baseExecutionGasCost', type: 'u32' },
+          { name: 'maxFeePerMessage', type: 'u32' },
         ],
       },
     },

--- a/ccip-sdk/src/solana/index.ts
+++ b/ccip-sdk/src/solana/index.ts
@@ -724,82 +724,60 @@ export class SolanaChain extends Chain<typeof ChainFamily.Solana> {
   }
 
   /**
-   * {@inheritDoc Chain.getOffRampsForRouter}
-   * @throws {@link CCIPSolanaOffRampEventsNotFoundError} if no OffRamp events found
+   * {@link Chain.getOffRampsForRouter}
+   *
+   * Both 1.6 and v2 routers maintain `allowed_offramp` marker PDAs per
+   * `(sourceChainSelector, offRamp)` pair, seeded as `[allowed_offramp, selectorLE, offRamp]`.
+   * The offRamp pubkey lives only in the seeds (marker data is just the 8-byte
+   * discriminator), so we:
+   *  1. enumerate all `allowed_offramp` marker accounts owned by the router
+   *     (filtered by 8-byte data length),
+   *  2. read each marker's transaction history (offRamps reference their marker
+   *     when executing commit/execute),
+   *  3. for every account key seen in those txs, re-derive the marker PDA for
+   *     our `sourceChainSelector` and keep the keys that reproduce the marker
+   *     address.
+   * A match proves both that the key is the offRamp program and that it's
+   * allowed for this source chain. All matching offRamps are returned (not just
+   * the first), so lanes with multiple historical offRamps are fully discovered.
+   *
+   * @throws {@link CCIPSolanaOffRampEventsNotFoundError} if no OffRamp markers
+   *         match for this source chain.
    */
   async getOffRampsForRouter(router: string, sourceChainSelector: bigint): Promise<string[]> {
-    const [, version] = await this.typeAndVersion(router)
-    if (version.startsWith('2.')) {
-      return this._getOffRampsForRouterV2(router, sourceChainSelector)
-    }
-
-    // feeQuoter is present in router's config, and has a DestChainState account which is updated by
-    // the offramps, so we can use it to narrow the search for the offramp
-    const { feeQuoter } = await this._getRouterConfig(router)
-
-    const [feeQuoterDestChainStateAccountAddress] = PublicKey.findProgramAddressSync(
-      [Buffer.from('dest_chain'), toLeArray(sourceChainSelector, 8)],
-      feeQuoter,
-    )
-
-    for await (const log of this.getLogs({
-      programs: true,
-      address: feeQuoterDestChainStateAccountAddress.toBase58(),
-      startBlock: 0, // use getLogs special-case to do a single getSignaturesForAddress pass
-      endBlock: 'finalized',
-      topics: ['ExecutionStateChanged', 'CommitReportAccepted', 'Transmitted'],
-    })) {
-      return [log.address] // assume single offramp per router/deployment on Solana
-    }
-    throw new CCIPSolanaOffRampEventsNotFoundError(feeQuoter.toString())
-  }
-
-  /**
-   * OffRamp discovery for CCIP v2 routers.
-   *
-   * v2 OffRamps don't touch the FeeQuoter's `dest_chain` state, so the v1 event-scan heuristic
-   * finds nothing. Instead, the router owns an `AllowedOfframp` marker PDA per allowed
-   * `(sourceChainSelector, offRamp)` pair, seeded as `[allowed_offramp, selectorLE, offRamp]`.
-   * The offRamp pubkey lives only in the seeds (marker data is just the discriminator), so we:
-   *  1. enumerate the router's `AllowedOfframp` markers,
-   *  2. read each marker's transaction history (offRamps reference their marker when executing),
-   *  3. for every account key seen in those txs, re-derive the marker PDA for our
-   *     `sourceChainSelector` and keep the keys that reproduce the marker address.
-   * A match proves both that the key is the offRamp program and that it's allowed for this source.
-   */
-  private async _getOffRampsForRouterV2(
-    router: string,
-    sourceChainSelector: bigint,
-  ): Promise<string[]> {
     const routerPk = new PublicKey(router)
-    const program = new Program(CCIP_ROUTER_V2_IDL, routerPk, { connection: this.connection })
-    const markers = await program.account.allowedOfframp.all()
+    // `allowed_offramp` markers are 8-byte accounts (discriminator only) on both
+    // 1.6 and v2 routers. Filter by data length to find them without needing a
+    // Program/IDL instance.
+    const markers = await this.connection.getProgramAccounts(routerPk, {
+      filters: [{ dataSize: 8 }],
+      encoding: 'base64',
+    })
 
     const offRamps = new Set<string>()
-    for (const { publicKey: marker } of markers) {
-      // Quick check: does this marker belong to our source selector for any candidate offRamp?
-      // We can only answer by testing candidate keys pulled from the marker's txs.
-      const sigs = await this.connection.getSignaturesForAddress(marker, { limit: 10 })
-      for (const { signature } of sigs) {
-        const tx = await this.connection.getTransaction(signature, {
-          maxSupportedTransactionVersion: 0,
-          commitment: 'confirmed',
-        })
-        if (!tx) continue
-        const keys = tx.transaction.message
-          .getAccountKeys({ accountKeysFromLookups: tx.meta?.loadedAddresses })
-          .keySegments()
-          .flat()
-        for (const key of keys) {
-          const [pda] = PublicKey.findProgramAddressSync(
-            [Buffer.from('allowed_offramp'), toLeArray(sourceChainSelector, 8), key.toBuffer()],
-            routerPk,
-          )
-          if (pda.equals(marker)) offRamps.add(key.toBase58())
+    await Promise.all(
+      markers.map(async ({ pubkey: marker }) => {
+        const sigs = await this.connection.getSignaturesForAddress(marker, { limit: 1 })
+        for (const { signature } of sigs) {
+          const tx = await this.connection.getTransaction(signature, {
+            maxSupportedTransactionVersion: 0,
+            commitment: 'confirmed',
+          })
+          if (!tx) continue
+          const keys = tx.transaction.message
+            .getAccountKeys({ accountKeysFromLookups: tx.meta?.loadedAddresses })
+            .keySegments()
+            .flat()
+          for (const key of keys) {
+            const [pda] = PublicKey.findProgramAddressSync(
+              [Buffer.from('allowed_offramp'), toLeArray(sourceChainSelector, 8), key.toBuffer()],
+              routerPk,
+            )
+            if (!pda.equals(marker)) offRamps.add(key.toBase58())
+          }
         }
-        if (offRamps.size) break // found the offRamp for this marker
-      }
-    }
+      }),
+    )
 
     if (!offRamps.size) throw new CCIPSolanaOffRampEventsNotFoundError(router)
     return [...offRamps]

--- a/ccip-sdk/src/solana/index.ts
+++ b/ccip-sdk/src/solana/index.ts
@@ -67,17 +67,30 @@ import {
 import {
   type EVMExtraArgsV2,
   type ExtraArgs,
+  type GenericExtraArgsV3,
   type SVMExtraArgsV1,
+  type SuiExtraArgsV1,
   EVMExtraArgsV2Tag,
+  GenericExtraArgsV3Tag,
+  SuiExtraArgsV1Tag,
 } from '../extra-args.ts'
 import { getDestTokenAmount } from '../gas.ts'
 import { cleanUpBuffers } from './cleanup.ts'
 import { createRateLimitedFetch, fetchProfileForUrl } from '../fetch.ts'
-import { encodeSolanaExtraArgs } from './extra-args.ts'
+import { generateUnsignedExecuteReport } from './exec.ts'
+import {
+  decodeSolanaGenericExtraArgsV3,
+  decodeSolanaSuiExtraArgsV1,
+  encodeSolanaExtraArgs,
+} from './extra-args.ts'
+import { estimateExecComputeUnits } from './gas.ts'
 import { getV16SolanaLeafHasher } from './hasher.ts'
 import type { LeafHasher } from '../hasher/common.ts'
+import { decodeMessageV1 } from '../messages.ts'
 import { type NetworkInfo, ChainFamily, networkInfo } from '../networks.ts'
+import { buildMessageForDest, decodeMessage, normalizeDeep } from '../requests.ts'
 import SELECTORS from '../selectors.ts'
+import { DEFAULT_GAS_LIMIT } from '../shared/constants.ts'
 import { supportedChains } from '../supported-chains.ts'
 import {
   type AnyMessage,
@@ -108,11 +121,6 @@ import {
   toLeArray,
   util,
 } from '../utils.ts'
-import { generateUnsignedExecuteReport } from './exec.ts'
-import { estimateExecComputeUnits } from './gas.ts'
-import { decodeMessageV1 } from '../messages.ts'
-import { buildMessageForDest, decodeMessage, normalizeDeep } from '../requests.ts'
-import { DEFAULT_GAS_LIMIT } from '../shared/constants.ts'
 import { IDL as BASE_TOKEN_POOL } from './idl/1.6.0/BASE_TOKEN_POOL.ts'
 import { IDL as BURN_MINT_TOKEN_POOL } from './idl/1.6.0/BURN_MINT_TOKEN_POOL.ts'
 import { IDL as CCIP_CCTP_TOKEN_POOL } from './idl/1.6.0/CCIP_CCTP_TOKEN_POOL.ts'
@@ -299,7 +307,8 @@ export class SolanaChain extends Chain<typeof ChainFamily.Solana> {
     this.getFeeTokens = memoize(this.getFeeTokens.bind(this), { async: true, maxArgs: 1 })
     this.getOffRampsForRouter = memoize(this.getOffRampsForRouter.bind(this), {
       async: true,
-      maxArgs: 1,
+      maxArgs: 2,
+      maxSize: 20,
     })
   }
 
@@ -757,7 +766,7 @@ export class SolanaChain extends Chain<typeof ChainFamily.Solana> {
     const offRamps = new Set<string>()
     await Promise.all(
       markers.map(async ({ pubkey: marker }) => {
-        const sigs = await this.connection.getSignaturesForAddress(marker, { limit: 1 })
+        const sigs = await this.connection.getSignaturesForAddress(marker, { limit: 10 })
         for (const { signature } of sigs) {
           const tx = await this.connection.getTransaction(signature, {
             maxSupportedTransactionVersion: 0,
@@ -773,7 +782,9 @@ export class SolanaChain extends Chain<typeof ChainFamily.Solana> {
               [Buffer.from('allowed_offramp'), toLeArray(sourceChainSelector, 8), key.toBuffer()],
               routerPk,
             )
-            if (!pda.equals(marker)) offRamps.add(key.toBase58())
+            const keyAddr = key.toBase58()
+            if (pda.equals(marker)) offRamps.add(keyAddr)
+            if (keyAddr.toLowerCase().startsWith('off')) return
           }
         }
       }),
@@ -1018,7 +1029,7 @@ export class SolanaChain extends Chain<typeof ChainFamily.Solana> {
     const extraArgs = hexlify(message.extraArgs)
     const parsed = this.decodeExtraArgs(extraArgs)
     if (!parsed) throw new CCIPExtraArgsInvalidError('SVM', extraArgs)
-    const { _tag, ...rest } = parsed
+    const { _tag, ...rest } = parsed as Record<string, unknown>
 
     return {
       // merge header fields to message
@@ -1036,24 +1047,35 @@ export class SolanaChain extends Chain<typeof ChainFamily.Solana> {
       feeValueJuels,
       extraArgs,
       ...rest,
-    }
+    } as unknown as CCIPMessage
   }
 
   /**
-   * Decodes extra arguments from Solana CCIP messages.
+   * Decodes extra arguments from Solana CCIP messages (Borsh-encoded, produced
+   * BY Solana targeting remote chain families).
+   *
+   * Handles:
+   * - `GenericExtraArgsV2` (EVMExtraArgsV2 tag) — Solana → EVM 1.6
+   * - `GenericExtraArgsV3` — Solana → EVM 2.0
+   * - `SuiExtraArgsV1` — Solana → Sui
+   *
    * @param extraArgs - Encoded extra arguments bytes.
-   * @returns Decoded EVMExtraArgsV2 or undefined if unknown format.
+   * @returns Decoded extra arguments or undefined if unknown format.
    * @throws {@link CCIPExtraArgsLengthInvalidError} if extra args length is invalid
    */
   static decodeExtraArgs(
     extraArgs: BytesLike,
-  ): (EVMExtraArgsV2 & { _tag: 'EVMExtraArgsV2' }) | undefined {
+  ):
+    | (EVMExtraArgsV2 & { _tag: 'EVMExtraArgsV2' })
+    | (GenericExtraArgsV3 & { _tag: 'GenericExtraArgsV3' })
+    | (SuiExtraArgsV1 & { _tag: 'SuiExtraArgsV1' })
+    | undefined {
     const data = getDataBytes(extraArgs),
       tag = dataSlice(data, 0, 4)
     switch (tag) {
       case EVMExtraArgsV2Tag: {
         if (dataLength(data) === 4 + 16 + 1) {
-          // Solana-generated EVMExtraArgsV2 (21 bytes total)
+          // Solana-generated EVMExtraArgsV2 (Borsh: 21 bytes total, u128 LE gasLimit)
           return {
             _tag: 'EVMExtraArgsV2',
             gasLimit: leToBigInt(dataSlice(data, 4, 4 + 16)), // from Uint128LE
@@ -1062,16 +1084,27 @@ export class SolanaChain extends Chain<typeof ChainFamily.Solana> {
         }
         throw new CCIPExtraArgsLengthInvalidError(dataLength(data))
       }
+      case GenericExtraArgsV3Tag: {
+        return decodeSolanaGenericExtraArgsV3(data)
+      }
+      case SuiExtraArgsV1Tag: {
+        return decodeSolanaSuiExtraArgsV1(data)
+      }
       default:
         return
     }
   }
 
   /**
-   * Encodes extra arguments for Solana CCIP messages.
+   * Encodes extra arguments for Solana CCIP messages in Borsh format.
+   *
+   * Handles messages FROM Solana TO remote chain families:
+   * - `EVMExtraArgsV2` / `GenericExtraArgsV2` (EVM dest): Borsh `{gasLimit: u128, ...}`
+   * - `GenericExtraArgsV3` (EVM v2 dest): Borsh `{gas_limit: u32, finality, ccvs, ...}`
+   * - `SuiExtraArgsV1` (Sui dest): Borsh `{gasLimit: u64, ...}`
+   *
    * @param args - Extra arguments to encode.
    * @returns Encoded extra arguments as hex string.
-   * @throws {@link CCIPSolanaExtraArgsEncodingError} if SVMExtraArgsV1 encoding is attempted
    */
   static encodeExtraArgs(args: ExtraArgs): string {
     return encodeSolanaExtraArgs(args)

--- a/ccip-sdk/src/solana/index.ts
+++ b/ccip-sdk/src/solana/index.ts
@@ -754,6 +754,28 @@ export class SolanaChain extends Chain<typeof ChainFamily.Solana> {
    *         match for this source chain.
    */
   async getOffRampsForRouter(router: string, sourceChainSelector: bigint): Promise<string[]> {
+    const [, version] = await this.typeAndVersion(router)
+    if (version.startsWith('1.')) {
+      // feeQuoter is present in router's config, and has a DestChainState account which is updated by
+      // the offramps, so we can use it to narrow the search for the offramp
+      const { feeQuoter } = await this._getRouterConfig(router)
+
+      const [feeQuoterDestChainStateAccountAddress] = PublicKey.findProgramAddressSync(
+        [Buffer.from('dest_chain'), toLeArray(sourceChainSelector, 8)],
+        feeQuoter,
+      )
+
+      for await (const log of this.getLogs({
+        programs: true,
+        address: feeQuoterDestChainStateAccountAddress.toBase58(),
+        startBlock: 0, // use getLogs special-case to do a single getSignaturesForAddress pass
+        endBlock: 'finalized',
+        topics: ['ExecutionStateChanged', 'CommitReportAccepted', 'Transmitted'],
+      })) {
+        return [log.address] // assume single offramp per router/deployment on Solana
+      }
+    }
+
     const routerPk = new PublicKey(router)
     // `allowed_offramp` markers are 8-byte accounts (discriminator only) on both
     // 1.6 and v2 routers. Filter by data length to find them without needing a

--- a/ccip-sdk/src/sui/discovery.ts
+++ b/ccip-sdk/src/sui/discovery.ts
@@ -102,11 +102,15 @@ async function findOffRampPackageByUpgrades(
  * types (`<pkg>::offramp::*`). Works on history-pruned RPCs once any offramp
  * activity (commit/execute/config) exists within event retention.
  */
-async function findOffRampPackageByEvents(
+export async function findOffRampPackageByEvents(
   client: SuiJsonRpcClient,
-  { maxPages = 100, limit = 50 }: { maxPages?: number; limit?: number } = {},
+  {
+    maxPages = 100,
+    limit = 50,
+    startTime = 0,
+  }: { maxPages?: number; limit?: number; startTime?: number } = {},
 ): Promise<string | undefined> {
-  const filter = { TimeRange: { startTime: '0', endTime: Date.now().toString() } }
+  const filter = { TimeRange: { startTime: startTime.toString(), endTime: Date.now().toString() } }
   let cursor: { txDigest: string; eventSeq: string } | null | undefined
   for (let page = 0; page < maxPages; page++) {
     const res = await withLookupRetry(() =>
@@ -117,6 +121,15 @@ async function findOffRampPackageByEvents(
       if (match) return normalizeSuiAddress(match[1]!) + '::offramp'
     }
     if (!res.hasNextPage || !res.data.length) break
+    // Guard against stuck pagination (some RPCs return the same cursor repeatedly
+    // on very large event ranges)
+    if (
+      cursor &&
+      res.nextCursor &&
+      res.nextCursor.txDigest === cursor.txDigest &&
+      res.nextCursor.eventSeq === cursor.eventSeq
+    )
+      break
     cursor = res.nextCursor
   }
 }

--- a/ccip-sdk/src/sui/index.ts
+++ b/ccip-sdk/src/sui/index.ts
@@ -36,7 +36,7 @@ import { createRateLimitedFetch, fetchProfileForUrl } from '../fetch.ts'
 import type { LeafHasher } from '../hasher/common.ts'
 import { type NetworkInfo, ChainFamily, networkInfo } from '../networks.ts'
 import { decodeMessage } from '../requests.ts'
-import { decodeMoveExtraArgs, getMoveAddress } from '../shared/bcs-codecs.ts'
+import { decodeMoveExtraArgs, encodeMoveExtraArgs, getMoveAddress } from '../shared/bcs-codecs.ts'
 import { supportedChains } from '../supported-chains.ts'
 import type {
   AnyMessage,
@@ -664,18 +664,22 @@ export class SuiChain extends Chain<typeof ChainFamily.Sui> {
   ):
     | (EVMExtraArgsV2 & { _tag: 'EVMExtraArgsV2' })
     | (SVMExtraArgsV1 & { _tag: 'SVMExtraArgsV1' })
+    | (SuiExtraArgsV1 & { _tag: 'SuiExtraArgsV1' })
     | undefined {
     return decodeMoveExtraArgs(extraArgs)
   }
 
   /**
-   * Encodes extra arguments for CCIP messages.
-   * @param _extraArgs - Extra arguments to encode.
+   * Encodes extra arguments for Sui CCIP messages in BCS format.
+   * Dispatches to the correct encoder based on the destination chain's extraArgs type:
+   * - `SVMExtraArgsV1` (Solana dest): BCS `{computeUnits, accountIsWritableBitmap, ...}`
+   * - `SuiExtraArgsV1` (Sui dest): BCS `{gasLimit, allowOutOfOrderExecution, ...}`
+   * - `EVMExtraArgsV2` / `GenericExtraArgsV2` (EVM dest): BCS `{gasLimit: u256, ...}`
+   * @param args - Extra arguments to encode.
    * @returns Encoded extra arguments as a hex string.
-   * @throws {@link CCIPNotImplementedError} always (not yet implemented)
    */
-  static encodeExtraArgs(_extraArgs: ExtraArgs): string {
-    throw new CCIPNotImplementedError()
+  static encodeExtraArgs(args: ExtraArgs): string {
+    return encodeMoveExtraArgs(args)
   }
 
   /**

--- a/ccip-sdk/src/sui/index.ts
+++ b/ccip-sdk/src/sui/index.ts
@@ -102,6 +102,17 @@ export class SuiChain extends Chain<typeof ChainFamily.Sui> {
       maxArgs: 1,
       maxSize: 100,
     })
+    this.client.getTransactionBlock = memoize(this.client.getTransactionBlock.bind(this.client), {
+      async: true,
+      maxArgs: 1,
+      maxSize: 100,
+      expires: 5e3,
+      transformKey: ([args]: Parameters<typeof this.client.getTransactionBlock>) => [
+        args.digest,
+        args.options?.showEffects,
+        args.options?.showInput,
+      ],
+    })
   }
 
   /**

--- a/ccip-sdk/src/ton/index.test.ts
+++ b/ccip-sdk/src/ton/index.test.ts
@@ -1219,6 +1219,35 @@ describe('TON index unit tests', () => {
         'block 10 (below startBlock) excluded; 11 & 12 are sealed (tip 13)',
       )
     })
+
+    it('refuses to scan when the resume floor lands past startBlock', async () => {
+      // Reproduces the disagreement that lost a finalized execution on ton-testnet: block
+      // 10's shard end_lt comes back one bucket too high (11_999 instead of 10_999 — the
+      // masterchain-vs-shard lt offset), so resuming at startBlock 11 would begin at lt
+      // 12_000 and skip block 11's tx for good. Fail loudly rather than scan and skip.
+      const chain = makeChain(13, [11_001, 12_001])
+      ;(
+        chain as unknown as {
+          getShardBlockEndLt: (w: number, s: string, n: number) => Promise<bigint>
+        }
+      ).getShardBlockEndLt = async (_w, _s, seqno) => SHARD_END(seqno === 10 ? 11 : seqno)
+      await assert.rejects(
+        () => collect(chain, { startBlock: 11 }),
+        /Inconsistent TON cursor/,
+        'a floor above startBlock must throw, not silently skip block 11',
+      )
+    })
+
+    it('stops the scan when a tx commits below startBlock', async () => {
+      // The same disagreement from the emit side: the floor checks out, but the tx it
+      // returns is assigned a block below startBlock. Emitting it would rewind the poller's
+      // watermark over blocks this scan never covered, so the scan stops with nothing.
+      const chain = makeChain(13, [11_001, 12_001])
+      ;(
+        chain as unknown as { committingSeqno: (lt: bigint, a: Address) => Promise<number> }
+      ).committingSeqno = async () => 10
+      assert.deepEqual(await collect(chain, { startBlock: 11 }), [])
+    })
   })
 
   describe('generateUnsignedSendMessage', () => {

--- a/ccip-sdk/src/ton/index.ts
+++ b/ccip-sdk/src/ton/index.ts
@@ -621,9 +621,30 @@ export class TONChain extends Chain<typeof ChainFamily.TON> {
     // Resume strictly after everything masterchain block (startBlock-1) committed, in
     // account-shard lt space.
     const opts_ = { ...opts }
+    let startSeqno: number | undefined
     if (opts.startBlock != null) {
       const b = Number(opts.startBlock)
+      startSeqno = b
       opts_.startBlock = b > 1 ? (await this.accountShardEndLt(b - 1, acct)) + 1n : 0n
+      // Consistency gate on the two directions of the mc-seqno↔lt mapping. The caller's
+      // cursor is an mc seqno but the fetch pages in lt, so resuming at `b` is only
+      // lossless while the floor derived here stays at or below the block committingSeqno
+      // would assign that lt to. If the floor lands PAST `b`, the scan silently starts
+      // above txs that belong to `b` and skips them for good: the poller never re-scans
+      // below its watermark, so those logs are lost AND its still-pending handlers for
+      // them get cancelled as phantom reorgs. Fail loudly instead — the getLogs activity
+      // retries (visible as attempts), and a fresh chain instance re-resolves the
+      // memoized shard headers this check distrusts.
+      if (b > 1) {
+        const floorSeqno = await this.committingSeqno(opts_.startBlock, acct)
+        if (floorSeqno > b)
+          throw new CCIPHttpError(
+            0,
+            `Inconsistent TON cursor for ${opts.address}: resume lt=${opts_.startBlock} ` +
+              `derived from startBlock=${b} commits at ${floorSeqno} > ${b} — shard/masterchain ` +
+              `lt mapping disagrees, refusing to scan and skip blocks ${b}..${floorSeqno - 1}`,
+          )
+      }
     }
 
     // Watch mode streams live: emit logs as their txs arrive (the completeness buffering
@@ -677,6 +698,24 @@ export class TONChain extends Chain<typeof ChainFamily.TON> {
         break
       }
       const block = tx.blockNumber
+      // Same mapping disagreement as the cursor gate above, caught from the emit side:
+      // the fetch floor was derived from startSeqno, so every tx it returns must commit
+      // at or after it — and must sit at or above the floor in lt space. A violation
+      // means blockNumber under-assigns relative to the resume boundary, which would
+      // advance the poller's watermark past blocks this scan never covered. Drop the
+      // in-progress block and stop, exactly like the gap case; the poller retries.
+      if (
+        (startSeqno !== undefined && block < startSeqno) ||
+        (raw && opts_.startBlock != null && raw.lt < BigInt(opts_.startBlock))
+      ) {
+        this.logger.warn(
+          `TON getLogs: tx lt=${raw?.lt} commits at block ${block}, below the ` +
+            `startBlock=${startSeqno} / lt=${opts_.startBlock} resume boundary; stopping scan`,
+        )
+        buf = []
+        curBlock = undefined
+        break
+      }
       // Crossed a block boundary with the chain intact ⇒ curBlock is complete.
       if (curBlock !== undefined && block !== curBlock) yield* drain()
       curBlock = block


### PR DESCRIPTION
This pull request updates the Solana CCIP v2 integration to match the latest devnet redeploy and improves off-ramp discovery logic for both Solana and Sui chains. The main changes include updating the Solana v2 IDL and related tests to reflect the new on-chain account layouts, refactoring and generalizing the Solana off-ramp discovery method, and enhancing Sui off-ramp event discovery for reliability.

**Solana v2 Integration and IDL Updates:**

* Updated the Solana v2 IDL (`CCIP_ROUTER.ts`) to match the latest devnet deployment, including new fields (`addressBytesLength`, `baseExecutionGasCost`, `maxFeePerMessage`) and changes to struct layouts and field types for compatibility with on-chain accounts. [[1]](diffhunk://#diff-e4f4c38f3fa0ad2c4e6c9f713206d77b7a629f05b6ae5d2e1c33b8a001f9576bL14-R18) [[2]](diffhunk://#diff-e4f4c38f3fa0ad2c4e6c9f713206d77b7a629f05b6ae5d2e1c33b8a001f9576bL93-R102) [[3]](diffhunk://#diff-e4f4c38f3fa0ad2c4e6c9f713206d77b7a629f05b6ae5d2e1c33b8a001f9576bL113-R113) [[4]](diffhunk://#diff-e4f4c38f3fa0ad2c4e6c9f713206d77b7a629f05b6ae5d2e1c33b8a001f9576bR124) [[5]](diffhunk://#diff-e4f4c38f3fa0ad2c4e6c9f713206d77b7a629f05b6ae5d2e1c33b8a001f9576bR133-R134) [[6]](diffhunk://#diff-e4f4c38f3fa0ad2c4e6c9f713206d77b7a629f05b6ae5d2e1c33b8a001f9576bL220-R231) [[7]](diffhunk://#diff-e4f4c38f3fa0ad2c4e6c9f713206d77b7a629f05b6ae5d2e1c33b8a001f9576bL240-R242) [[8]](diffhunk://#diff-e4f4c38f3fa0ad2c4e6c9f713206d77b7a629f05b6ae5d2e1c33b8a001f9576bR253) [[9]](diffhunk://#diff-e4f4c38f3fa0ad2c4e6c9f713206d77b7a629f05b6ae5d2e1c33b8a001f9576bR262-R263)

* Updated test fixtures and assertions in `integration.test.ts` and `decodeMessage.test.ts` to reflect new transaction IDs, message data, sequence numbers, and log formats resulting from the redeploy. [[1]](diffhunk://#diff-3cb56f478d739a65774b64d75660fb4aba01b88a9fc48b2b71d07ee54cec1389L28-R34) [[2]](diffhunk://#diff-3cb56f478d739a65774b64d75660fb4aba01b88a9fc48b2b71d07ee54cec1389R281-R305) [[3]](diffhunk://#diff-66a69c5e9e5dc1fd468d375b60424a5d6a8485b3e693be841539734f384ea2bfL72-R75) [[4]](diffhunk://#diff-66a69c5e9e5dc1fd468d375b60424a5d6a8485b3e693be841539734f384ea2bfL83-R94)

**Solana Off-Ramp Discovery Refactor:**

* Refactored and unified the `getOffRampsForRouter` method in `solana/index.ts` to use a generalized approach for both v1.6 and v2 routers, based on marker account enumeration and transaction history analysis, improving accuracy and supporting multiple off-ramps per lane. [[1]](diffhunk://#diff-52672eb6cc423fb95d60a145828ba993dcb12ba7273499cd7dc882110b7be379L727-R760) [[2]](diffhunk://#diff-52672eb6cc423fb95d60a145828ba993dcb12ba7273499cd7dc882110b7be379L798-R780)

**Sui Off-Ramp Event Discovery Improvements:**

* Enhanced the Sui off-ramp event discovery function to accept a `startTime` parameter and added logic to prevent infinite pagination loops on certain RPCs. The function is now exported for use in other modules. [[1]](diffhunk://#diff-fbf645aa67956fdf4c866da9f093f07ddae5d59948f79bf881ea2749f6d6f610L105-R113) [[2]](diffhunk://#diff-fbf645aa67956fdf4c866da9f093f07ddae5d59948f79bf881ea2749f6d6f610R124-R132)

**Cross-chain Address Normalization:**

* Improved address normalization in `execution.ts` to ensure onRamp addresses are compared in a consistent, chain-specific format, reducing cross-chain discovery errors. [[1]](diffhunk://#diff-cdce02e49926edff8518f8d5fb4751b33353c96f27ed023a94a68d67f09fe1bbL170-R178) [[2]](diffhunk://#diff-cdce02e49926edff8518f8d5fb4751b33353c96f27ed023a94a68d67f09fe1bbR241-R251)