### PR TITLE
Fix/check execute decimals

### DIFF
--- a/ccip-sdk/src/chain.ts
+++ b/ccip-sdk/src/chain.ts
@@ -67,7 +67,6 @@ import {
 import {
   getDataBytes,
   getSourceDecimalsFromExtraData,
-  isVersionBelow,
   parseTypeAndVersion,
   scaleDecimals,
   util,
@@ -1411,7 +1410,7 @@ export abstract class Chain<F extends ChainFamily = ChainFamily> {
       // forwards it to releaseOrMint as sourceDenominatedAmount.
       // `typeAndVersion` is the raw string from getTokenPoolConfig and may be kebab-case
       // (e.g. Solana's `foo-lock-release 1.5.0`); normalize via parseTypeAndVersion first.
-      const [poolType] = typeAndVersion ? parseTypeAndVersion(typeAndVersion) : []
+      const [poolType, poolVersion] = typeAndVersion ? parseTypeAndVersion(typeAndVersion) : []
       const isLockRelease = Boolean(poolType?.includes('LockRelease'))
       const sourceDecimals = getSourceDecimalsFromExtraData(ta.extraData)
       const tokenInfo =
@@ -1452,7 +1451,7 @@ export abstract class Chain<F extends ChainFamily = ChainFamily> {
       // (TokenPool._validateReleaseOrMint); 1.5.1 and 1.6.0 consume the source-denominated
       // amount. Every other family debits local units at all versions.
       const bucketAmount =
-        this.network.family === ChainFamily.EVM && isVersionBelow(typeAndVersion, '1.6.1')
+        this.network.family === ChainFamily.EVM && poolVersion != null && poolVersion < '1.6.1'
           ? ta.amount
           : localAmount
       if (bucketAmount > remote.inboundRateLimiterState.tokens) {

--- a/ccip-sdk/src/chain.ts
+++ b/ccip-sdk/src/chain.ts
@@ -1,4 +1,4 @@
-import { type BytesLike, dataLength, hexlify, isBytesLike, keccak256 } from 'ethers'
+import { type BytesLike, dataLength, formatUnits, hexlify, isBytesLike, keccak256 } from 'ethers'
 import type { PickDeep } from 'type-fest'
 
 import { type LaneLatencyResponse, CCIPAPIClient } from './api/index.ts'
@@ -14,6 +14,7 @@ import {
   CCIPLogsRequiresStartError,
   CCIPNotImplementedError,
   CCIPRateLimitExceededError,
+  CCIPTokenDecimalsInsufficientError,
   CCIPTokenPoolChainConfigNotFoundError,
 } from './errors/index.ts'
 import type { UnsignedEVMTx } from './evm/types.ts'
@@ -31,7 +32,7 @@ import type {
 import type { EstimateMessageInput, GetRequiredCCVsMessage, GetRequiredCCVsResult } from './gas.ts'
 import type { LeafHasher } from './hasher/common.ts'
 import { decodeMessageV1 } from './messages.ts'
-import { type ChainFamily, type NetworkInfo, type NetworkType, networkInfo } from './networks.ts'
+import { type NetworkInfo, type NetworkType, ChainFamily, networkInfo } from './networks.ts'
 import { getOffchainTokenData } from './offchain.ts'
 import {
   getMessagesInBatch,
@@ -63,7 +64,14 @@ import {
   CCIPVersion,
   ExecutionState,
 } from './types.ts'
-import { getDataBytes, getSourceDecimalsFromExtraData, util, withRetry } from './utils.ts'
+import {
+  getDataBytes,
+  getSourceDecimalsFromExtraData,
+  isVersionBelow,
+  scaleDecimals,
+  util,
+  withRetry,
+} from './utils.ts'
 
 /** All valid field names for GenericExtraArgsV2. */
 const V2_FIELDS = new Set(['gasLimit', 'allowOutOfOrderExecution'])
@@ -1393,42 +1401,65 @@ export abstract class Chain<F extends ChainFamily = ChainFamily> {
       const token = 'destTokenAddress' in ta ? ta.destTokenAddress : ta.token
       // Native value transfers aren't pool-managed — skip the token-pool preflight.
       if (!token || token.match(/^(0x)?0*$/i)) continue
-      // liquidity and inbound rate-limit state below are dest-denominated, so rescale a
-      // source-denominated amount here; `ta.amount` itself must stay source-denominated —
-      // EVMChain's override feeds it to releaseOrMint as sourceDenominatedAmount
-      const sourceDecimals = getSourceDecimalsFromExtraData(ta.extraData)
-      let amount = ta.amount
-      if (sourceDecimals != null) {
-        const { decimals: destDecimals } = await this.getTokenInfo(token)
-        amount =
-          (ta.amount * BigInt(10) ** BigInt(destDecimals)) / BigInt(10) ** BigInt(sourceDecimals)
-      }
       registry ??= await this.getTokenAdminRegistryFor(offRamp)
       const { tokenPool } = await this.getRegistryTokenConfig(registry, token)
       const { typeAndVersion, lockBox } = await this.getTokenPoolConfig(tokenPool!)
-      // if a LockReleaseTokenPool, also check it has enough liquidity
-      if (typeAndVersion?.includes('LockRelease')) {
-        const [balance, { symbol }] = await Promise.all([
-          this.getBalance({ holder: lockBox || tokenPool!, token }),
-          this.getTokenInfo(token),
-        ])
-        if (balance < amount) {
-          throw new CCIPInsufficientBalanceError(balance.toString(), amount.toString(), symbol, {
-            context: { tokenPool, token, typeAndVersion, network: this.network.name },
-          })
+
+      // `ta.amount` is source-denominated whenever `extraData` declares the source decimals.
+      // Convert for the comparisons below, but never touch `ta.amount`: EVMChain's override
+      // forwards it to releaseOrMint as sourceDenominatedAmount.
+      const isLockRelease = Boolean(typeAndVersion?.includes('LockRelease'))
+      const sourceDecimals = getSourceDecimalsFromExtraData(ta.extraData)
+      const tokenInfo =
+        sourceDecimals != null || isLockRelease ? await this.getTokenInfo(token) : undefined
+      let localAmount = ta.amount
+      let scaled
+      if (sourceDecimals != null) {
+        localAmount = scaleDecimals(ta.amount, sourceDecimals, tokenInfo!.decimals)
+        scaled = { sourceAmount: ta.amount, sourceDecimals, destDecimals: tokenInfo!.decimals }
+        // the dest token cannot represent the transfer at all — the pool would release nothing
+        if (localAmount === 0n && ta.amount > 0n)
+          throw new CCIPTokenDecimalsInsufficientError(
+            token,
+            tokenInfo!.decimals,
+            this.network.name,
+            formatUnits(ta.amount, sourceDecimals),
+          )
+      }
+
+      // pool balances are in local units in every pool version
+      if (isLockRelease) {
+        const balance = await this.getBalance({ holder: lockBox || tokenPool!, token })
+        if (balance < localAmount) {
+          throw new CCIPInsufficientBalanceError(
+            balance.toString(),
+            localAmount.toString(),
+            tokenInfo!.symbol,
+            {
+              context: { tokenPool, token, typeAndVersion, network: this.network.name, ...scaled },
+            },
+          )
         }
       }
 
       const remote = await this.getTokenPoolRemote(tokenPool!, message.sourceChainSelector)
       if (!remote.inboundRateLimiterState) continue
-      if (amount > remote.inboundRateLimiterState.tokens) {
+      // EVM pools debit the inbound bucket in local units only from 1.6.1
+      // (TokenPool._validateReleaseOrMint); 1.5.1 and 1.6.0 consume the source-denominated
+      // amount. Every other family debits local units at all versions.
+      const bucketAmount =
+        this.network.family === ChainFamily.EVM && isVersionBelow(typeAndVersion, '1.6.1')
+          ? ta.amount
+          : localAmount
+      if (bucketAmount > remote.inboundRateLimiterState.tokens) {
         throw new CCIPRateLimitExceededError('INBOUND', remote.inboundRateLimiterState, {
           token,
-          amount,
+          amount: bucketAmount,
           tokenPool: tokenPool!,
           registry,
           sourceChainSelector: message.sourceChainSelector,
           destChainSelector: this.network.chainSelector,
+          ...(bucketAmount === localAmount ? scaled : undefined),
         })
       }
     }

--- a/ccip-sdk/src/chain.ts
+++ b/ccip-sdk/src/chain.ts
@@ -63,7 +63,7 @@ import {
   CCIPVersion,
   ExecutionState,
 } from './types.ts'
-import { getDataBytes, util, withRetry } from './utils.ts'
+import { getDataBytes, getSourceDecimalsFromExtraData, util, withRetry } from './utils.ts'
 
 /** All valid field names for GenericExtraArgsV2. */
 const V2_FIELDS = new Set(['gasLimit', 'allowOutOfOrderExecution'])
@@ -1390,10 +1390,19 @@ export abstract class Chain<F extends ChainFamily = ChainFamily> {
   }): Promise<true> {
     let registry
     for (const ta of message.tokenAmounts ?? []) {
-      const amount = ta.amount
       const token = 'destTokenAddress' in ta ? ta.destTokenAddress : ta.token
       // Native value transfers aren't pool-managed — skip the token-pool preflight.
       if (!token || token.match(/^(0x)?0*$/i)) continue
+      // liquidity and inbound rate-limit state below are dest-denominated, so rescale a
+      // source-denominated amount here; `ta.amount` itself must stay source-denominated —
+      // EVMChain's override feeds it to releaseOrMint as sourceDenominatedAmount
+      const sourceDecimals = getSourceDecimalsFromExtraData(ta.extraData)
+      let amount = ta.amount
+      if (sourceDecimals != null) {
+        const { decimals: destDecimals } = await this.getTokenInfo(token)
+        amount =
+          (ta.amount * BigInt(10) ** BigInt(destDecimals)) / BigInt(10) ** BigInt(sourceDecimals)
+      }
       registry ??= await this.getTokenAdminRegistryFor(offRamp)
       const { tokenPool } = await this.getRegistryTokenConfig(registry, token)
       const { typeAndVersion, lockBox } = await this.getTokenPoolConfig(tokenPool!)

--- a/ccip-sdk/src/chain.ts
+++ b/ccip-sdk/src/chain.ts
@@ -68,6 +68,7 @@ import {
   getDataBytes,
   getSourceDecimalsFromExtraData,
   isVersionBelow,
+  parseTypeAndVersion,
   scaleDecimals,
   util,
   withRetry,
@@ -1408,7 +1409,10 @@ export abstract class Chain<F extends ChainFamily = ChainFamily> {
       // `ta.amount` is source-denominated whenever `extraData` declares the source decimals.
       // Convert for the comparisons below, but never touch `ta.amount`: EVMChain's override
       // forwards it to releaseOrMint as sourceDenominatedAmount.
-      const isLockRelease = Boolean(typeAndVersion?.includes('LockRelease'))
+      // `typeAndVersion` is the raw string from getTokenPoolConfig and may be kebab-case
+      // (e.g. Solana's `foo-lock-release 1.5.0`); normalize via parseTypeAndVersion first.
+      const [poolType] = typeAndVersion ? parseTypeAndVersion(typeAndVersion) : []
+      const isLockRelease = Boolean(poolType?.includes('LockRelease'))
       const sourceDecimals = getSourceDecimalsFromExtraData(ta.extraData)
       const tokenInfo =
         sourceDecimals != null || isLockRelease ? await this.getTokenInfo(token) : undefined

--- a/ccip-sdk/src/check-execute.test.ts
+++ b/ccip-sdk/src/check-execute.test.ts
@@ -1,16 +1,14 @@
-/**
- * Base `Chain.checkExecute` — the generic (non-EVM-override) destination preflight.
- *
- * Focus: the amount reaching the rate-limit bucket and the LockRelease balance must be
- * DEST-denominated. `extraData` declares what `amount` is denominated in.
- */
 import assert from 'node:assert/strict'
 import { after, beforeEach, describe, it, mock } from 'node:test'
 
 import { AbiCoder, getAddress, hexlify, randomBytes } from 'ethers'
 
 import { Chain } from './chain.ts'
-import { CCIPInsufficientBalanceError, CCIPRateLimitExceededError } from './errors/index.ts'
+import {
+  CCIPInsufficientBalanceError,
+  CCIPRateLimitExceededError,
+  CCIPTokenDecimalsInsufficientError,
+} from './errors/index.ts'
 import { ChainFamily, NetworkType } from './networks.ts'
 
 const abi = AbiCoder.defaultAbiCoder()
@@ -19,19 +17,23 @@ const DEST_SELECTOR = 16423721717087811551n // solana-devnet
 const OFFRAMP = getAddress(hexlify(randomBytes(20)))
 const POOL = getAddress(hexlify(randomBytes(20)))
 const TOKEN = getAddress(hexlify(randomBytes(20)))
+const TOKEN2 = getAddress(hexlify(randomBytes(20)))
 
-/** A minimal dest chain exercising the base method — no family override in the way. */
+/** A dest chain built straight on `Chain.prototype` — no family override. */
 function makeChain(opts: {
-  destDecimals?: number
+  family?: ChainFamily
+  decimals?: Record<string, number>
   poolTypeAndVersion?: string
   balance?: bigint
   inboundRateLimiterState?: { tokens: bigint; capacity: bigint; rate: bigint }
 }) {
-  const getTokenInfo = mock.fn(async () => ({
-    decimals: opts.destDecimals ?? 9,
-    symbol: 'CCIP-BnM',
-    name: 'CCIP-BnM',
-  }))
+  const decimals = opts.decimals ?? { [TOKEN]: 9 }
+  const getTokenInfo = mock.fn((token: string) =>
+    Promise.resolve({ decimals: decimals[token] ?? 9, symbol: 'CCIP-BnM', name: 'CCIP-BnM' }),
+  )
+  const getTokenAdminRegistryFor = mock.fn(() =>
+    Promise.resolve(getAddress(hexlify(randomBytes(20)))),
+  )
   const chain = Object.create(Chain.prototype) as Chain
   Object.assign(chain, {
     logger: { debug() {}, info() {}, warn() {}, error() {} },
@@ -39,28 +41,35 @@ function makeChain(opts: {
       name: 'solana-devnet',
       chainId: 'devnet',
       chainSelector: DEST_SELECTOR,
-      family: ChainFamily.Solana,
+      family: opts.family ?? ChainFamily.Solana,
       networkType: NetworkType.Testnet,
     },
-    getTokenAdminRegistryFor: mock.fn(async () => getAddress(hexlify(randomBytes(20)))),
-    getRegistryTokenConfig: mock.fn(async () => ({ tokenPool: POOL })),
-    getTokenPoolConfig: mock.fn(async () => ({
-      typeAndVersion: opts.poolTypeAndVersion ?? 'BurnMintTokenPool 1.6.0',
-      lockBox: undefined,
-    })),
-    getTokenPoolRemote: mock.fn(async () => ({
-      remoteToken: TOKEN,
-      remotePools: [],
-      inboundRateLimiterState: opts.inboundRateLimiterState,
-      outboundRateLimiterState: undefined,
-    })),
-    getBalance: mock.fn(async () => opts.balance ?? 10n ** 24n),
+    getTokenAdminRegistryFor,
+    getRegistryTokenConfig: mock.fn(() => Promise.resolve({ tokenPool: POOL })),
+    getTokenPoolConfig: mock.fn(() =>
+      Promise.resolve({
+        typeAndVersion: opts.poolTypeAndVersion ?? 'BurnMintTokenPool 1.6.1',
+        lockBox: undefined,
+      }),
+    ),
+    getTokenPoolRemote: mock.fn(() =>
+      Promise.resolve({
+        remoteToken: TOKEN,
+        remotePools: [],
+        inboundRateLimiterState: opts.inboundRateLimiterState,
+        outboundRateLimiterState: undefined,
+      }),
+    ),
+    getBalance: mock.fn(() => Promise.resolve(opts.balance ?? 10n ** 24n)),
     getTokenInfo,
   })
-  return { chain, getTokenInfo }
+  return { chain, getTokenInfo, getTokenAdminRegistryFor }
 }
 
-const check = (chain: Chain, tokenAmounts: { amount: bigint; extraData?: string }[]) =>
+const check = (
+  chain: Chain,
+  tokenAmounts: { token?: string; amount: bigint; extraData?: string }[],
+) =>
   chain.checkExecute({
     offRamp: OFFRAMP,
     message: {
@@ -71,49 +80,88 @@ const check = (chain: Chain, tokenAmounts: { amount: bigint; extraData?: string 
 
 /** A full bucket of 100,000 CCIP-BnM at 9 decimals — the live sepolia→solana-devnet numbers. */
 const FULL_BUCKET = { tokens: 10n ** 14n, capacity: 10n ** 14n, rate: 167000000000n }
+const dec = (d: bigint) => abi.encode(['uint256'], [d])
 
-describe('Chain.checkExecute — amount denomination', () => {
-  beforeEach(() => mock.restoreAll())
-  after(() => mock.restoreAll())
+void describe('Chain.checkExecute — amount denomination', () => {
+  void beforeEach(() => mock.restoreAll())
+  void after(() => mock.restoreAll())
 
-  it('18→9: a source-denominated amount is converted before hitting the bucket', async () => {
-    // 0.001 CCIP-BnM sent from an 18-decimals chain = 1e15 source units, 1e6 dest units.
-    // Comparing 1e15 against a full 1e14 bucket false-blocked every realistic transfer.
+  void it('18→9: a source-denominated amount is converted before hitting the bucket', async () => {
+    // 0.001 CCIP-BnM from an 18-decimals source = 1e15 source units, 1e6 dest; unconverted,
+    // 1e15 exceeds even a full 1e14 bucket
     const { chain } = makeChain({ inboundRateLimiterState: FULL_BUCKET })
-    assert.equal(
-      await check(chain, [{ amount: 10n ** 15n, extraData: abi.encode(['uint256'], [18n]) }]),
-      true,
-    )
+    assert.equal(await check(chain, [{ amount: 10n ** 15n, extraData: dec(18n) }]), true)
   })
 
-  it('18→9: an amount genuinely over the bucket still throws, reporting dest units', async () => {
+  void it('18→9: an amount genuinely over the bucket still throws, reporting dest units', async () => {
     const { chain } = makeChain({
       inboundRateLimiterState: { tokens: 10n ** 5n, capacity: 10n ** 14n, rate: 1n },
     })
     await assert.rejects(
-      () => check(chain, [{ amount: 10n ** 15n, extraData: abi.encode(['uint256'], [18n]) }]),
-      (err: CCIPRateLimitExceededError) => {
+      () => check(chain, [{ amount: 10n ** 15n, extraData: dec(18n) }]),
+      (err: unknown) => {
         assert.ok(err instanceof CCIPRateLimitExceededError)
         assert.equal(err.context['amount'], 10n ** 6n) // dest-denominated, not 1e15
+        assert.equal(err.context['sourceAmount'], 10n ** 15n)
+        assert.equal(err.context['sourceDecimals'], 18)
+        assert.equal(err.context['destDecimals'], 9)
         return true
       },
     )
   })
 
-  it('9→18: the silent false-PASS direction now blocks', async () => {
-    // 1 token from a 9-decimals source is 1e9 there and 1e18 here; against a 1e17 bucket the
-    // unconverted comparison passed, then execution hit the limit on-chain.
+  void it('9→18: an amount that only exceeds the bucket after conversion is blocked', async () => {
+    // 1 token is 1e9 at the source, 1e18 here; unconverted it fits the 1e17 bucket, on-chain it
+    // does not
     const { chain } = makeChain({
-      destDecimals: 18,
+      decimals: { [TOKEN]: 18 },
       inboundRateLimiterState: { tokens: 10n ** 17n, capacity: 10n ** 18n, rate: 1n },
     })
     await assert.rejects(
-      () => check(chain, [{ amount: 10n ** 9n, extraData: abi.encode(['uint256'], [9n]) }]),
+      () => check(chain, [{ amount: 10n ** 9n, extraData: dec(9n) }]),
       CCIPRateLimitExceededError,
     )
   })
 
-  it('no extraData => amount is already dest-denominated, compared as-is', async () => {
+  void it('equal decimals => no conversion', async () => {
+    const { chain } = makeChain({
+      inboundRateLimiterState: { tokens: 10n ** 5n, capacity: 10n ** 14n, rate: 1n },
+    })
+    await assert.rejects(
+      () => check(chain, [{ amount: 10n ** 6n, extraData: dec(9n) }]),
+      (err: unknown) => {
+        assert.ok(err instanceof CCIPRateLimitExceededError)
+        assert.equal(err.context['amount'], 10n ** 6n)
+        return true
+      },
+    )
+  })
+
+  void it('0 declared decimals is a declaration, not an absent one', async () => {
+    // a 0-decimal SPL mint emits 32 zero bytes; treating that as "undeclared" compares 1e9× low
+    const { chain } = makeChain({
+      inboundRateLimiterState: { tokens: 10n ** 5n, capacity: 10n ** 14n, rate: 1n },
+    })
+    await assert.rejects(
+      () => check(chain, [{ amount: 1n, extraData: dec(0n) }]),
+      (err: unknown) => {
+        assert.ok(err instanceof CCIPRateLimitExceededError)
+        assert.equal(err.context['amount'], 10n ** 9n) // 1 whole token at 9 decimals
+        return true
+      },
+    )
+  })
+
+  void it('an amount the dest token cannot represent is rejected, not silently passed', async () => {
+    // 1 unit at 18 decimals truncates to 0 at 9 — it would clear every bucket and balance
+    const { chain } = makeChain({ inboundRateLimiterState: FULL_BUCKET })
+    await assert.rejects(
+      () => check(chain, [{ amount: 1n, extraData: dec(18n) }]),
+      CCIPTokenDecimalsInsufficientError,
+    )
+  })
+
+  void it('no extraData => amount is already dest-denominated, compared as-is', async () => {
     const { chain, getTokenInfo } = makeChain({
       inboundRateLimiterState: { tokens: 10n ** 5n, capacity: 10n ** 14n, rate: 1n },
     })
@@ -121,40 +169,90 @@ describe('Chain.checkExecute — amount denomination', () => {
     assert.equal(getTokenInfo.mock.callCount(), 0) // no decimals read when nothing is declared
   })
 
-  it('extraData that declares no decimals => identity, no throw', async () => {
-    // a short CCTP-style payload; the USDC hybrid pool's abi.encode(LOCK_RELEASE_FLAG), which IS
-    // 32 bytes but decodes far outside the decimals range; and a plain out-of-range word
-    for (const extraData of [
-      '0xfa7c07de',
-      abi.encode(['bytes4'], ['0xfa7c07de']),
-      abi.encode(['uint256'], [999n]),
-    ]) {
-      const { chain } = makeChain({ inboundRateLimiterState: FULL_BUCKET })
-      assert.equal(await check(chain, [{ amount: 10n ** 6n, extraData }]), true)
+  void it('extraData that declares no decimals => identity, no throw', async () => {
+    // a short CCTP-style payload; the USDC hybrid pool's abi.encode(LOCK_RELEASE_FLAG) — 32 bytes
+    // but far outside the decimals range; and a plain out-of-range word
+    for (const extraData of ['0xfa7c07de', abi.encode(['bytes4'], ['0xfa7c07de']), dec(999n)]) {
+      const { chain, getTokenInfo } = makeChain({ inboundRateLimiterState: FULL_BUCKET })
+      assert.equal(await check(chain, [{ amount: 10n ** 6n, extraData }]), true, extraData)
+      assert.equal(getTokenInfo.mock.callCount(), 0, extraData) // no conversion attempted
     }
   })
 
-  it('LockRelease liquidity is compared in dest units too', async () => {
+  void it('converts per token, resolving the registry once', async () => {
+    const { chain, getTokenAdminRegistryFor } = makeChain({
+      decimals: { [TOKEN]: 9, [TOKEN2]: 18 },
+      inboundRateLimiterState: { tokens: 10n ** 14n, capacity: 10n ** 18n, rate: 1n },
+    })
+    // TOKEN2 declares 9 source decimals against an 18-decimals dest token => 1e15, over the bucket
+    await assert.rejects(
+      () =>
+        check(chain, [
+          { amount: 10n ** 6n },
+          { token: TOKEN2, amount: 10n ** 6n, extraData: dec(9n) },
+        ]),
+      (err: unknown) => {
+        assert.ok(err instanceof CCIPRateLimitExceededError)
+        assert.equal(err.context['token'], TOKEN2)
+        assert.equal(err.context['amount'], 10n ** 15n)
+        return true
+      },
+    )
+    assert.equal(getTokenAdminRegistryFor.mock.callCount(), 1)
+  })
+
+  void it('EVM pools debit the bucket in source units below 1.6.1, local units from 1.6.1', async () => {
+    // @1.6.0 _validateReleaseOrMint consumes releaseOrMintIn.amount; @1.6.1 it consumes localAmount
+    for (const [version, expected] of [
+      ['LockReleaseTokenPool 1.5.1', 10n ** 15n],
+      ['LockReleaseTokenPool 1.6.0', 10n ** 15n],
+      ['LockReleaseTokenPool 1.6.1', 10n ** 6n],
+      ['LockReleaseTokenPool 2.0.0', 10n ** 6n],
+    ] as const) {
+      const { chain } = makeChain({
+        family: ChainFamily.EVM,
+        poolTypeAndVersion: version,
+        inboundRateLimiterState: { tokens: 10n ** 5n, capacity: 10n ** 14n, rate: 1n },
+      })
+      await assert.rejects(
+        () => check(chain, [{ amount: 10n ** 15n, extraData: dec(18n) }]),
+        (err: unknown) => {
+          assert.ok(err instanceof CCIPRateLimitExceededError)
+          assert.equal(err.context['amount'], expected, version)
+          return true
+        },
+      )
+    }
+  })
+
+  void it('a non-EVM pool reporting an old version still uses local units', async () => {
+    // Solana's validate_release_or_mint debits parsed_amount at every version
+    const { chain } = makeChain({
+      poolTypeAndVersion: 'BurnMintTokenPool 1.6.0',
+      inboundRateLimiterState: FULL_BUCKET,
+    })
+    assert.equal(await check(chain, [{ amount: 10n ** 15n, extraData: dec(18n) }]), true)
+  })
+
+  void it('LockRelease liquidity is compared in dest units too', async () => {
     const { chain } = makeChain({
       poolTypeAndVersion: 'LockReleaseTokenPool 1.5.1',
       balance: 10n ** 14n, // 100,000 CCIP-BnM at 9 decimals — plenty for 0.001
     })
-    assert.equal(
-      await check(chain, [{ amount: 10n ** 15n, extraData: abi.encode(['uint256'], [18n]) }]),
-      true,
-    )
+    assert.equal(await check(chain, [{ amount: 10n ** 15n, extraData: dec(18n) }]), true)
   })
 
-  it('LockRelease genuinely short of liquidity still throws, reporting dest units', async () => {
+  void it('LockRelease genuinely short of liquidity still throws, reporting dest units', async () => {
     const { chain } = makeChain({
       poolTypeAndVersion: 'LockReleaseTokenPool 1.5.1',
       balance: 10n ** 5n,
     })
     await assert.rejects(
-      () => check(chain, [{ amount: 10n ** 15n, extraData: abi.encode(['uint256'], [18n]) }]),
-      (err: CCIPInsufficientBalanceError) => {
+      () => check(chain, [{ amount: 10n ** 15n, extraData: dec(18n) }]),
+      (err: unknown) => {
         assert.ok(err instanceof CCIPInsufficientBalanceError)
-        assert.match(err.message, /1000000\b/) // 1e6 dest units, not 1e15
+        assert.equal(err.context['need'], (10n ** 6n).toString()) // dest units, not 1e15
+        assert.equal(err.context['have'], (10n ** 5n).toString())
         return true
       },
     )

--- a/ccip-sdk/src/check-execute.test.ts
+++ b/ccip-sdk/src/check-execute.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Base `Chain.checkExecute` — the generic (non-EVM-override) destination preflight.
+ *
+ * Focus: the amount reaching the rate-limit bucket and the LockRelease balance must be
+ * DEST-denominated. `extraData` declares what `amount` is denominated in.
+ */
+import assert from 'node:assert/strict'
+import { after, beforeEach, describe, it, mock } from 'node:test'
+
+import { AbiCoder, getAddress, hexlify, randomBytes } from 'ethers'
+
+import { Chain } from './chain.ts'
+import { CCIPInsufficientBalanceError, CCIPRateLimitExceededError } from './errors/index.ts'
+import { ChainFamily, NetworkType } from './networks.ts'
+
+const abi = AbiCoder.defaultAbiCoder()
+const SOURCE_SELECTOR = 16015286601757825753n // sepolia
+const DEST_SELECTOR = 16423721717087811551n // solana-devnet
+const OFFRAMP = getAddress(hexlify(randomBytes(20)))
+const POOL = getAddress(hexlify(randomBytes(20)))
+const TOKEN = getAddress(hexlify(randomBytes(20)))
+
+/** A minimal dest chain exercising the base method — no family override in the way. */
+function makeChain(opts: {
+  destDecimals?: number
+  poolTypeAndVersion?: string
+  balance?: bigint
+  inboundRateLimiterState?: { tokens: bigint; capacity: bigint; rate: bigint }
+}) {
+  const getTokenInfo = mock.fn(async () => ({
+    decimals: opts.destDecimals ?? 9,
+    symbol: 'CCIP-BnM',
+    name: 'CCIP-BnM',
+  }))
+  const chain = Object.create(Chain.prototype) as Chain
+  Object.assign(chain, {
+    logger: { debug() {}, info() {}, warn() {}, error() {} },
+    network: {
+      name: 'solana-devnet',
+      chainId: 'devnet',
+      chainSelector: DEST_SELECTOR,
+      family: ChainFamily.Solana,
+      networkType: NetworkType.Testnet,
+    },
+    getTokenAdminRegistryFor: mock.fn(async () => getAddress(hexlify(randomBytes(20)))),
+    getRegistryTokenConfig: mock.fn(async () => ({ tokenPool: POOL })),
+    getTokenPoolConfig: mock.fn(async () => ({
+      typeAndVersion: opts.poolTypeAndVersion ?? 'BurnMintTokenPool 1.6.0',
+      lockBox: undefined,
+    })),
+    getTokenPoolRemote: mock.fn(async () => ({
+      remoteToken: TOKEN,
+      remotePools: [],
+      inboundRateLimiterState: opts.inboundRateLimiterState,
+      outboundRateLimiterState: undefined,
+    })),
+    getBalance: mock.fn(async () => opts.balance ?? 10n ** 24n),
+    getTokenInfo,
+  })
+  return { chain, getTokenInfo }
+}
+
+const check = (chain: Chain, tokenAmounts: { amount: bigint; extraData?: string }[]) =>
+  chain.checkExecute({
+    offRamp: OFFRAMP,
+    message: {
+      sourceChainSelector: SOURCE_SELECTOR,
+      tokenAmounts: tokenAmounts.map((ta) => ({ token: TOKEN, ...ta })),
+    },
+  })
+
+/** A full bucket of 100,000 CCIP-BnM at 9 decimals — the live sepolia→solana-devnet numbers. */
+const FULL_BUCKET = { tokens: 10n ** 14n, capacity: 10n ** 14n, rate: 167000000000n }
+
+describe('Chain.checkExecute — amount denomination', () => {
+  beforeEach(() => mock.restoreAll())
+  after(() => mock.restoreAll())
+
+  it('18→9: a source-denominated amount is converted before hitting the bucket', async () => {
+    // 0.001 CCIP-BnM sent from an 18-decimals chain = 1e15 source units, 1e6 dest units.
+    // Comparing 1e15 against a full 1e14 bucket false-blocked every realistic transfer.
+    const { chain } = makeChain({ inboundRateLimiterState: FULL_BUCKET })
+    assert.equal(
+      await check(chain, [{ amount: 10n ** 15n, extraData: abi.encode(['uint256'], [18n]) }]),
+      true,
+    )
+  })
+
+  it('18→9: an amount genuinely over the bucket still throws, reporting dest units', async () => {
+    const { chain } = makeChain({
+      inboundRateLimiterState: { tokens: 10n ** 5n, capacity: 10n ** 14n, rate: 1n },
+    })
+    await assert.rejects(
+      () => check(chain, [{ amount: 10n ** 15n, extraData: abi.encode(['uint256'], [18n]) }]),
+      (err: CCIPRateLimitExceededError) => {
+        assert.ok(err instanceof CCIPRateLimitExceededError)
+        assert.equal(err.context['amount'], 10n ** 6n) // dest-denominated, not 1e15
+        return true
+      },
+    )
+  })
+
+  it('9→18: the silent false-PASS direction now blocks', async () => {
+    // 1 token from a 9-decimals source is 1e9 there and 1e18 here; against a 1e17 bucket the
+    // unconverted comparison passed, then execution hit the limit on-chain.
+    const { chain } = makeChain({
+      destDecimals: 18,
+      inboundRateLimiterState: { tokens: 10n ** 17n, capacity: 10n ** 18n, rate: 1n },
+    })
+    await assert.rejects(
+      () => check(chain, [{ amount: 10n ** 9n, extraData: abi.encode(['uint256'], [9n]) }]),
+      CCIPRateLimitExceededError,
+    )
+  })
+
+  it('no extraData => amount is already dest-denominated, compared as-is', async () => {
+    const { chain, getTokenInfo } = makeChain({
+      inboundRateLimiterState: { tokens: 10n ** 5n, capacity: 10n ** 14n, rate: 1n },
+    })
+    await assert.rejects(() => check(chain, [{ amount: 10n ** 6n }]), CCIPRateLimitExceededError)
+    assert.equal(getTokenInfo.mock.callCount(), 0) // no decimals read when nothing is declared
+  })
+
+  it('extraData that declares no decimals => identity, no throw', async () => {
+    // a short CCTP-style payload; the USDC hybrid pool's abi.encode(LOCK_RELEASE_FLAG), which IS
+    // 32 bytes but decodes far outside the decimals range; and a plain out-of-range word
+    for (const extraData of [
+      '0xfa7c07de',
+      abi.encode(['bytes4'], ['0xfa7c07de']),
+      abi.encode(['uint256'], [999n]),
+    ]) {
+      const { chain } = makeChain({ inboundRateLimiterState: FULL_BUCKET })
+      assert.equal(await check(chain, [{ amount: 10n ** 6n, extraData }]), true)
+    }
+  })
+
+  it('LockRelease liquidity is compared in dest units too', async () => {
+    const { chain } = makeChain({
+      poolTypeAndVersion: 'LockReleaseTokenPool 1.5.1',
+      balance: 10n ** 14n, // 100,000 CCIP-BnM at 9 decimals — plenty for 0.001
+    })
+    assert.equal(
+      await check(chain, [{ amount: 10n ** 15n, extraData: abi.encode(['uint256'], [18n]) }]),
+      true,
+    )
+  })
+
+  it('LockRelease genuinely short of liquidity still throws, reporting dest units', async () => {
+    const { chain } = makeChain({
+      poolTypeAndVersion: 'LockReleaseTokenPool 1.5.1',
+      balance: 10n ** 5n,
+    })
+    await assert.rejects(
+      () => check(chain, [{ amount: 10n ** 15n, extraData: abi.encode(['uint256'], [18n]) }]),
+      (err: CCIPInsufficientBalanceError) => {
+        assert.ok(err instanceof CCIPInsufficientBalanceError)
+        assert.match(err.message, /1000000\b/) // 1e6 dest units, not 1e15
+        return true
+      },
+    )
+  })
+})

--- a/ccip-sdk/src/evm/dest-liquidity.test.ts
+++ b/ccip-sdk/src/evm/dest-liquidity.test.ts
@@ -890,6 +890,31 @@ describe('EVMChain.checkExecute — dest-liquidity guard', () => {
     assert.equal(decoded.sourcePoolAddress, SRC_POOL_BYTES)
   })
 
+  it('the generic layer rescales for its own comparisons, never for the simulation', async () => {
+    // base checkExecute converts the amount to dest decimals for the rate-limit/liquidity reads;
+    // releaseOrMint must still see it exactly as the source pool reported it
+    const { chain, provider } = makeChain({
+      inboundRateLimiterState: { tokens: 10n ** 16n, capacity: 10n ** 18n, rate: 1n },
+    })
+    await chain.checkExecute({
+      offRamp: OFFRAMP,
+      message: {
+        ...MESSAGE,
+        tokenAmounts: [
+          {
+            sourcePoolAddress: SRC_POOL_BYTES,
+            destTokenAddress: TOKEN,
+            amount: 1000n,
+            extraData: abi.encode(['uint256'], [6n]), // source 6 decimals, dest mock is 18
+          },
+        ],
+      },
+    })
+    const simCall = provider.calls.find((c) => c.data?.startsWith(ROM_V2_SEL))!
+    const [decoded] = pool.decodeFunctionData(ROM_V2_FRAG, simCall.data!)
+    assert.equal(decoded.sourceDenominatedAmount, 1000n) // not 1000 * 10**12
+  })
+
   // ==========================================================================
   // attestation-consuming pools (USDC/CCTP v1.x, Lombard v1.x)
   // ==========================================================================

--- a/ccip-sdk/src/evm/dest-liquidity.test.ts
+++ b/ccip-sdk/src/evm/dest-liquidity.test.ts
@@ -891,10 +891,10 @@ describe('EVMChain.checkExecute — dest-liquidity guard', () => {
   })
 
   it('the generic layer rescales for its own comparisons, never for the simulation', async () => {
-    // base checkExecute converts the amount to dest decimals for the rate-limit/liquidity reads;
-    // releaseOrMint must still see it exactly as the source pool reported it
+    // a 2.0.0 pool debits its bucket in local units, so 1000n at 6 source decimals is compared
+    // as 1e15 — over this bucket, deferred, then discarded when the sim passes
     const { chain, provider } = makeChain({
-      inboundRateLimiterState: { tokens: 10n ** 16n, capacity: 10n ** 18n, rate: 1n },
+      inboundRateLimiterState: { tokens: 10n ** 14n, capacity: 10n ** 18n, rate: 1n },
     })
     await chain.checkExecute({
       offRamp: OFFRAMP,
@@ -910,7 +910,8 @@ describe('EVMChain.checkExecute — dest-liquidity guard', () => {
         ],
       },
     })
-    const simCall = provider.calls.find((c) => c.data?.startsWith(ROM_V2_SEL))!
+    const simCall = provider.calls.find((c) => c.data?.startsWith(ROM_V2_SEL))
+    assert.ok(simCall, 'the releaseOrMint simulation ran')
     const [decoded] = pool.decodeFunctionData(ROM_V2_FRAG, simCall.data!)
     assert.equal(decoded.sourceDenominatedAmount, 1000n) // not 1000 * 10**12
   })
@@ -1023,9 +1024,9 @@ describe('EVMChain.checkExecute — dest-liquidity guard', () => {
     )
   })
 
-  it('generic rate-limit verdict defers to the simulation (amount denominations differ)', async () => {
-    // the check payload carries SOURCE-denominated amounts while the base layer's bucket is in
-    // dest units — the sim (which consumes the rate limit with correct local amounts) decides
+  it('generic rate-limit verdict defers to the simulation', async () => {
+    // the sim consumes the pool's own rate limit with correctly-converted local amounts, so it
+    // decides; the generic read is only a fallback
     const { chain, provider } = makeChain({
       inboundRateLimiterState: { tokens: 10n, capacity: 100n, rate: 1n }, // < amount 1000n
     })

--- a/ccip-sdk/src/evm/index.ts
+++ b/ccip-sdk/src/evm/index.ts
@@ -2627,15 +2627,13 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
     try {
       await super.checkExecute(opts)
     } catch (err) {
-      // The generic layer's amount comparisons can be denomination-inconsistent here: the check
-      // payload carries SOURCE-denominated amounts (paired with the pool's sourcePoolData),
-      // while rate-limit buckets and pool balances are in dest-token units; the LockRelease
-      // heuristic additionally reads the wrong holder for *AndProxy pools (liquidity lives on
-      // the previousPool). The releaseOrMint simulation below is the accurate oracle for both
-      // (the pool consumes its inbound rate limit and releases with correctly-converted local
-      // amounts) — so when it can run, DEFER these two verdicts to it; they are re-raised if the
-      // simulation cannot deliver a verdict for that token. Kept immediately when no simulation
-      // is possible (no receiver).
+      // The generic layer's LockRelease heuristic reads the wrong holder for *AndProxy pools
+      // (liquidity lives on the previousPool), and it only reads the standard inbound bucket —
+      // 2.0 pools debit a separate one on fast-finality transfers.
+      // The releaseOrMint simulation below is the accurate oracle for both (the pool consumes
+      // its own inbound rate limit and releases correctly-converted local amounts) — so when it
+      // can run, DEFER these two verdicts to it; they are re-raised if the simulation cannot
+      // deliver a verdict for that token. Kept immediately when no simulation is possible.
       if (
         (err instanceof CCIPInsufficientBalanceError ||
           err instanceof CCIPRateLimitExceededError) &&

--- a/ccip-sdk/src/gas.ts
+++ b/ccip-sdk/src/gas.ts
@@ -1,4 +1,4 @@
-import { type BytesLike, formatUnits, hexlify, randomBytes, toBigInt } from 'ethers'
+import { type BytesLike, formatUnits, hexlify, randomBytes } from 'ethers'
 import type { Simplify } from 'type-fest'
 
 import type { Chain } from './chain.ts'
@@ -17,7 +17,7 @@ import { networkInfo } from './networks.ts'
 import { buildMessageForDest } from './requests.ts'
 import type { CCIPMessage_V1_6_Solana } from './solana/types.ts'
 import type { CCIPMessage, MessageInput, OffchainTokenData } from './types.ts'
-import { getDataBytes } from './utils.ts'
+import { getDataBytes, getSourceDecimalsFromExtraData } from './utils.ts'
 
 /**
  * A subset of {@link MessageInput} for estimating receive execution gas.
@@ -171,18 +171,6 @@ export async function sourceToDestTokenAddresses<S extends { token: string }>({
     sourcePoolAddress,
     sourceTokenAddress,
     destTokenAddress: remotes[networkInfo(destChainSelector).name]!.remoteToken,
-  }
-}
-
-function getSourceDecimalsFromExtraData(extraData?: string): bigint | undefined {
-  if (!extraData) return undefined
-  try {
-    const bytes = getDataBytes(extraData)
-    if (bytes.length !== 32) return undefined
-    const decimals = toBigInt(bytes)
-    return 0 < decimals && decimals <= 36 ? decimals : undefined
-  } catch {
-    return undefined
   }
 }
 

--- a/ccip-sdk/src/gas.ts
+++ b/ccip-sdk/src/gas.ts
@@ -17,7 +17,7 @@ import { networkInfo } from './networks.ts'
 import { buildMessageForDest } from './requests.ts'
 import type { CCIPMessage_V1_6_Solana } from './solana/types.ts'
 import type { CCIPMessage, MessageInput, OffchainTokenData } from './types.ts'
-import { getDataBytes, getSourceDecimalsFromExtraData } from './utils.ts'
+import { getDataBytes, getSourceDecimalsFromExtraData, scaleDecimals } from './utils.ts'
 
 /**
  * A subset of {@link MessageInput} for estimating receive execution gas.
@@ -219,8 +219,7 @@ export async function getDestTokenAmount({
         ).decimals
       : destDecimals)
 
-  const destAmount =
-    (tokenAmount.amount * BigInt(10) ** BigInt(destDecimals)) / BigInt(10) ** BigInt(sourceDecimals)
+  const destAmount = scaleDecimals(tokenAmount.amount, sourceDecimals, destDecimals)
   if (destAmount === 0n)
     throw new CCIPTokenDecimalsInsufficientError(
       destTokenAddress,

--- a/ccip-sdk/src/utils.test.ts
+++ b/ccip-sdk/src/utils.test.ts
@@ -16,11 +16,14 @@ import {
   getAddressBytes,
   getDataBytes,
   getSomeBlockNumberBefore,
+  getSourceDecimalsFromExtraData,
   isBase64,
+  isVersionBelow,
   jsonParse,
   jsonStringify,
   leToBigInt,
   parseTypeAndVersion,
+  scaleDecimals,
   sleep,
   snakeToCamel,
   toLeArray,
@@ -1343,5 +1346,58 @@ describe('jsonParse', () => {
     assert.equal(parsed.x, val.x)
     assert.equal(parsed.y, val.y)
     assert.equal(parsed.z, val.z)
+  })
+})
+
+describe('getSourceDecimalsFromExtraData', () => {
+  const word = (n: bigint) => '0x' + n.toString(16).padStart(64, '0')
+
+  it('reads a 32-byte decimals word, including 0', () => {
+    assert.equal(getSourceDecimalsFromExtraData(word(0n)), 0)
+    assert.equal(getSourceDecimalsFromExtraData(word(6n)), 6)
+    assert.equal(getSourceDecimalsFromExtraData(word(18n)), 18)
+    assert.equal(getSourceDecimalsFromExtraData(word(36n)), 36)
+  })
+
+  it('declares nothing for absent, wrong-length or implausible payloads', () => {
+    for (const extraData of [
+      undefined,
+      '0x',
+      word(0n).slice(0, -2), // 31 bytes
+      word(0n) + '00', // 33 bytes
+      word(37n),
+      word(2n ** 251n), // a Lombard-style payload hash
+      'not-hex',
+    ]) {
+      assert.equal(getSourceDecimalsFromExtraData(extraData), undefined, String(extraData))
+    }
+  })
+})
+
+describe('scaleDecimals', () => {
+  it('scales up, down and not at all', () => {
+    assert.equal(scaleDecimals(10n ** 15n, 18, 9), 10n ** 6n)
+    assert.equal(scaleDecimals(10n ** 6n, 9, 18), 10n ** 15n)
+    assert.equal(scaleDecimals(1234n, 6, 6), 1234n)
+  })
+
+  it('truncates like the pools do', () => {
+    assert.equal(scaleDecimals(1n, 18, 9), 0n)
+    assert.equal(scaleDecimals(1_999_999_999n, 18, 9), 1n)
+  })
+})
+
+describe('isVersionBelow', () => {
+  it('compares numerically, not lexically', () => {
+    assert.equal(isVersionBelow('LockReleaseTokenPool 1.5.1', '1.6.1'), true)
+    assert.equal(isVersionBelow('LockReleaseTokenPool 1.6.0', '1.6.1'), true)
+    assert.equal(isVersionBelow('LockReleaseTokenPool 1.6.1', '1.6.1'), false)
+    assert.equal(isVersionBelow('BurnMintTokenPool 1.6.10', '1.6.1'), false)
+    assert.equal(isVersionBelow('BurnMintTokenPool 2.0.0', '1.6.1'), false)
+  })
+
+  it('treats an unparseable version as recent', () => {
+    assert.equal(isVersionBelow(undefined, '1.6.1'), false)
+    assert.equal(isVersionBelow('BurnMintTokenPool', '1.6.1'), false)
   })
 })

--- a/ccip-sdk/src/utils.test.ts
+++ b/ccip-sdk/src/utils.test.ts
@@ -18,7 +18,6 @@ import {
   getSomeBlockNumberBefore,
   getSourceDecimalsFromExtraData,
   isBase64,
-  isVersionBelow,
   jsonParse,
   jsonStringify,
   leToBigInt,
@@ -1384,20 +1383,5 @@ describe('scaleDecimals', () => {
   it('truncates like the pools do', () => {
     assert.equal(scaleDecimals(1n, 18, 9), 0n)
     assert.equal(scaleDecimals(1_999_999_999n, 18, 9), 1n)
-  })
-})
-
-describe('isVersionBelow', () => {
-  it('compares numerically, not lexically', () => {
-    assert.equal(isVersionBelow('LockReleaseTokenPool 1.5.1', '1.6.1'), true)
-    assert.equal(isVersionBelow('LockReleaseTokenPool 1.6.0', '1.6.1'), true)
-    assert.equal(isVersionBelow('LockReleaseTokenPool 1.6.1', '1.6.1'), false)
-    assert.equal(isVersionBelow('BurnMintTokenPool 1.6.10', '1.6.1'), false)
-    assert.equal(isVersionBelow('BurnMintTokenPool 2.0.0', '1.6.1'), false)
-  })
-
-  it('treats an unparseable version as recent', () => {
-    assert.equal(isVersionBelow(undefined, '1.6.1'), false)
-    assert.equal(isVersionBelow('BurnMintTokenPool', '1.6.1'), false)
   })
 })

--- a/ccip-sdk/src/utils.ts
+++ b/ccip-sdk/src/utils.ts
@@ -288,22 +288,53 @@ export function getDataBytes(data: BytesLike | readonly number[]): Uint8Array {
 
 /**
  * Reads the source decimals a source pool declares in its `destPoolData`/`extraData`.
- * Mirrors `TokenPool._parseRemoteDecimals`: only a 32-byte plausible-decimals payload declares
- * them; anything else (absent, short, or a pool-specific payload) means the amount is already
- * in local decimals.
- * @param extraData - The token transfer's `extraData`/`destPoolData`.
- * @returns The declared source decimals, or `undefined`.
+ * Deliberately narrower than `TokenPool._parseRemoteDecimals`, which reverts on a non-empty
+ * non-32-byte payload and accepts any `uint8`: pools that override it (USDC/CCTP, Lombard) put
+ * their own payloads here, so only a 32-byte word in the plausible `0..36` range is read as a
+ * declaration.
+ * @param extraData - The transfer's `extraData`/`destPoolData`.
+ * @returns Declared source decimals, or `undefined` when the amount is already in local decimals.
  */
-export function getSourceDecimalsFromExtraData(extraData?: string): bigint | undefined {
+export function getSourceDecimalsFromExtraData(extraData?: string): number | undefined {
   if (!extraData) return undefined
   try {
     const bytes = getDataBytes(extraData)
     if (bytes.length !== 32) return undefined
     const decimals = toBigInt(bytes)
-    return 0 < decimals && decimals <= 36 ? decimals : undefined
+    // 0 is a legal declaration — 0-decimal tokens exist
+    return 0n <= decimals && decimals <= 36n ? Number(decimals) : undefined
   } catch {
     return undefined
   }
+}
+
+/**
+ * Rescales `amount` from one token's decimals to another's, truncating like the pools do.
+ * @param amount - Amount in `fromDecimals` units.
+ * @param fromDecimals - Decimals `amount` is denominated in.
+ * @param toDecimals - Decimals to convert to.
+ * @returns `amount` in `toDecimals` units.
+ */
+export function scaleDecimals(amount: bigint, fromDecimals: number, toDecimals: number): bigint {
+  if (fromDecimals === toDecimals) return amount
+  return (amount * BigInt(10) ** BigInt(toDecimals)) / BigInt(10) ** BigInt(fromDecimals)
+}
+
+/**
+ * Whether a `typeAndVersion` string's version is below `minVersion`.
+ * @param typeAndVersion - E.g. `'LockReleaseTokenPool 1.6.0'`; an unparseable one reads as not-below.
+ * @param minVersion - Exclusive lower bound, e.g. `'1.6.1'`.
+ * @returns True only when the parsed version is strictly below `minVersion`.
+ */
+export function isVersionBelow(typeAndVersion: string | undefined, minVersion: string): boolean {
+  const found = typeAndVersion?.match(/(\d+)\.(\d+)\.(\d+)/)
+  if (!found) return false
+  const bounds = minVersion.split('.')
+  for (const [i, bound] of bounds.entries()) {
+    const part = Number(found[i + 1])
+    if (part !== Number(bound)) return part < Number(bound)
+  }
+  return false
 }
 
 /**

--- a/ccip-sdk/src/utils.ts
+++ b/ccip-sdk/src/utils.ts
@@ -321,23 +321,6 @@ export function scaleDecimals(amount: bigint, fromDecimals: number, toDecimals: 
 }
 
 /**
- * Whether a `typeAndVersion` string's version is below `minVersion`.
- * @param typeAndVersion - E.g. `'LockReleaseTokenPool 1.6.0'`; an unparseable one reads as not-below.
- * @param minVersion - Exclusive lower bound, e.g. `'1.6.1'`.
- * @returns True only when the parsed version is strictly below `minVersion`.
- */
-export function isVersionBelow(typeAndVersion: string | undefined, minVersion: string): boolean {
-  const found = typeAndVersion?.match(/(\d+)\.(\d+)\.(\d+)/)
-  if (!found) return false
-  const bounds = minVersion.split('.')
-  for (const [i, bound] of bounds.entries()) {
-    const part = Number(found[i + 1])
-    if (part !== Number(bound)) return part < Number(bound)
-  }
-  return false
-}
-
-/**
  * Converts bytes to a Node.js Buffer.
  * @param bytes - Bytes to convert (hex string, Uint8Array, Base64, etc).
  * @returns Node.js Buffer.

--- a/ccip-sdk/src/utils.ts
+++ b/ccip-sdk/src/utils.ts
@@ -287,6 +287,26 @@ export function getDataBytes(data: BytesLike | readonly number[]): Uint8Array {
 }
 
 /**
+ * Reads the source decimals a source pool declares in its `destPoolData`/`extraData`.
+ * Mirrors `TokenPool._parseRemoteDecimals`: only a 32-byte plausible-decimals payload declares
+ * them; anything else (absent, short, or a pool-specific payload) means the amount is already
+ * in local decimals.
+ * @param extraData - The token transfer's `extraData`/`destPoolData`.
+ * @returns The declared source decimals, or `undefined`.
+ */
+export function getSourceDecimalsFromExtraData(extraData?: string): bigint | undefined {
+  if (!extraData) return undefined
+  try {
+    const bytes = getDataBytes(extraData)
+    if (bytes.length !== 32) return undefined
+    const decimals = toBigInt(bytes)
+    return 0 < decimals && decimals <= 36 ? decimals : undefined
+  } catch {
+    return undefined
+  }
+}
+
+/**
  * Converts bytes to a Node.js Buffer.
  * @param bytes - Bytes to convert (hex string, Uint8Array, Base64, etc).
  * @returns Node.js Buffer.


### PR DESCRIPTION
This pull request introduces significant improvements to how token amount denominations are handled across chains, especially when source and destination tokens have differing decimal places. The changes ensure that token amounts are correctly converted and validated according to the token's decimals, preventing silent errors and improving error reporting. Additionally, the codebase is refactored for better test coverage and utility reuse.

**Token denomination handling and validation:**

* Updated `Chain.checkExecute` to convert source-denominated token amounts to destination token decimals before comparing against pool balances and rate limits. This prevents transfers that would result in unrepresentable or zero-value releases on the destination chain. A new error, `CCIPTokenDecimalsInsufficientError`, is thrown if the conversion results in an unrepresentable amount. [[1]](diffhunk://#diff-807a4ca9474665a0a92dd38d0c7b802fa323550a99ef0c98a2ae754be2cd8838L1393-R1462) [[2]](diffhunk://#diff-807a4ca9474665a0a92dd38d0c7b802fa323550a99ef0c98a2ae754be2cd8838R17)
* Refactored the logic for extracting source decimals from `extraData` and for scaling token amounts into utility functions (`getSourceDecimalsFromExtraData`, `scaleDecimals`), and reused these utilities throughout the codebase for consistency. [[1]](diffhunk://#diff-807a4ca9474665a0a92dd38d0c7b802fa323550a99ef0c98a2ae754be2cd8838L66-R74) [[2]](diffhunk://#diff-dc947dd345124b95450aec2428d6a45de93bdeebcfeaa47014612805a8191098L20-R20) [[3]](diffhunk://#diff-dc947dd345124b95450aec2428d6a45de93bdeebcfeaa47014612805a8191098L177-L188) [[4]](diffhunk://#diff-dc947dd345124b95450aec2428d6a45de93bdeebcfeaa47014612805a8191098L234-R222)

**Testing improvements:**

* Added a comprehensive new test suite in `check-execute.test.ts` to verify correct denomination handling, conversion, error reporting, and edge cases (such as zero or mismatched decimals).
* Extended EVM chain tests to verify that denomination conversions are only applied for generic checks and not for on-chain simulations, and clarified test comments for rate-limit behavior. [[1]](diffhunk://#diff-efabde28ff377c08cdfad8f0a886bfab6075757a2f37352edda8df6e5d6e0a54R893-R918) [[2]](diffhunk://#diff-efabde28ff377c08cdfad8f0a886bfab6075757a2f37352edda8df6e5d6e0a54L1001-R1029)

**Error handling and documentation:**

* Improved error context and messaging for rate limit and insufficient balance errors to include both source and destination units, as well as decimal information, aiding in debugging and integration.
* Updated comments and error handling in the EVM chain implementation to clarify when generic checks defer to on-chain simulation for verdicts, and to document the limitations of generic checks for certain pool types and versions.

**Utility and import refactoring:**

* Cleaned up imports and removed redundant local implementations of utility functions, consolidating logic in shared utilities. [[1]](diffhunk://#diff-807a4ca9474665a0a92dd38d0c7b802fa323550a99ef0c98a2ae754be2cd8838L1-R1) [[2]](diffhunk://#diff-807a4ca9474665a0a92dd38d0c7b802fa323550a99ef0c98a2ae754be2cd8838L34-R35) [[3]](diffhunk://#diff-dc947dd345124b95450aec2428d6a45de93bdeebcfeaa47014612805a8191098L1-R1) [[4]](diffhunk://#diff-a5fe9cf02e24c7530c13e210715967b5478159e2f1d8b5006f4db208acc0662cR19-R26)

These changes collectively improve the correctness, maintainability, and reliability of cross-chain token transfers in the SDK.