### PR TITLE
feat(cct-sdk): Add apply chain updates op solana

### DIFF
--- a/ccip-sdk/src/cct/solana/index.test.ts
+++ b/ccip-sdk/src/cct/solana/index.test.ts
@@ -46,6 +46,8 @@ describe('SolanaTokenManager (cct/solana)', () => {
     assert.equal(typeof cct.getSupportedTokens, 'function')
 
     // Token pool operations
+    assert.equal(typeof cct.generateUnsignedAppendRemotePoolAddresses, 'function')
+    assert.equal(typeof cct.appendRemotePoolAddresses, 'function')
     assert.equal(typeof cct.generateUnsignedApplyChainUpdates, 'function')
     assert.equal(typeof cct.applyChainUpdates, 'function')
     assert.equal(typeof cct.generateUnsignedConfigureAllowlist, 'function')

--- a/ccip-sdk/src/cct/solana/index.test.ts
+++ b/ccip-sdk/src/cct/solana/index.test.ts
@@ -46,6 +46,8 @@ describe('SolanaTokenManager (cct/solana)', () => {
     assert.equal(typeof cct.getSupportedTokens, 'function')
 
     // Token pool operations
+    assert.equal(typeof cct.generateUnsignedApplyChainUpdates, 'function')
+    assert.equal(typeof cct.applyChainUpdates, 'function')
     assert.equal(typeof cct.generateUnsignedConfigureAllowlist, 'function')
     assert.equal(typeof cct.configureAllowlist, 'function')
     assert.equal(typeof cct.generateUnsignedCreateTokenMultisig, 'function')

--- a/ccip-sdk/src/cct/solana/index.ts
+++ b/ccip-sdk/src/cct/solana/index.ts
@@ -64,6 +64,8 @@ import {
   type BaseGetTokenPoolStateResult,
   type BurnMintPoolProgramRef,
   type CustomPoolProgramRef,
+  type ExecuteAppendRemotePoolAddressesParams,
+  type ExecuteAppendRemotePoolAddressesResult,
   type ExecuteApplyChainUpdatesParams,
   type ExecuteApplyChainUpdatesResult,
   type ExecuteConfigureAllowlistParams,
@@ -84,6 +86,8 @@ import {
   type ExecuteSetChainRateLimitResult,
   type ExecuteSetRateLimitAdminParams,
   type ExecuteSetRateLimitAdminResult,
+  type GenerateAppendRemotePoolAddressesParams,
+  type GenerateAppendRemotePoolAddressesResult,
   type GenerateApplyChainUpdatesParams,
   type GenerateApplyChainUpdatesResult,
   type GenerateConfigureAllowlistParams,
@@ -108,6 +112,7 @@ import {
   type GetTokenPoolStateResult,
   type LockReleaseGetTokenPoolStateResult,
   type LockReleasePoolProgramRef,
+  AppendRemotePoolAddresses,
   ApplyChainUpdates,
   ConfigureAllowlist,
   CreateTokenMultisig,
@@ -138,6 +143,7 @@ export class SolanaTokenManager extends TokenManager<typeof ChainFamily.Solana> 
   readonly #transferAdmin = new TransferAdmin()
 
   // Token pool operations
+  readonly #appendRemotePoolAddresses = new AppendRemotePoolAddresses()
   readonly #applyChainUpdates = new ApplyChainUpdates()
   readonly #configureAllowlist = new ConfigureAllowlist()
   readonly #createTokenMultisig = new CreateTokenMultisig()
@@ -608,6 +614,76 @@ export class SolanaTokenManager extends TokenManager<typeof ChainFamily.Solana> 
    */
   applyChainUpdates(opts: ExecuteApplyChainUpdatesParams): Promise<ExecuteApplyChainUpdatesResult> {
     return this.#applyChainUpdates.executeBatch(this.chain, opts)
+  }
+
+  /**
+   * Builds an unsigned instruction that appends remote pool addresses to an initialized Solana
+   * token pool remote-chain config. Pass canonical `poolType` or a compatible
+   * `poolProgramAddress`; `authority` defaults to `payer`.
+   *
+   * @remarks `remotePoolAddresses` must be non-empty and contain no duplicates. Existing addresses
+   * are retained. On-chain execution rejects addresses already present. To clear all pools, use
+   * `generateUnsignedEditChainRemoteConfig` with `remotePoolAddresses: []`. The remote-chain config
+   * must already exist.
+   *
+   * @see {@link appendRemotePoolAddresses}
+   * @see {@link generateUnsignedEditChainRemoteConfig}
+   *
+   * @throws {@link CCTParamsInvalidError} If a pool parameter, selector, or remote pool address is invalid.
+   *
+   * @example
+   * ```ts
+   * const cct = SolanaTokenManager.fromChain(chain)
+   * const unsigned = await cct.generateUnsignedAppendRemotePoolAddresses({
+   *   tokenAddress: mint,
+   *   poolType: 'burn-mint',
+   *   remoteChainSelector: 5009297550715157269n,
+   *   remotePoolAddresses: ['0x1234567890abcdef1234567890abcdef12345678'],
+   *   payer,
+   *   authority,
+   * })
+   * ```
+   */
+  generateUnsignedAppendRemotePoolAddresses(
+    opts: GenerateAppendRemotePoolAddressesParams,
+  ): Promise<GenerateAppendRemotePoolAddressesResult> {
+    return this.#appendRemotePoolAddresses.generate(this.chain, opts)
+  }
+
+  /**
+   * Appends remote pool addresses to an initialized Solana token pool remote-chain config with the
+   * pool owner wallet.
+   *
+   * @remarks `remotePoolAddresses` must be non-empty and contain no duplicates. Existing addresses
+   * are retained. The remote-chain config must already exist; addresses already on-chain cause the
+   * transaction to fail. To clear all pools, use `editChainRemoteConfig` with
+   * `remotePoolAddresses: []`.
+   *
+   * @see {@link generateUnsignedAppendRemotePoolAddresses}
+   * @see {@link editChainRemoteConfig}
+   *
+   * @throws {@link CCIPWalletInvalidError} If `wallet` cannot sign Solana transactions.
+   * @throws {@link CCTParamsInvalidError} If a pool parameter or remote pool address is invalid, or
+   * the authority differs from the executing wallet.
+   * @throws {@link CCTTxFailedError} If the chain config does not exist, the wallet is not the pool
+   * owner, an address already exists, or simulation/submission fails.
+   *
+   * @example
+   * ```ts
+   * const cct = SolanaTokenManager.fromChain(chain)
+   * await cct.appendRemotePoolAddresses({
+   *   tokenAddress: mint,
+   *   poolType: 'burn-mint',
+   *   remoteChainSelector: 5009297550715157269n,
+   *   remotePoolAddresses: ['0x1234567890abcdef1234567890abcdef12345678'],
+   *   wallet,
+   * })
+   * ```
+   */
+  appendRemotePoolAddresses(
+    opts: ExecuteAppendRemotePoolAddressesParams,
+  ): Promise<ExecuteAppendRemotePoolAddressesResult> {
+    return this.#appendRemotePoolAddresses.execute(this.chain, opts)
   }
 
   /**

--- a/ccip-sdk/src/cct/solana/index.ts
+++ b/ccip-sdk/src/cct/solana/index.ts
@@ -64,6 +64,8 @@ import {
   type BaseGetTokenPoolStateResult,
   type BurnMintPoolProgramRef,
   type CustomPoolProgramRef,
+  type ExecuteApplyChainUpdatesParams,
+  type ExecuteApplyChainUpdatesResult,
   type ExecuteConfigureAllowlistParams,
   type ExecuteConfigureAllowlistResult,
   type ExecuteCreateTokenMultisigParams,
@@ -82,6 +84,8 @@ import {
   type ExecuteSetChainRateLimitResult,
   type ExecuteSetRateLimitAdminParams,
   type ExecuteSetRateLimitAdminResult,
+  type GenerateApplyChainUpdatesParams,
+  type GenerateApplyChainUpdatesResult,
   type GenerateConfigureAllowlistParams,
   type GenerateConfigureAllowlistResult,
   type GenerateCreateTokenMultisigParams,
@@ -104,6 +108,7 @@ import {
   type GetTokenPoolStateResult,
   type LockReleaseGetTokenPoolStateResult,
   type LockReleasePoolProgramRef,
+  ApplyChainUpdates,
   ConfigureAllowlist,
   CreateTokenMultisig,
   DeleteChainRemoteConfig,
@@ -133,6 +138,7 @@ export class SolanaTokenManager extends TokenManager<typeof ChainFamily.Solana> 
   readonly #transferAdmin = new TransferAdmin()
 
   // Token pool operations
+  readonly #applyChainUpdates = new ApplyChainUpdates()
   readonly #configureAllowlist = new ConfigureAllowlist()
   readonly #createTokenMultisig = new CreateTokenMultisig()
   readonly #deployTokenPool = new DeployTokenPool()
@@ -517,6 +523,88 @@ export class SolanaTokenManager extends TokenManager<typeof ChainFamily.Solana> 
    */
   deployTokenPool(opts: ExecuteDeployTokenPoolParams): Promise<ExecuteDeployTokenPoolResult> {
     return this.#deployTokenPool.execute(this.chain, opts)
+  }
+
+  /**
+   * Builds one unsigned transaction that removes remote-chain configs and adds new configs with
+   * their remote pools and rate limits. This accepts the same `remoteChainSelectorsToRemove` and
+   * `chainsToAdd` parameters as EVM `applyChainUpdates`.
+   *
+   * @remarks Solana preserves EVM ordering with separate instructions: all removals run first,
+   * then each addition is initialized, configured with remote pools, and assigned both rate-limit
+   * configs, including disabled ones. A chain in `chainsToAdd` must not already exist; to replace
+   * one, include its selector in both `remoteChainSelectorsToRemove` and `chainsToAdd`. Solana
+   * additionally requires `remoteTokenDecimals`. Pass canonical `poolType` or a compatible
+   * `poolProgramAddress`; `authority` defaults to `payer`.
+   *
+   * @see {@link applyChainUpdates}
+   *
+   * @throws {@link CCTParamsInvalidError} If a pool parameter or chain update is invalid.
+   *
+   * @example
+   * ```ts
+   * const cct = SolanaTokenManager.fromChain(chain)
+   * const unsigned = await cct.generateUnsignedApplyChainUpdates({
+   *   tokenAddress: mint,
+   *   poolType: 'burn-mint',
+   *   remoteChainSelectorsToRemove: [oldSelector],
+   *   chainsToAdd: [{
+   *     remoteChainSelector: newSelector,
+   *     remoteTokenAddress: '0x1234567890abcdef1234567890abcdef12345678',
+   *     remotePoolAddresses: ['0x1234567890abcdef1234567890abcdef12345678'],
+   *     remoteTokenDecimals: 18,
+   *     inboundRateLimiterConfig: { enabled: false },
+   *     outboundRateLimiterConfig: { enabled: true, capacity: 1_000_000n, rate: 1_000n },
+   *   }],
+   *   payer,
+   *   authority,
+   * })
+   * ```
+   */
+  generateUnsignedApplyChainUpdates(
+    opts: GenerateApplyChainUpdatesParams,
+  ): Promise<GenerateApplyChainUpdatesResult> {
+    return this.#applyChainUpdates.generate(this.chain, opts)
+  }
+
+  /**
+   * Applies EVM-equivalent remote-chain configuration changes with the pool owner wallet.
+   *
+   * @remarks All removals run before additions. Each addition initializes the chain config, sets
+   * remote pools, and applies both rate-limit configs, including disabled configs. To replace an
+   * existing config, include its selector in both `remoteChainSelectorsToRemove` and `chainsToAdd`.
+   * This is atomic: if any instruction fails, none commit. `wallet` is both the fee payer and
+   * default authority; specify `authority` only when it is the same wallet.
+   *
+   * @see {@link generateUnsignedApplyChainUpdates}
+   *
+   * @throws {@link CCIPWalletInvalidError} If `wallet` cannot sign Solana transactions.
+   * @throws {@link CCTParamsInvalidError} If a pool parameter or chain update is invalid, or the
+   * authority differs from the executing wallet.
+   * @throws {@link CCTTxFailedError} If a chain config already exists or is missing, the wallet is
+   * not the pool owner, or simulation/submission fails.
+   *
+   * @example
+   * ```ts
+   * const cct = SolanaTokenManager.fromChain(chain)
+   * await cct.applyChainUpdates({
+   *   tokenAddress: mint,
+   *   poolType: 'burn-mint',
+   *   remoteChainSelectorsToRemove: [],
+   *   chainsToAdd: [{
+   *     remoteChainSelector: selector,
+   *     remoteTokenAddress: '0x1234567890abcdef1234567890abcdef12345678',
+   *     remotePoolAddresses: ['0x1234567890abcdef1234567890abcdef12345678'],
+   *     remoteTokenDecimals: 18,
+   *     inboundRateLimiterConfig: { enabled: false },
+   *     outboundRateLimiterConfig: { enabled: false },
+   *   }],
+   *   wallet,
+   * })
+   * ```
+   */
+  applyChainUpdates(opts: ExecuteApplyChainUpdatesParams): Promise<ExecuteApplyChainUpdatesResult> {
+    return this.#applyChainUpdates.execute(this.chain, opts)
   }
 
   /**

--- a/ccip-sdk/src/cct/solana/index.ts
+++ b/ccip-sdk/src/cct/solana/index.ts
@@ -531,8 +531,8 @@ export class SolanaTokenManager extends TokenManager<typeof ChainFamily.Solana> 
    * `chainsToAdd` parameters as EVM `applyChainUpdates`.
    *
    * @remarks Removals run before additions. Each added chain is initialized, configured, and
-   * rate-limited as one transaction group; groups are packed into as many transactions as needed.
-   * To replace a chain, include its selector in both `remoteChainSelectorsToRemove` and `chainsToAdd`.
+   * rate-limited as one transaction group; returns one or more packed transactions. To replace a
+   * chain, include its selector in both `remoteChainSelectorsToRemove` and `chainsToAdd`.
    * Solana requires `remoteTokenDecimals`. `authority` must be the pool owner and defaults to `payer`.
    *
    * @see {@link applyChainUpdates}
@@ -542,7 +542,7 @@ export class SolanaTokenManager extends TokenManager<typeof ChainFamily.Solana> 
    * @example
    * ```ts
    * const cct = SolanaTokenManager.fromChain(chain)
-   * const unsigned = await cct.generateUnsignedApplyChainUpdates({
+   * const unsignedTxs = await cct.generateUnsignedApplyChainUpdates({
    *   tokenAddress: mint,
    *   poolType: 'burn-mint',
    *   remoteChainSelectorsToRemove: [oldSelector],
@@ -557,6 +557,10 @@ export class SolanaTokenManager extends TokenManager<typeof ChainFamily.Solana> 
    *   payer,
    *   authority,
    * })
+   *
+   * for (const unsignedTx of unsignedTxs) {
+   *   // Sign and submit each transaction in order.
+   * }
    * ```
    */
   generateUnsignedApplyChainUpdates(

--- a/ccip-sdk/src/cct/solana/index.ts
+++ b/ccip-sdk/src/cct/solana/index.ts
@@ -526,16 +526,14 @@ export class SolanaTokenManager extends TokenManager<typeof ChainFamily.Solana> 
   }
 
   /**
-   * Builds one unsigned transaction that removes remote-chain configs and adds new configs with
+   * Builds ordered unsigned transactions that remove remote-chain configs and add new configs with
    * their remote pools and rate limits. This accepts the same `remoteChainSelectorsToRemove` and
    * `chainsToAdd` parameters as EVM `applyChainUpdates`.
    *
-   * @remarks Solana preserves EVM ordering with separate instructions: all removals run first,
-   * then each addition is initialized, configured with remote pools, and assigned both rate-limit
-   * configs, including disabled ones. A chain in `chainsToAdd` must not already exist; to replace
-   * one, include its selector in both `remoteChainSelectorsToRemove` and `chainsToAdd`. Solana
-   * additionally requires `remoteTokenDecimals`. Pass canonical `poolType` or a compatible
-   * `poolProgramAddress`; `authority` defaults to `payer`.
+   * @remarks Removals run before additions. Each added chain is initialized, configured, and
+   * rate-limited as one transaction group; groups are packed into as many transactions as needed.
+   * To replace a chain, include its selector in both `remoteChainSelectorsToRemove` and `chainsToAdd`.
+   * Solana requires `remoteTokenDecimals`. `authority` must be the pool owner and defaults to `payer`.
    *
    * @see {@link applyChainUpdates}
    *
@@ -564,17 +562,18 @@ export class SolanaTokenManager extends TokenManager<typeof ChainFamily.Solana> 
   generateUnsignedApplyChainUpdates(
     opts: GenerateApplyChainUpdatesParams,
   ): Promise<GenerateApplyChainUpdatesResult> {
-    return this.#applyChainUpdates.generate(this.chain, opts)
+    return this.#applyChainUpdates.generateBatch(this.chain, opts)
   }
 
   /**
    * Applies EVM-equivalent remote-chain configuration changes with the pool owner wallet.
    *
-   * @remarks All removals run before additions. Each addition initializes the chain config, sets
-   * remote pools, and applies both rate-limit configs, including disabled configs. To replace an
-   * existing config, include its selector in both `remoteChainSelectorsToRemove` and `chainsToAdd`.
-   * This is atomic: if any instruction fails, none commit. `wallet` is both the fee payer and
-   * default authority; specify `authority` only when it is the same wallet.
+   * @remarks Removals run before additions. Each added chain is initialized, configured, and
+   * rate-limited as one transaction group. Groups are submitted sequentially and are not atomic;
+   * if a later transaction fails, earlier groups may already be committed. The result contains every
+   * transaction hash. To replace a chain, include its selector in both `remoteChainSelectorsToRemove`
+   * and `chainsToAdd`. `wallet` must be the
+   * pool owner and is the fee payer and default authority.
    *
    * @see {@link generateUnsignedApplyChainUpdates}
    *
@@ -604,7 +603,7 @@ export class SolanaTokenManager extends TokenManager<typeof ChainFamily.Solana> 
    * ```
    */
   applyChainUpdates(opts: ExecuteApplyChainUpdatesParams): Promise<ExecuteApplyChainUpdatesResult> {
-    return this.#applyChainUpdates.execute(this.chain, opts)
+    return this.#applyChainUpdates.executeBatch(this.chain, opts)
   }
 
   /**

--- a/ccip-sdk/src/cct/solana/token-pool/operations/append-remote-pool-addresses.test.ts
+++ b/ccip-sdk/src/cct/solana/token-pool/operations/append-remote-pool-addresses.test.ts
@@ -18,7 +18,6 @@ const TOKEN = Keypair.generate().publicKey.toBase58()
 const PAYER = Keypair.generate().publicKey.toBase58()
 const AUTHORITY = Keypair.generate().publicKey.toBase58()
 const SELECTOR = 5009297550715157269n
-const REMOTE_TOKEN = '0x1234567890abcdef1234567890abcdef12345678'
 const REMOTE_POOLS = ['0x1234567890abcdef1234567890abcdef12345678', '0xaabbccdd']
 const HASH = Keypair.generate().publicKey.toBase58()
 const WALLET = {
@@ -49,22 +48,20 @@ function submitChain(): SolanaChain {
 }
 
 function generate(opts = {}) {
-  return SolanaTokenManager.fromChain(chain()).generateUnsignedEditChainRemoteConfig({
+  return SolanaTokenManager.fromChain(chain()).generateUnsignedAppendRemotePoolAddresses({
     tokenAddress: TOKEN,
     poolType: 'burn-mint',
     payer: PAYER,
     authority: AUTHORITY,
     remoteChainSelector: SELECTOR,
-    remoteTokenAddress: REMOTE_TOKEN,
     remotePoolAddresses: REMOTE_POOLS,
-    remoteTokenDecimals: 18,
     ...opts,
   })
 }
 
-describe('EditChainRemoteConfig (cct/solana)', () => {
+describe('AppendRemotePoolAddresses (cct/solana)', () => {
   describe('generate', () => {
-    it('builds a padded remote-token config with remote pools', async () => {
+    it('builds the append-remote-pool-addresses instruction', async () => {
       const unsigned = await generate()
       const [instruction] = unsigned.instructions
       const poolProgram = resolveTokenPoolProgram('burn-mint')
@@ -99,29 +96,18 @@ describe('EditChainRemoteConfig (cct/solana)', () => {
         ],
       )
       assert.ok(decoded)
-      assert.equal(decoded.name, 'editChainRemoteConfig')
+      assert.equal(decoded.name, 'appendRemotePoolAddresses')
       const data = decoded.data as {
         remoteChainSelector: { toString(): string }
-        cfg: {
-          tokenAddress: { address: Buffer }
-          poolAddresses: { address: Buffer }[]
-          decimals: number
-        }
+        mint: PublicKey
+        addresses: { address: Buffer }[]
       }
       assert.equal(data.remoteChainSelector.toString(), SELECTOR.toString())
+      assert.equal(data.mint.toBase58(), TOKEN)
       assert.deepEqual(
-        data.cfg.tokenAddress.address,
-        Buffer.from(REMOTE_TOKEN.slice(2).padStart(64, '0'), 'hex'),
-      )
-      assert.deepEqual(
-        data.cfg.poolAddresses.map(({ address }) => address),
+        data.addresses.map(({ address }) => address),
         REMOTE_POOLS.map((address) => Buffer.from(address.slice(2), 'hex')),
       )
-      assert.equal(data.cfg.decimals, 18)
-    })
-
-    it('supports a zero remote-chain selector', async () => {
-      await assert.doesNotReject(() => generate({ remoteChainSelector: 0n }))
     })
 
     it('uses a compatible custom pool program', async () => {
@@ -133,16 +119,16 @@ describe('EditChainRemoteConfig (cct/solana)', () => {
   })
 
   describe('validation', () => {
-    it('rejects invalid remote configuration values', async () => {
+    it('rejects invalid remote pool addresses', async () => {
       for (const [opts, param] of [
         [{ remoteChainSelector: 1 }, 'remoteChainSelector'],
         [{ remoteChainSelector: -1n }, 'remoteChainSelector'],
         [{ remoteChainSelector: 1n << 64n }, 'remoteChainSelector'],
-        [{ remoteTokenAddress: '0x123' }, 'remoteTokenAddress'],
+        [{ remotePoolAddresses: [] }, 'remotePoolAddresses'],
         [{ remotePoolAddresses: [''] }, 'remotePoolAddresses[0]'],
         [{ remotePoolAddresses: ['0x123'] }, 'remotePoolAddresses[0]'],
+        [{ remotePoolAddresses: ['0xaabbccdd', 'aabbccdd'] }, 'remotePoolAddresses[1]'],
         [{ remotePoolAddresses: '0x12' }, 'remotePoolAddresses'],
-        [{ remoteTokenDecimals: 256 }, 'remoteTokenDecimals'],
       ] as const) {
         await assert.rejects(
           () => generate(opts),
@@ -154,35 +140,31 @@ describe('EditChainRemoteConfig (cct/solana)', () => {
 
   describe('execute', () => {
     it('signs, submits, and returns the tx hash', async () => {
-      const result = await SolanaTokenManager.fromChain(submitChain()).editChainRemoteConfig({
+      const result = await SolanaTokenManager.fromChain(submitChain()).appendRemotePoolAddresses({
         tokenAddress: TOKEN,
         poolType: 'burn-mint',
         remoteChainSelector: SELECTOR,
-        remoteTokenAddress: REMOTE_TOKEN,
         remotePoolAddresses: REMOTE_POOLS,
-        remoteTokenDecimals: 18,
         wallet: WALLET,
       })
 
       assert.deepEqual(result, { hash: HASH })
     })
 
-    it('rejects a non-wallet authority for signed editing', async () => {
+    it('rejects a non-wallet authority for signed appending', async () => {
       await assert.rejects(
         () =>
-          SolanaTokenManager.fromChain(chain()).editChainRemoteConfig({
+          SolanaTokenManager.fromChain(chain()).appendRemotePoolAddresses({
             tokenAddress: TOKEN,
             poolType: 'burn-mint',
             authority: AUTHORITY,
             remoteChainSelector: SELECTOR,
-            remoteTokenAddress: REMOTE_TOKEN,
             remotePoolAddresses: REMOTE_POOLS,
-            remoteTokenDecimals: 18,
             wallet: WALLET,
           }),
         (err: unknown) =>
           err instanceof CCTParamsInvalidError &&
-          err.context.operation === 'editChainRemoteConfig' &&
+          err.context.operation === 'appendRemotePoolAddresses' &&
           err.context.param === 'authority',
       )
     })

--- a/ccip-sdk/src/cct/solana/token-pool/operations/append-remote-pool-addresses.ts
+++ b/ccip-sdk/src/cct/solana/token-pool/operations/append-remote-pool-addresses.ts
@@ -1,0 +1,174 @@
+import type { Buffer } from 'buffer'
+
+import { type PublicKey, SystemProgram } from '@solana/web3.js'
+import BN from 'bn.js'
+
+import { ChainFamily } from '../../../../networks.ts'
+import type { SolanaChain } from '../../../../solana/index.ts'
+import type { UnsignedSolanaTx } from '../../../../solana/types.ts'
+import { CCTParamsInvalidError } from '../../../errors.ts'
+import type { TransactionResult } from '../../../operation.ts'
+import {
+  type SolanaExecuteParams,
+  type SolanaGenerateParams,
+  SolanaOperation,
+} from '../../operation.ts'
+import {
+  type PoolProgramRef,
+  createTokenPoolProgram,
+  deriveTokenPoolChainConfigPda,
+  deriveTokenPoolConfigPda,
+} from '../../programs/token-pool.ts'
+import { submit } from '../../submit.ts'
+import {
+  U64_MAX,
+  parseNonEmptyHexBytes,
+  parsePublicKey,
+  resolvePoolProgram,
+  validateAuthorityMatchesWallet,
+  validateBigInt,
+} from '../../validate.ts'
+
+/** Parameters shared by Solana remote pool address appending generation and execution. */
+type AppendRemotePoolAddressesParams = PoolProgramRef & {
+  /** Token mint address managed by the local pool. */
+  tokenAddress: string
+  /** CCIP selector of the remote chain (`u64`). */
+  remoteChainSelector: bigint
+  /**
+   * Non-empty array of non-empty hex-encoded remote pool addresses, optionally `0x`-prefixed.
+   * Stored at native byte length; unlike `remoteTokenAddress`, not left-padded to 32 bytes.
+   */
+  remotePoolAddresses: string[]
+  /** Pool owner. Defaults to `payer` for single-signer transactions. */
+  authority?: string
+}
+
+type ParsedAppendRemotePoolAddressesParams = {
+  tokenAddress: PublicKey
+  poolProgram: PublicKey
+  payer: PublicKey
+  authority: PublicKey
+  remoteChainSelector: bigint
+  remotePoolAddresses: Buffer[]
+}
+
+/** Parameters for unsigned Solana remote pool address appending. */
+export type GenerateAppendRemotePoolAddressesParams =
+  SolanaGenerateParams<AppendRemotePoolAddressesParams>
+
+/** Unsigned Solana remote pool address appending result. */
+export type GenerateAppendRemotePoolAddressesResult = UnsignedSolanaTx
+
+/** Parameters for executing Solana remote pool address appending. */
+export type ExecuteAppendRemotePoolAddressesParams =
+  SolanaExecuteParams<AppendRemotePoolAddressesParams>
+
+/** Result of executing Solana remote pool address appending. */
+export type ExecuteAppendRemotePoolAddressesResult = TransactionResult
+
+/**
+ * Appends remote pool addresses to an initialized remote-chain config.
+ *
+ * @remarks Existing addresses are retained. The remote-chain config must already exist. The pool
+ * rejects addresses already present; duplicate addresses in this request are rejected. To clear
+ * all pools, use `editChainRemoteConfig` with `remotePoolAddresses: []`.
+ */
+export class AppendRemotePoolAddresses extends SolanaOperation<
+  AppendRemotePoolAddressesParams,
+  UnsignedSolanaTx,
+  ParsedAppendRemotePoolAddressesParams
+> {
+  readonly name = 'appendRemotePoolAddresses'
+
+  /** Parses addresses and defaults authority to payer without mutating caller params. */
+  protected override parse(
+    params: GenerateAppendRemotePoolAddressesParams,
+  ): ParsedAppendRemotePoolAddressesParams {
+    validateBigInt(this.name, 'remoteChainSelector', params.remoteChainSelector, 0n, U64_MAX)
+
+    if (!Array.isArray(params.remotePoolAddresses) || params.remotePoolAddresses.length === 0) {
+      throw new CCTParamsInvalidError(this.name, 'remotePoolAddresses', 'must be a non-empty array')
+    }
+
+    const remotePoolAddresses = params.remotePoolAddresses.map((address, i) =>
+      parseNonEmptyHexBytes(this.name, `remotePoolAddresses[${i}]`, address),
+    )
+    const seen = new Set<string>()
+
+    for (const [i, address] of remotePoolAddresses.entries()) {
+      const hex = address.toString('hex')
+      if (seen.has(hex)) {
+        throw new CCTParamsInvalidError(
+          this.name,
+          `remotePoolAddresses[${i}]`,
+          'must not duplicate a remote pool address',
+        )
+      }
+      seen.add(hex)
+    }
+
+    const payer = parsePublicKey(this.name, 'payer', params.payer)
+    return {
+      tokenAddress: parsePublicKey(this.name, 'tokenAddress', params.tokenAddress),
+      poolProgram: resolvePoolProgram(this.name, params),
+      payer,
+      authority:
+        params.authority === undefined
+          ? payer
+          : parsePublicKey(this.name, 'authority', params.authority),
+      remoteChainSelector: params.remoteChainSelector,
+      remotePoolAddresses,
+    }
+  }
+
+  /** Builds the unsigned Solana `appendRemotePoolAddresses` instruction. */
+  protected async buildUnsigned(
+    chain: SolanaChain,
+    opts: ParsedAppendRemotePoolAddressesParams,
+  ): Promise<UnsignedSolanaTx> {
+    const program = createTokenPoolProgram(chain, opts.poolProgram, opts.payer)
+    const instruction = await program.methods
+      .appendRemotePoolAddresses(
+        new BN(opts.remoteChainSelector.toString()),
+        opts.tokenAddress,
+        opts.remotePoolAddresses.map((address) => ({ address })),
+      )
+      .accountsStrict({
+        state: deriveTokenPoolConfigPda(opts.poolProgram, opts.tokenAddress),
+        chainConfig: deriveTokenPoolChainConfigPda(
+          opts.poolProgram,
+          opts.remoteChainSelector,
+          opts.tokenAddress,
+        ),
+        authority: opts.authority,
+        systemProgram: SystemProgram.programId,
+      })
+      .instruction()
+
+    chain.logger.debug(
+      `${this.name}: token = ${opts.tokenAddress.toBase58()}, poolProgram = ${opts.poolProgram.toBase58()}, remoteChainSelector = ${opts.remoteChainSelector}`,
+    )
+
+    return { family: ChainFamily.Solana, instructions: [instruction], mainIndex: 0 }
+  }
+
+  /** Generate, sign, simulate, send, and confirm with the pool owner wallet. */
+  override async execute(
+    chain: SolanaChain,
+    params: ExecuteAppendRemotePoolAddressesParams,
+  ): Promise<ExecuteAppendRemotePoolAddressesResult> {
+    const { wallet, computeUnits, parsed } = this.prepareWalletExecution(params)
+
+    if (params.authority !== undefined) {
+      validateAuthorityMatchesWallet(
+        this.name,
+        parsed.authority,
+        wallet.publicKey,
+        'appendRemotePoolAddresses requires authority to be the executing wallet. Use generateUnsignedAppendRemotePoolAddresses for externally signed transactions.',
+      )
+    }
+
+    return submit(chain, wallet, await this.buildUnsigned(chain, parsed), this.name, computeUnits)
+  }
+}

--- a/ccip-sdk/src/cct/solana/token-pool/operations/apply-chain-updates.test.ts
+++ b/ccip-sdk/src/cct/solana/token-pool/operations/apply-chain-updates.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from 'node:test'
 
 import { Keypair, PublicKey } from '@solana/web3.js'
 
+import { CCIPError } from '../../../../errors/index.ts'
 import { ChainFamily } from '../../../../networks.ts'
 import { tokenPoolCoder } from '../../../../solana/idl/token-pool-coder.ts'
 import type { SolanaChain } from '../../../../solana/index.ts'
@@ -208,7 +209,9 @@ describe('ApplyChainUpdates (cct/solana)', () => {
             ],
           }),
         (err: unknown) =>
-          err instanceof CCTParamsInvalidError && err.context.param === 'chainsToAdd',
+          err instanceof CCTParamsInvalidError &&
+          err.context.param === 'chainsToAdd' &&
+          err.message.includes('chain selector 0x3 (30 remote pool addresses)'),
       )
     })
 
@@ -355,7 +358,7 @@ describe('ApplyChainUpdates (cct/solana)', () => {
         wallet: WALLET,
       })
 
-      assert.deepEqual(result, { hashes: [HASH] })
+      assert.deepEqual(result, { hashes: [HASH], chainSelectors: [[`0x${SELECTOR.toString(16)}`]] })
     })
 
     it('submits every safely packed batch and returns all hashes', async () => {
@@ -367,7 +370,37 @@ describe('ApplyChainUpdates (cct/solana)', () => {
         wallet: WALLET,
       })
 
-      assert.deepEqual(result, { hashes: [HASH, HASH] })
+      assert.deepEqual(result, { hashes: [HASH, HASH], chainSelectors: [['0x3', '0x4'], ['0x5']] })
+    })
+
+    it('attaches committed hashes when a later batch fails', async () => {
+      let simulations = 0
+      const failedChain = submitChain()
+      failedChain.connection.simulateTransaction = (async () => {
+        simulations++
+        return {
+          value: { err: simulations >= 2 ? { custom: 1 } : null, logs: [], unitsConsumed: 1 },
+        }
+      }) as never
+
+      await assert.rejects(
+        () =>
+          SolanaTokenManager.fromChain(failedChain).applyChainUpdates({
+            tokenAddress: TOKEN,
+            poolType: 'burn-mint',
+            remoteChainSelectorsToRemove: [],
+            chainsToAdd: batchChains(),
+            wallet: WALLET,
+          }),
+        (error: unknown) =>
+          CCIPError.isCCIPError(error) &&
+          error.context.committedHashes instanceof Array &&
+          error.context.committedHashes[0] === HASH &&
+          error.context.committedChainSelectors instanceof Array &&
+          error.context.committedChainSelectors[0]?.join() === '0x3,0x4' &&
+          error.context.failedBatchIndex === 1 &&
+          error.context.totalBatches === 2,
+      )
     })
 
     it('rejects a non-wallet authority for signed configuration', async () => {

--- a/ccip-sdk/src/cct/solana/token-pool/operations/apply-chain-updates.test.ts
+++ b/ccip-sdk/src/cct/solana/token-pool/operations/apply-chain-updates.test.ts
@@ -1,0 +1,251 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import { Keypair, PublicKey } from '@solana/web3.js'
+
+import { ChainFamily } from '../../../../networks.ts'
+import { tokenPoolCoder } from '../../../../solana/idl/token-pool-coder.ts'
+import type { SolanaChain } from '../../../../solana/index.ts'
+import { CCTParamsInvalidError } from '../../../errors.ts'
+import { SolanaTokenManager } from '../../index.ts'
+import { resolveTokenPoolProgram } from '../../programs/token-pool.ts'
+
+const TOKEN = Keypair.generate().publicKey.toBase58()
+const PAYER = Keypair.generate().publicKey.toBase58()
+const AUTHORITY = Keypair.generate().publicKey.toBase58()
+const SELECTOR = 5009297550715157269n
+const HASH = Keypair.generate().publicKey.toBase58()
+const WALLET = {
+  publicKey: Keypair.generate().publicKey,
+  signTransaction: async <T>(tx: T) => tx,
+}
+
+function chain(): SolanaChain {
+  return {
+    logger: { debug() {}, info() {}, warn() {}, error() {} },
+    connection: {},
+  } as unknown as SolanaChain
+}
+
+function submitChain(): SolanaChain {
+  return {
+    ...chain(),
+    connection: {
+      simulateTransaction: async () => ({ value: { err: null, logs: [], unitsConsumed: 1 } }),
+      getLatestBlockhash: async () => ({
+        blockhash: PublicKey.default.toBase58(),
+        lastValidBlockHeight: 1,
+      }),
+      sendTransaction: async () => HASH,
+      confirmTransaction: async () => ({ value: { err: null } }),
+    },
+  } as unknown as SolanaChain
+}
+
+function generate(opts = {}) {
+  return SolanaTokenManager.fromChain(chain()).generateUnsignedApplyChainUpdates({
+    tokenAddress: TOKEN,
+    poolType: 'burn-mint',
+    payer: PAYER,
+    authority: AUTHORITY,
+    remoteChainSelectorsToRemove: [SELECTOR],
+    chainsToAdd: [
+      {
+        remoteChainSelector: SELECTOR,
+        remoteTokenAddress: '0x1234567890abcdef1234567890abcdef12345678',
+        remotePoolAddresses: ['0x1234567890abcdef1234567890abcdef12345678'],
+        remoteTokenDecimals: 18,
+        inboundRateLimiterConfig: { enabled: false },
+        outboundRateLimiterConfig: { enabled: true, capacity: 100n, rate: 10n },
+      },
+    ],
+    ...opts,
+  })
+}
+
+describe('ApplyChainUpdates (cct/solana)', () => {
+  describe('generate', () => {
+    it('builds delete, initialize, edit, and rate-limit instructions', async () => {
+      const unsigned = await generate()
+      const poolProgram = resolveTokenPoolProgram('burn-mint')
+
+      assert.equal(unsigned.family, ChainFamily.Solana)
+      assert.equal(unsigned.mainIndex, 0)
+      assert.ok(unsigned.instructions.every(({ programId }) => programId.equals(poolProgram)))
+      assert.deepEqual(
+        unsigned.instructions.map(
+          (instruction) => tokenPoolCoder.instruction.decode(instruction.data)!.name,
+        ),
+        [
+          'deleteChainConfig',
+          'initChainRemoteConfig',
+          'editChainRemoteConfig',
+          'setChainRateLimit',
+        ],
+      )
+    })
+
+    it('sets disabled rate-limit configs like EVM applyChainUpdates', async () => {
+      const unsigned = await generate({
+        remoteChainSelectorsToRemove: [],
+        chainsToAdd: [
+          {
+            remoteChainSelector: SELECTOR,
+            remoteTokenAddress: '0x1234567890abcdef1234567890abcdef12345678',
+            remotePoolAddresses: ['0x1234567890abcdef1234567890abcdef12345678'],
+            remoteTokenDecimals: 18,
+            inboundRateLimiterConfig: { enabled: false },
+            outboundRateLimiterConfig: { enabled: false },
+          },
+        ],
+      })
+
+      const decoded = tokenPoolCoder.instruction.decode(unsigned.instructions[2]!.data)
+
+      assert.equal(unsigned.instructions.length, 3)
+      assert.ok(decoded)
+      assert.equal(decoded.name, 'setChainRateLimit')
+    })
+
+    it('uses a compatible custom pool program', async () => {
+      const poolProgramAddress = Keypair.generate().publicKey.toBase58()
+      const unsigned = await generate({ poolType: undefined, poolProgramAddress })
+
+      assert.ok(
+        unsigned.instructions.every(({ programId }) => programId.toBase58() === poolProgramAddress),
+      )
+    })
+  })
+
+  describe('validation', () => {
+    it('rejects invalid chain updates', async () => {
+      for (const [opts, param] of [
+        [{ remoteChainSelectorsToRemove: null }, 'remoteChainSelectorsToRemove'],
+        [{ remoteChainSelectorsToRemove: [-1n] }, 'remoteChainSelector'],
+        [{ chainsToAdd: null }, 'chainsToAdd'],
+        [{ chainsToAdd: [null] }, 'chainsToAdd[0]'],
+        [
+          {
+            chainsToAdd: [
+              {
+                remoteChainSelector: SELECTOR,
+                remoteTokenAddress: '0x1234567890abcdef1234567890abcdef12345678',
+                remotePoolAddresses: [],
+                remoteTokenDecimals: 256,
+                inboundRateLimiterConfig: { enabled: false },
+                outboundRateLimiterConfig: { enabled: false },
+              },
+            ],
+          },
+          'remoteTokenDecimals',
+        ],
+        [
+          {
+            chainsToAdd: [
+              {
+                remoteChainSelector: SELECTOR,
+                remoteTokenAddress: '0x1234567890abcdef1234567890abcdef12345678',
+                remotePoolAddresses: null,
+                remoteTokenDecimals: 18,
+                inboundRateLimiterConfig: { enabled: false },
+                outboundRateLimiterConfig: { enabled: false },
+              },
+            ],
+          },
+          'remotePoolAddresses',
+        ],
+        [
+          {
+            chainsToAdd: [
+              {
+                remoteChainSelector: SELECTOR,
+                remoteTokenAddress: '0x1234567890abcdef1234567890abcdef12345678',
+                remotePoolAddresses: ['0x'],
+                remoteTokenDecimals: 18,
+                inboundRateLimiterConfig: { enabled: false },
+                outboundRateLimiterConfig: { enabled: false },
+              },
+            ],
+          },
+          'chainsToAdd[0].remotePoolAddresses[0]',
+        ],
+        [
+          {
+            chainsToAdd: [
+              {
+                remoteChainSelector: SELECTOR,
+                remoteTokenAddress: '0x1234567890abcdef1234567890abcdef12345678',
+                remotePoolAddresses: ['0x1234', '0x1234'],
+                remoteTokenDecimals: 18,
+                inboundRateLimiterConfig: { enabled: false },
+                outboundRateLimiterConfig: { enabled: false },
+              },
+            ],
+          },
+          'chainsToAdd[0].remotePoolAddresses[1]',
+        ],
+        [
+          {
+            chainsToAdd: [
+              {
+                remoteChainSelector: SELECTOR,
+                remoteTokenAddress: '0x1234567890abcdef1234567890abcdef12345678',
+                remotePoolAddresses: [],
+                remoteTokenDecimals: 18,
+                inboundRateLimiterConfig: { enabled: false, capacity: 1n, rate: 0n },
+                outboundRateLimiterConfig: { enabled: false },
+              },
+            ],
+          },
+          'inbound',
+        ],
+      ] as const) {
+        await assert.rejects(
+          () => generate(opts),
+          (err: unknown) => err instanceof CCTParamsInvalidError && err.context.param === param,
+        )
+      }
+    })
+  })
+
+  describe('execute', () => {
+    it('signs, submits, and returns the tx hash', async () => {
+      const result = await SolanaTokenManager.fromChain(submitChain()).applyChainUpdates({
+        tokenAddress: TOKEN,
+        poolType: 'burn-mint',
+        remoteChainSelectorsToRemove: [SELECTOR],
+        chainsToAdd: [
+          {
+            remoteChainSelector: SELECTOR,
+            remoteTokenAddress: '0x1234567890abcdef1234567890abcdef12345678',
+            remotePoolAddresses: ['0x1234567890abcdef1234567890abcdef12345678'],
+            remoteTokenDecimals: 18,
+            inboundRateLimiterConfig: { enabled: false },
+            outboundRateLimiterConfig: { enabled: true, capacity: 100n, rate: 10n },
+          },
+        ],
+        wallet: WALLET,
+      })
+
+      assert.deepEqual(result, { hash: HASH })
+    })
+
+    it('rejects a non-wallet authority for signed configuration', async () => {
+      await assert.rejects(
+        () =>
+          SolanaTokenManager.fromChain(chain()).applyChainUpdates({
+            tokenAddress: TOKEN,
+            poolType: 'burn-mint',
+            authority: AUTHORITY,
+            remoteChainSelectorsToRemove: [],
+            chainsToAdd: [],
+            wallet: WALLET,
+          }),
+        (err: unknown) =>
+          err instanceof CCTParamsInvalidError &&
+          err.context.operation === 'applyChainUpdates' &&
+          err.context.param === 'authority',
+      )
+    })
+  })
+})

--- a/ccip-sdk/src/cct/solana/token-pool/operations/apply-chain-updates.test.ts
+++ b/ccip-sdk/src/cct/solana/token-pool/operations/apply-chain-updates.test.ts
@@ -42,7 +42,18 @@ function submitChain(): SolanaChain {
   } as unknown as SolanaChain
 }
 
-function generate(opts = {}) {
+function batchChains() {
+  return [3n, 4n, 5n].map((remoteChainSelector, i) => ({
+    remoteChainSelector,
+    remoteTokenAddress: `0x${(i + 1).toString(16).padStart(40, '0')}`,
+    remotePoolAddresses: [`0x${(i + 11).toString(16).padStart(40, '0')}`],
+    remoteTokenDecimals: 6 + i,
+    inboundRateLimiterConfig: { enabled: false as const },
+    outboundRateLimiterConfig: { enabled: true as const, capacity: 100n, rate: 10n },
+  }))
+}
+
+function generateBatches(opts = {}) {
   return SolanaTokenManager.fromChain(chain()).generateUnsignedApplyChainUpdates({
     tokenAddress: TOKEN,
     poolType: 'burn-mint',
@@ -61,6 +72,11 @@ function generate(opts = {}) {
     ],
     ...opts,
   })
+}
+
+async function generate(opts = {}) {
+  const [unsigned] = await generateBatches(opts)
+  return unsigned!
 }
 
 describe('ApplyChainUpdates (cct/solana)', () => {
@@ -82,6 +98,117 @@ describe('ApplyChainUpdates (cct/solana)', () => {
           'editChainRemoteConfig',
           'setChainRateLimit',
         ],
+      )
+    })
+
+    it('builds delete, then per-chain init, edit, and rate-limit instructions for multiple chains', async () => {
+      const batches = await generateBatches({
+        remoteChainSelectorsToRemove: [1n, 2n],
+        chainsToAdd: [
+          {
+            remoteChainSelector: 3n,
+            remoteTokenAddress: '0x1234567890abcdef1234567890abcdef12345678',
+            remotePoolAddresses: ['0x1234567890abcdef1234567890abcdef12345678'],
+            remoteTokenDecimals: 18,
+            inboundRateLimiterConfig: { enabled: false },
+            outboundRateLimiterConfig: { enabled: true, capacity: 100n, rate: 10n },
+          },
+          {
+            remoteChainSelector: 4n,
+            remoteTokenAddress: '0xaabbccddeeff00112233445566778899aabbccdd',
+            remotePoolAddresses: [],
+            remoteTokenDecimals: 6,
+            inboundRateLimiterConfig: { enabled: true, capacity: 200n, rate: 20n },
+            outboundRateLimiterConfig: { enabled: false },
+          },
+          {
+            remoteChainSelector: 5n,
+            remoteTokenAddress: '0x11223344556677889900aabbccddeeff00112233',
+            remotePoolAddresses: ['0x1234', '0xabcd'],
+            remoteTokenDecimals: 8,
+            inboundRateLimiterConfig: { enabled: true, capacity: 5_000n, rate: 50n },
+            outboundRateLimiterConfig: { enabled: false },
+          },
+        ],
+      })
+
+      assert.deepEqual(
+        batches.flatMap((batch) =>
+          batch.instructions.map(
+            (instruction) => tokenPoolCoder.instruction.decode(instruction.data)!.name,
+          ),
+        ),
+        [
+          'deleteChainConfig',
+          'deleteChainConfig',
+          'initChainRemoteConfig',
+          'editChainRemoteConfig',
+          'setChainRateLimit',
+          'initChainRemoteConfig',
+          'editChainRemoteConfig',
+          'setChainRateLimit',
+          'initChainRemoteConfig',
+          'editChainRemoteConfig',
+          'setChainRateLimit',
+        ],
+      )
+    })
+
+    it('packs large updates without splitting a chain instruction group', async () => {
+      const batches = await SolanaTokenManager.fromChain(chain()).generateUnsignedApplyChainUpdates(
+        {
+          tokenAddress: TOKEN,
+          poolType: 'burn-mint',
+          payer: PAYER,
+          authority: AUTHORITY,
+          remoteChainSelectorsToRemove: [],
+          chainsToAdd: batchChains(),
+        },
+      )
+
+      assert.equal(batches.length, 2)
+      assert.deepEqual(
+        batches.flatMap((batch) =>
+          batch.instructions.map(
+            (instruction) => tokenPoolCoder.instruction.decode(instruction.data)!.name,
+          ),
+        ),
+        [
+          'initChainRemoteConfig',
+          'editChainRemoteConfig',
+          'setChainRateLimit',
+          'initChainRemoteConfig',
+          'editChainRemoteConfig',
+          'setChainRateLimit',
+          'initChainRemoteConfig',
+          'editChainRemoteConfig',
+          'setChainRateLimit',
+        ],
+      )
+      assert.ok(batches.every((batch) => batch.instructions.length % 3 === 0))
+    })
+
+    it('rejects a chain update that cannot fit one transaction', async () => {
+      await assert.rejects(
+        () =>
+          SolanaTokenManager.fromChain(chain()).generateUnsignedApplyChainUpdates({
+            tokenAddress: TOKEN,
+            poolType: 'burn-mint',
+            payer: PAYER,
+            authority: AUTHORITY,
+            remoteChainSelectorsToRemove: [],
+            chainsToAdd: [
+              {
+                ...batchChains()[0]!,
+                remotePoolAddresses: Array.from(
+                  { length: 30 },
+                  (_, i) => `0x${(i + 1).toString(16).padStart(40, '0')}`,
+                ),
+              },
+            ],
+          }),
+        (err: unknown) =>
+          err instanceof CCTParamsInvalidError && err.context.param === 'chainsToAdd',
       )
     })
 
@@ -123,6 +250,7 @@ describe('ApplyChainUpdates (cct/solana)', () => {
         [{ remoteChainSelectorsToRemove: null }, 'remoteChainSelectorsToRemove'],
         [{ remoteChainSelectorsToRemove: [-1n] }, 'remoteChainSelector'],
         [{ chainsToAdd: null }, 'chainsToAdd'],
+        [{ chainsToAdd: [], remoteChainSelectorsToRemove: [] }, 'chainsToAdd'],
         [{ chainsToAdd: [null] }, 'chainsToAdd[0]'],
         [
           {
@@ -209,7 +337,7 @@ describe('ApplyChainUpdates (cct/solana)', () => {
   })
 
   describe('execute', () => {
-    it('signs, submits, and returns the tx hash', async () => {
+    it('signs, submits, and returns all tx hashes', async () => {
       const result = await SolanaTokenManager.fromChain(submitChain()).applyChainUpdates({
         tokenAddress: TOKEN,
         poolType: 'burn-mint',
@@ -227,7 +355,19 @@ describe('ApplyChainUpdates (cct/solana)', () => {
         wallet: WALLET,
       })
 
-      assert.deepEqual(result, { hash: HASH })
+      assert.deepEqual(result, { hashes: [HASH] })
+    })
+
+    it('submits every safely packed batch and returns all hashes', async () => {
+      const result = await SolanaTokenManager.fromChain(submitChain()).applyChainUpdates({
+        tokenAddress: TOKEN,
+        poolType: 'burn-mint',
+        remoteChainSelectorsToRemove: [],
+        chainsToAdd: batchChains(),
+        wallet: WALLET,
+      })
+
+      assert.deepEqual(result, { hashes: [HASH, HASH] })
     })
 
     it('rejects a non-wallet authority for signed configuration', async () => {
@@ -237,7 +377,7 @@ describe('ApplyChainUpdates (cct/solana)', () => {
             tokenAddress: TOKEN,
             poolType: 'burn-mint',
             authority: AUTHORITY,
-            remoteChainSelectorsToRemove: [],
+            remoteChainSelectorsToRemove: [SELECTOR],
             chainsToAdd: [],
             wallet: WALLET,
           }),

--- a/ccip-sdk/src/cct/solana/token-pool/operations/apply-chain-updates.ts
+++ b/ccip-sdk/src/cct/solana/token-pool/operations/apply-chain-updates.ts
@@ -24,7 +24,7 @@ import {
 import type { PoolProgramRef } from '../../programs/token-pool.ts'
 import { submit } from '../../submit.ts'
 import {
-  parseHexBytes,
+  parseNonEmptyHexBytes,
   parsePublicKey,
   resolvePoolProgram,
   validateAuthorityMatchesWallet,
@@ -94,18 +94,11 @@ function validateRemotePoolAddresses(operation: string, updates: unknown[]): voi
 
     const pools = new Set<string>()
     for (const [j, address] of remotePoolAddresses.entries()) {
-      const parsed = parseHexBytes(
+      const parsed = parseNonEmptyHexBytes(
         operation,
         `chainsToAdd[${i}].remotePoolAddresses[${j}]`,
         address,
       )
-      if (!parsed.length) {
-        throw new CCTParamsInvalidError(
-          operation,
-          `chainsToAdd[${i}].remotePoolAddresses[${j}]`,
-          'must not be empty',
-        )
-      }
       if (pools.has(parsed.toString('hex'))) {
         throw new CCTParamsInvalidError(
           operation,

--- a/ccip-sdk/src/cct/solana/token-pool/operations/apply-chain-updates.ts
+++ b/ccip-sdk/src/cct/solana/token-pool/operations/apply-chain-updates.ts
@@ -10,10 +10,12 @@ import { DeleteChainRemoteConfig } from './delete-chain-remote-config.ts'
 import { EditChainRemoteConfig } from './edit-chain-remote-config.ts'
 import { InitChainRemoteConfig } from './init-chain-remote-config.ts'
 import { type RateLimitConfig, SetChainRateLimit } from './set-chain-rate-limit.ts'
+import { CCIPError, CCIPMethodUnsupportedError } from '../../../../errors/index.ts'
 import { ChainFamily } from '../../../../networks.ts'
 import type { SolanaChain } from '../../../../solana/index.ts'
 import type { UnsignedSolanaTx } from '../../../../solana/types.ts'
 import { CCTParamsInvalidError } from '../../../errors.ts'
+import type { TransactionResult } from '../../../operation.ts'
 import {
   type SolanaExecuteParams,
   type SolanaGenerateParams,
@@ -29,6 +31,17 @@ import {
 } from '../../validate.ts'
 
 const MAX_TRANSACTION_SIZE = 1232
+
+type InstructionGroup = {
+  instructions: TransactionInstruction[]
+  remoteChainSelector?: bigint
+  remotePoolCount?: number
+}
+
+type PackedInstructionGroup = {
+  transaction: UnsignedSolanaTx
+  chainSelectors: string[]
+}
 
 /** A remote-chain configuration to add, matching the EVM `ChainUpdate` fields plus Solana decimals. */
 type ChainUpdate = {
@@ -105,6 +118,7 @@ function validateRemotePoolAddresses(operation: string, updates: unknown[]): voi
   }
 }
 
+/** Serializes a conservative v0 transaction, including compute-budget overhead, to check its size. */
 function fitsInTransaction(payer: PublicKey, instructions: TransactionInstruction[]): boolean {
   try {
     const transaction = new VersionedTransaction(
@@ -126,28 +140,49 @@ function fitsInTransaction(payer: PublicKey, instructions: TransactionInstructio
 
 /** Packs ordered instruction groups without splitting a remote-chain update across transactions. */
 function packInstructionGroups(
+  operation: string,
   payer: PublicKey,
-  groups: TransactionInstruction[][],
-): UnsignedSolanaTx[] {
-  const batches: UnsignedSolanaTx[] = []
+  groups: InstructionGroup[],
+): PackedInstructionGroup[] {
+  const batches: PackedInstructionGroup[] = []
   let instructions: TransactionInstruction[] = []
+  let chainSelectors: string[] = []
 
   for (const group of groups) {
-    if (!fitsInTransaction(payer, group)) {
+    if (!fitsInTransaction(payer, group.instructions)) {
+      const detail =
+        group.remoteChainSelector === undefined
+          ? 'a delete'
+          : `chain selector 0x${group.remoteChainSelector.toString(16)} (${group.remotePoolCount} remote pool addresses)`
       throw new CCTParamsInvalidError(
-        'applyChainUpdates',
+        operation,
         'chainsToAdd',
-        `one update exceeds Solana's ${MAX_TRANSACTION_SIZE}-byte transaction limit`,
+        `${detail} exceeds Solana's ${MAX_TRANSACTION_SIZE}-byte transaction limit`,
       )
     }
-    if (instructions.length && !fitsInTransaction(payer, [...instructions, ...group])) {
-      batches.push({ family: ChainFamily.Solana, instructions, mainIndex: 0 })
+    if (
+      instructions.length &&
+      !fitsInTransaction(payer, [...instructions, ...group.instructions])
+    ) {
+      batches.push({
+        transaction: { family: ChainFamily.Solana, instructions, mainIndex: 0 },
+        chainSelectors,
+      })
       instructions = []
+      chainSelectors = []
     }
-    instructions.push(...group)
+    instructions.push(...group.instructions)
+    if (group.remoteChainSelector !== undefined) {
+      chainSelectors.push(`0x${group.remoteChainSelector.toString(16)}`)
+    }
   }
 
-  if (instructions.length) batches.push({ family: ChainFamily.Solana, instructions, mainIndex: 0 })
+  if (instructions.length) {
+    batches.push({
+      transaction: { family: ChainFamily.Solana, instructions, mainIndex: 0 },
+      chainSelectors,
+    })
+  }
   return batches
 }
 
@@ -161,7 +196,7 @@ export type GenerateApplyChainUpdatesResult = UnsignedSolanaTx[]
 export type ExecuteApplyChainUpdatesParams = SolanaExecuteParams<ApplyChainUpdatesParams>
 
 /** All confirmed transaction hashes for Solana token pool chain updates. */
-export type ExecuteApplyChainUpdatesResult = { hashes: string[] }
+export type ExecuteApplyChainUpdatesResult = { hashes: string[]; chainSelectors: string[][] }
 
 /**
  * Applies the EVM `applyChainUpdates` equivalent as Solana instructions.
@@ -172,7 +207,7 @@ export type ExecuteApplyChainUpdatesResult = { hashes: string[] }
  * supported by listing a selector in both `remoteChainSelectorsToRemove` and `chainsToAdd`;
  * adding an existing selector without removing it fails. Updates are packed into one or more
  * transactions, keeping each chain's initialization, configuration, and rate-limit instructions
- * together.
+ * together. Batches are submitted sequentially; a later failure leaves earlier batches committed.
  */
 export class ApplyChainUpdates extends SolanaOperation<
   ApplyChainUpdatesParams,
@@ -196,7 +231,7 @@ export class ApplyChainUpdates extends SolanaOperation<
       throw new CCTParamsInvalidError(
         this.name,
         'chainsToAdd',
-        'or remoteChainSelectorsToRemove must not be empty',
+        'at least one of chainsToAdd or remoteChainSelectorsToRemove must be non-empty',
       )
     }
     validateRemotePoolAddresses(this.name, params.chainsToAdd)
@@ -238,7 +273,7 @@ export class ApplyChainUpdates extends SolanaOperation<
   private async buildInstructionGroups(
     chain: SolanaChain,
     params: ParsedApplyChainUpdatesParams,
-  ): Promise<TransactionInstruction[][]> {
+  ): Promise<InstructionGroup[]> {
     const pool: PoolInstructionParams = {
       tokenAddress: params.tokenAddress,
       payer: params.payer,
@@ -247,17 +282,21 @@ export class ApplyChainUpdates extends SolanaOperation<
         ? { poolProgramAddress: params.poolProgramAddress }
         : { poolType: params.poolType }),
     }
-    const groups: TransactionInstruction[][] = []
+    const groups: InstructionGroup[] = []
 
     for (const remoteChainSelector of params.remoteChainSelectorsToRemove) {
       const tx = await new DeleteChainRemoteConfig().generate(chain, {
         ...pool,
         remoteChainSelector,
       })
-      groups.push(tx.instructions)
+      groups.push({ instructions: tx.instructions })
     }
     for (const update of params.chainsToAdd) {
-      groups.push(await this.buildAddInstructions(chain, pool, update))
+      groups.push({
+        instructions: await this.buildAddInstructions(chain, pool, update),
+        remoteChainSelector: update.remoteChainSelector,
+        remotePoolCount: update.remotePoolAddresses.length,
+      })
     }
     return groups
   }
@@ -269,9 +308,22 @@ export class ApplyChainUpdates extends SolanaOperation<
   ): Promise<UnsignedSolanaTx> {
     return {
       family: ChainFamily.Solana,
-      instructions: (await this.buildInstructionGroups(chain, params)).flat(),
+      instructions: (await this.buildInstructionGroups(chain, params)).flatMap(
+        (group) => group.instructions,
+      ),
       mainIndex: 0,
     }
+  }
+
+  /**
+   * Unsupported because this operation may require multiple transactions.
+   * @see {@link generateBatch}.
+   */
+  override generate(
+    _chain: SolanaChain,
+    _params: GenerateApplyChainUpdatesParams,
+  ): Promise<UnsignedSolanaTx> {
+    throw new CCIPMethodUnsupportedError('ApplyChainUpdates', 'generate; use generateBatch')
   }
 
   /** Builds one or more ordered transactions without splitting a per-chain update group. */
@@ -281,9 +333,21 @@ export class ApplyChainUpdates extends SolanaOperation<
   ): Promise<GenerateApplyChainUpdatesResult> {
     const parsed = this.prepare(params)
     return packInstructionGroups(
+      this.name,
       new PublicKey(parsed.payer),
       await this.buildInstructionGroups(chain, parsed),
-    )
+    ).map(({ transaction }) => transaction)
+  }
+
+  /**
+   * Unsupported because this operation may require multiple transactions.
+   * @see {@link executeBatch}.
+   */
+  override execute(
+    _chain: SolanaChain,
+    _params: ExecuteApplyChainUpdatesParams,
+  ): Promise<TransactionResult> {
+    throw new CCIPMethodUnsupportedError('ApplyChainUpdates', 'execute; use executeBatch')
   }
 
   /** Signs, submits, and confirms each packed transaction, returning every transaction hash. */
@@ -300,16 +364,30 @@ export class ApplyChainUpdates extends SolanaOperation<
     )
 
     const batches = packInstructionGroups(
+      this.name,
       wallet.publicKey,
       await this.buildInstructionGroups(chain, parsed),
     )
     const hashes: string[] = []
+    const chainSelectors: string[][] = []
 
-    for (const batch of batches) {
-      const tx = await submit(chain, wallet, batch, this.name, computeUnits)
-      hashes.push(tx.hash)
+    for (const [failedBatchIndex, batch] of batches.entries()) {
+      try {
+        hashes.push((await submit(chain, wallet, batch.transaction, this.name, computeUnits)).hash)
+        chainSelectors.push(batch.chainSelectors)
+      } catch (error) {
+        if (CCIPError.isCCIPError(error)) {
+          Object.assign(error.context, {
+            committedHashes: hashes,
+            committedChainSelectors: chainSelectors,
+            failedBatchIndex,
+            totalBatches: batches.length,
+          })
+        }
+        throw error
+      }
     }
 
-    return { hashes }
+    return { hashes, chainSelectors }
   }
 }

--- a/ccip-sdk/src/cct/solana/token-pool/operations/apply-chain-updates.ts
+++ b/ccip-sdk/src/cct/solana/token-pool/operations/apply-chain-updates.ts
@@ -1,4 +1,4 @@
-import { PublicKey } from '@solana/web3.js'
+import { type TransactionInstruction, PublicKey } from '@solana/web3.js'
 
 import { DeleteChainRemoteConfig } from './delete-chain-remote-config.ts'
 import { EditChainRemoteConfig } from './edit-chain-remote-config.ts'
@@ -117,8 +117,8 @@ export type ExecuteApplyChainUpdatesResult = TransactionResult
  * This preserves EVM `applyChainUpdates` ordering: all removals run first, then each added chain
  * is initialized, configured with remote pools, and assigned both rate-limit configs (including
  * disabled configs). EVM-style replacement is therefore supported by listing a selector in both
- * arrays; adding an existing selector without removing it fails. Solana requires
- * `remoteTokenDecimals` and has native address-size limits in addition to the EVM fields.
+ * arrays; adding an existing selector without removing it fails. Solana additionally requires
+ * `remoteTokenDecimals`.
  */
 export class ApplyChainUpdates extends SolanaOperation<
   ApplyChainUpdatesParams,
@@ -189,7 +189,7 @@ export class ApplyChainUpdates extends SolanaOperation<
         ? { poolProgramAddress: params.poolProgramAddress }
         : { poolType: params.poolType }),
     }
-    const instructions = []
+    const instructions: TransactionInstruction[] = []
 
     for (const remoteChainSelector of params.remoteChainSelectorsToRemove) {
       const tx = await new DeleteChainRemoteConfig().generate(chain, {
@@ -211,12 +211,14 @@ export class ApplyChainUpdates extends SolanaOperation<
     params: ExecuteApplyChainUpdatesParams,
   ): Promise<ExecuteApplyChainUpdatesResult> {
     const { wallet, computeUnits, parsed } = this.prepareWalletExecution(params)
+
     validateAuthorityMatchesWallet(
       this.name,
       new PublicKey(parsed.authority),
       wallet.publicKey,
       'applyChainUpdates requires authority to be the executing wallet. Use generateUnsignedApplyChainUpdates for externally signed transactions.',
     )
+
     return submit(chain, wallet, await this.buildUnsigned(chain, parsed), this.name, computeUnits)
   }
 }

--- a/ccip-sdk/src/cct/solana/token-pool/operations/apply-chain-updates.ts
+++ b/ccip-sdk/src/cct/solana/token-pool/operations/apply-chain-updates.ts
@@ -171,7 +171,8 @@ export type ExecuteApplyChainUpdatesResult = { hashes: string[] }
  * configured with remote pools, and assigned both rate-limit configs. EVM-style replacement is
  * supported by listing a selector in both `remoteChainSelectorsToRemove` and `chainsToAdd`;
  * adding an existing selector without removing it fails. Updates are packed into one or more
- * transactions without splitting a chain update.
+ * transactions, keeping each chain's initialization, configuration, and rate-limit instructions
+ * together.
  */
 export class ApplyChainUpdates extends SolanaOperation<
   ApplyChainUpdatesParams,

--- a/ccip-sdk/src/cct/solana/token-pool/operations/apply-chain-updates.ts
+++ b/ccip-sdk/src/cct/solana/token-pool/operations/apply-chain-updates.ts
@@ -1,0 +1,222 @@
+import { PublicKey } from '@solana/web3.js'
+
+import { DeleteChainRemoteConfig } from './delete-chain-remote-config.ts'
+import { EditChainRemoteConfig } from './edit-chain-remote-config.ts'
+import { InitChainRemoteConfig } from './init-chain-remote-config.ts'
+import { type RateLimitConfig, SetChainRateLimit } from './set-chain-rate-limit.ts'
+import { ChainFamily } from '../../../../networks.ts'
+import type { SolanaChain } from '../../../../solana/index.ts'
+import type { UnsignedSolanaTx } from '../../../../solana/types.ts'
+import { CCTParamsInvalidError } from '../../../errors.ts'
+import type { TransactionResult } from '../../../operation.ts'
+import {
+  type SolanaExecuteParams,
+  type SolanaGenerateParams,
+  SolanaOperation,
+} from '../../operation.ts'
+import type { PoolProgramRef } from '../../programs/token-pool.ts'
+import { submit } from '../../submit.ts'
+import {
+  parseHexBytes,
+  parsePublicKey,
+  resolvePoolProgram,
+  validateAuthorityMatchesWallet,
+} from '../../validate.ts'
+
+/** A remote-chain configuration to add, matching the EVM `ChainUpdate` fields plus Solana decimals. */
+type ChainUpdate = {
+  /** CCIP selector of the remote chain (`u64`). */
+  remoteChainSelector: bigint
+  /** Hex-encoded remote token address, optionally `0x`-prefixed, up to 32 bytes. */
+  remoteTokenAddress: string
+  /** Non-empty, unique hex-encoded remote pool addresses, optionally `0x`-prefixed. */
+  remotePoolAddresses: string[]
+  /** Remote token decimals (`u8`), required by the Solana pool account. */
+  remoteTokenDecimals: number
+  /** Rate limit for tokens received from the remote chain. */
+  inboundRateLimiterConfig: RateLimitConfig
+  /** Rate limit for tokens sent to the remote chain. */
+  outboundRateLimiterConfig: RateLimitConfig
+}
+
+type ApplyChainUpdatesParams = PoolProgramRef & {
+  /** Token mint address managed by the local pool. */
+  tokenAddress: string
+  /**
+   * Remote chain configurations to add, including their rate limits. To replace a config, include
+   * its selector here and in `remoteChainSelectorsToRemove`.
+   */
+  chainsToAdd: ChainUpdate[]
+  /** Remote chain configurations to delete before additions are initialized. */
+  remoteChainSelectorsToRemove: bigint[]
+  /** Pool owner. Defaults to `payer` for single-signer transactions. */
+  authority?: string
+}
+
+type PoolInstructionParams = PoolProgramRef & {
+  tokenAddress: string
+  payer: string
+  authority: string
+}
+
+function validateRemotePoolAddresses(operation: string, updates: unknown[]): void {
+  for (const [i, update] of updates.entries()) {
+    if (typeof update !== 'object' || update === null) {
+      throw new CCTParamsInvalidError(operation, `chainsToAdd[${i}]`, 'must be a chain update')
+    }
+    const remotePoolAddresses = (update as { remotePoolAddresses?: unknown }).remotePoolAddresses
+    if (!Array.isArray(remotePoolAddresses)) continue
+
+    const pools = new Set<string>()
+    for (const [j, address] of remotePoolAddresses.entries()) {
+      const parsed = parseHexBytes(
+        operation,
+        `chainsToAdd[${i}].remotePoolAddresses[${j}]`,
+        address,
+      )
+      if (!parsed.length) {
+        throw new CCTParamsInvalidError(
+          operation,
+          `chainsToAdd[${i}].remotePoolAddresses[${j}]`,
+          'must not be empty',
+        )
+      }
+      if (pools.has(parsed.toString('hex'))) {
+        throw new CCTParamsInvalidError(
+          operation,
+          `chainsToAdd[${i}].remotePoolAddresses[${j}]`,
+          'must not duplicate a remote pool address',
+        )
+      }
+      pools.add(parsed.toString('hex'))
+    }
+  }
+}
+
+type ParsedApplyChainUpdatesParams = ApplyChainUpdatesParams & {
+  payer: string
+  authority: string
+}
+
+/** Parameters for unsigned Solana token pool chain updates. */
+export type GenerateApplyChainUpdatesParams = SolanaGenerateParams<ApplyChainUpdatesParams>
+
+/** Unsigned Solana token pool chain updates result. */
+export type GenerateApplyChainUpdatesResult = UnsignedSolanaTx
+
+/** Parameters for executing Solana token pool chain updates. */
+export type ExecuteApplyChainUpdatesParams = SolanaExecuteParams<ApplyChainUpdatesParams>
+
+/** Result of executing Solana token pool chain updates. */
+export type ExecuteApplyChainUpdatesResult = TransactionResult
+
+/**
+ * Applies the EVM `applyChainUpdates` equivalent as one Solana transaction.
+ *
+ * @remarks
+ * This preserves EVM `applyChainUpdates` ordering: all removals run first, then each added chain
+ * is initialized, configured with remote pools, and assigned both rate-limit configs (including
+ * disabled configs). EVM-style replacement is therefore supported by listing a selector in both
+ * arrays; adding an existing selector without removing it fails. Solana requires
+ * `remoteTokenDecimals` and has native address-size limits in addition to the EVM fields.
+ */
+export class ApplyChainUpdates extends SolanaOperation<
+  ApplyChainUpdatesParams,
+  UnsignedSolanaTx,
+  ParsedApplyChainUpdatesParams
+> {
+  readonly name = 'applyChainUpdates'
+
+  /** Validates the batch envelope; component operations validate each chain update. */
+  protected override parse(params: GenerateApplyChainUpdatesParams): ParsedApplyChainUpdatesParams {
+    parsePublicKey(this.name, 'tokenAddress', params.tokenAddress)
+    parsePublicKey(this.name, 'payer', params.payer)
+    resolvePoolProgram(this.name, params)
+    if (!Array.isArray(params.chainsToAdd)) {
+      throw new CCTParamsInvalidError(this.name, 'chainsToAdd', 'must be an array')
+    }
+    if (!Array.isArray(params.remoteChainSelectorsToRemove)) {
+      throw new CCTParamsInvalidError(this.name, 'remoteChainSelectorsToRemove', 'must be an array')
+    }
+    validateRemotePoolAddresses(this.name, params.chainsToAdd)
+
+    return {
+      ...params,
+      authority:
+        params.authority === undefined
+          ? params.payer
+          : parsePublicKey(this.name, 'authority', params.authority).toBase58(),
+    }
+  }
+
+  /** Builds the initialize, edit, and rate-limit instructions for one added chain. */
+  private async buildAddInstructions(
+    chain: SolanaChain,
+    pool: PoolInstructionParams,
+    update: ChainUpdate,
+  ) {
+    const config = {
+      ...pool,
+      remoteChainSelector: update.remoteChainSelector,
+      remoteTokenAddress: update.remoteTokenAddress,
+      remotePoolAddresses: update.remotePoolAddresses,
+      remoteTokenDecimals: update.remoteTokenDecimals,
+    }
+    const init = await new InitChainRemoteConfig().generate(chain, config)
+    const edit = await new EditChainRemoteConfig().generate(chain, config)
+    const instructions = [...init.instructions, ...edit.instructions]
+
+    const rateLimit = await new SetChainRateLimit().generate(chain, {
+      ...pool,
+      remoteChainSelector: update.remoteChainSelector,
+      inbound: update.inboundRateLimiterConfig,
+      outbound: update.outboundRateLimiterConfig,
+    })
+    instructions.push(...rateLimit.instructions)
+    return instructions
+  }
+
+  /** Builds the component instructions in contract-equivalent order. */
+  protected async buildUnsigned(
+    chain: SolanaChain,
+    params: ParsedApplyChainUpdatesParams,
+  ): Promise<UnsignedSolanaTx> {
+    const pool: PoolInstructionParams = {
+      tokenAddress: params.tokenAddress,
+      payer: params.payer,
+      authority: params.authority,
+      ...(params.poolType === undefined
+        ? { poolProgramAddress: params.poolProgramAddress }
+        : { poolType: params.poolType }),
+    }
+    const instructions = []
+
+    for (const remoteChainSelector of params.remoteChainSelectorsToRemove) {
+      const tx = await new DeleteChainRemoteConfig().generate(chain, {
+        ...pool,
+        remoteChainSelector,
+      })
+      instructions.push(...tx.instructions)
+    }
+    for (const update of params.chainsToAdd) {
+      instructions.push(...(await this.buildAddInstructions(chain, pool, update)))
+    }
+
+    return { family: ChainFamily.Solana, instructions, mainIndex: 0 }
+  }
+
+  /** Generates, signs, simulates, sends, and confirms the update transaction. */
+  override async execute(
+    chain: SolanaChain,
+    params: ExecuteApplyChainUpdatesParams,
+  ): Promise<ExecuteApplyChainUpdatesResult> {
+    const { wallet, computeUnits, parsed } = this.prepareWalletExecution(params)
+    validateAuthorityMatchesWallet(
+      this.name,
+      new PublicKey(parsed.authority),
+      wallet.publicKey,
+      'applyChainUpdates requires authority to be the executing wallet. Use generateUnsignedApplyChainUpdates for externally signed transactions.',
+    )
+    return submit(chain, wallet, await this.buildUnsigned(chain, parsed), this.name, computeUnits)
+  }
+}

--- a/ccip-sdk/src/cct/solana/token-pool/operations/apply-chain-updates.ts
+++ b/ccip-sdk/src/cct/solana/token-pool/operations/apply-chain-updates.ts
@@ -1,4 +1,10 @@
-import { type TransactionInstruction, PublicKey } from '@solana/web3.js'
+import {
+  type TransactionInstruction,
+  ComputeBudgetProgram,
+  PublicKey,
+  TransactionMessage,
+  VersionedTransaction,
+} from '@solana/web3.js'
 
 import { DeleteChainRemoteConfig } from './delete-chain-remote-config.ts'
 import { EditChainRemoteConfig } from './edit-chain-remote-config.ts'
@@ -8,7 +14,6 @@ import { ChainFamily } from '../../../../networks.ts'
 import type { SolanaChain } from '../../../../solana/index.ts'
 import type { UnsignedSolanaTx } from '../../../../solana/types.ts'
 import { CCTParamsInvalidError } from '../../../errors.ts'
-import type { TransactionResult } from '../../../operation.ts'
 import {
   type SolanaExecuteParams,
   type SolanaGenerateParams,
@@ -23,13 +28,15 @@ import {
   validateAuthorityMatchesWallet,
 } from '../../validate.ts'
 
+const MAX_TRANSACTION_SIZE = 1232
+
 /** A remote-chain configuration to add, matching the EVM `ChainUpdate` fields plus Solana decimals. */
 type ChainUpdate = {
   /** CCIP selector of the remote chain (`u64`). */
   remoteChainSelector: bigint
   /** Hex-encoded remote token address, optionally `0x`-prefixed, up to 32 bytes. */
   remoteTokenAddress: string
-  /** Non-empty, unique hex-encoded remote pool addresses, optionally `0x`-prefixed. */
+  /** Hex-encoded remote pool addresses, optionally `0x`-prefixed; supplied addresses are non-empty and unique. */
   remotePoolAddresses: string[]
   /** Remote token decimals (`u8`), required by the Solana pool account. */
   remoteTokenDecimals: number
@@ -55,6 +62,11 @@ type ApplyChainUpdatesParams = PoolProgramRef & {
 
 type PoolInstructionParams = PoolProgramRef & {
   tokenAddress: string
+  payer: string
+  authority: string
+}
+
+type ParsedApplyChainUpdatesParams = ApplyChainUpdatesParams & {
   payer: string
   authority: string
 }
@@ -93,32 +105,73 @@ function validateRemotePoolAddresses(operation: string, updates: unknown[]): voi
   }
 }
 
-type ParsedApplyChainUpdatesParams = ApplyChainUpdatesParams & {
-  payer: string
-  authority: string
+function fitsInTransaction(payer: PublicKey, instructions: TransactionInstruction[]): boolean {
+  try {
+    const transaction = new VersionedTransaction(
+      new TransactionMessage({
+        payerKey: payer,
+        recentBlockhash: PublicKey.default.toBase58(),
+        instructions: [
+          // submit may add this instruction after simulation; include it so batches remain safe.
+          ComputeBudgetProgram.setComputeUnitLimit({ units: 1_400_000 }),
+          ...instructions,
+        ],
+      }).compileToV0Message(),
+    )
+    return transaction.serialize().length <= MAX_TRANSACTION_SIZE
+  } catch {
+    return false
+  }
+}
+
+/** Packs ordered instruction groups without splitting a remote-chain update across transactions. */
+function packInstructionGroups(
+  payer: PublicKey,
+  groups: TransactionInstruction[][],
+): UnsignedSolanaTx[] {
+  const batches: UnsignedSolanaTx[] = []
+  let instructions: TransactionInstruction[] = []
+
+  for (const group of groups) {
+    if (!fitsInTransaction(payer, group)) {
+      throw new CCTParamsInvalidError(
+        'applyChainUpdates',
+        'chainsToAdd',
+        `one update exceeds Solana's ${MAX_TRANSACTION_SIZE}-byte transaction limit`,
+      )
+    }
+    if (instructions.length && !fitsInTransaction(payer, [...instructions, ...group])) {
+      batches.push({ family: ChainFamily.Solana, instructions, mainIndex: 0 })
+      instructions = []
+    }
+    instructions.push(...group)
+  }
+
+  if (instructions.length) batches.push({ family: ChainFamily.Solana, instructions, mainIndex: 0 })
+  return batches
 }
 
 /** Parameters for unsigned Solana token pool chain updates. */
 export type GenerateApplyChainUpdatesParams = SolanaGenerateParams<ApplyChainUpdatesParams>
 
 /** Unsigned Solana token pool chain updates result. */
-export type GenerateApplyChainUpdatesResult = UnsignedSolanaTx
+export type GenerateApplyChainUpdatesResult = UnsignedSolanaTx[]
 
 /** Parameters for executing Solana token pool chain updates. */
 export type ExecuteApplyChainUpdatesParams = SolanaExecuteParams<ApplyChainUpdatesParams>
 
-/** Result of executing Solana token pool chain updates. */
-export type ExecuteApplyChainUpdatesResult = TransactionResult
+/** All confirmed transaction hashes for Solana token pool chain updates. */
+export type ExecuteApplyChainUpdatesResult = { hashes: string[] }
 
 /**
- * Applies the EVM `applyChainUpdates` equivalent as one Solana transaction.
+ * Applies the EVM `applyChainUpdates` equivalent as Solana instructions.
  *
  * @remarks
- * This preserves EVM `applyChainUpdates` ordering: all removals run first, then each added chain
- * is initialized, configured with remote pools, and assigned both rate-limit configs (including
- * disabled configs). EVM-style replacement is therefore supported by listing a selector in both
- * arrays; adding an existing selector without removing it fails. Solana additionally requires
- * `remoteTokenDecimals`.
+ * This preserves EVM ordering: all removals run first, then each added chain is initialized,
+ * configured with remote pools, and assigned both rate-limit configs. EVM-style replacement is
+ * supported by listing a selector in both `remoteChainSelectorsToRemove` and `chainsToAdd`;
+ * adding an existing selector without removing it fails. Updates are packed into one or more
+ * transactions without splitting a chain update.
  */
 export class ApplyChainUpdates extends SolanaOperation<
   ApplyChainUpdatesParams,
@@ -138,6 +191,13 @@ export class ApplyChainUpdates extends SolanaOperation<
     if (!Array.isArray(params.remoteChainSelectorsToRemove)) {
       throw new CCTParamsInvalidError(this.name, 'remoteChainSelectorsToRemove', 'must be an array')
     }
+    if (!params.chainsToAdd.length && !params.remoteChainSelectorsToRemove.length) {
+      throw new CCTParamsInvalidError(
+        this.name,
+        'chainsToAdd',
+        'or remoteChainSelectorsToRemove must not be empty',
+      )
+    }
     validateRemotePoolAddresses(this.name, params.chainsToAdd)
 
     return {
@@ -154,7 +214,7 @@ export class ApplyChainUpdates extends SolanaOperation<
     chain: SolanaChain,
     pool: PoolInstructionParams,
     update: ChainUpdate,
-  ) {
+  ): Promise<TransactionInstruction[]> {
     const config = {
       ...pool,
       remoteChainSelector: update.remoteChainSelector,
@@ -164,23 +224,20 @@ export class ApplyChainUpdates extends SolanaOperation<
     }
     const init = await new InitChainRemoteConfig().generate(chain, config)
     const edit = await new EditChainRemoteConfig().generate(chain, config)
-    const instructions = [...init.instructions, ...edit.instructions]
-
     const rateLimit = await new SetChainRateLimit().generate(chain, {
       ...pool,
       remoteChainSelector: update.remoteChainSelector,
       inbound: update.inboundRateLimiterConfig,
       outbound: update.outboundRateLimiterConfig,
     })
-    instructions.push(...rateLimit.instructions)
-    return instructions
+    return [...init.instructions, ...edit.instructions, ...rateLimit.instructions]
   }
 
-  /** Builds the component instructions in contract-equivalent order. */
-  protected async buildUnsigned(
+  /** Builds ordered delete and per-chain update instruction groups. */
+  private async buildInstructionGroups(
     chain: SolanaChain,
     params: ParsedApplyChainUpdatesParams,
-  ): Promise<UnsignedSolanaTx> {
+  ): Promise<TransactionInstruction[][]> {
     const pool: PoolInstructionParams = {
       tokenAddress: params.tokenAddress,
       payer: params.payer,
@@ -189,29 +246,51 @@ export class ApplyChainUpdates extends SolanaOperation<
         ? { poolProgramAddress: params.poolProgramAddress }
         : { poolType: params.poolType }),
     }
-    const instructions: TransactionInstruction[] = []
+    const groups: TransactionInstruction[][] = []
 
     for (const remoteChainSelector of params.remoteChainSelectorsToRemove) {
       const tx = await new DeleteChainRemoteConfig().generate(chain, {
         ...pool,
         remoteChainSelector,
       })
-      instructions.push(...tx.instructions)
+      groups.push(tx.instructions)
     }
     for (const update of params.chainsToAdd) {
-      instructions.push(...(await this.buildAddInstructions(chain, pool, update)))
+      groups.push(await this.buildAddInstructions(chain, pool, update))
     }
-
-    return { family: ChainFamily.Solana, instructions, mainIndex: 0 }
+    return groups
   }
 
-  /** Generates, signs, simulates, sends, and confirms the update transaction. */
-  override async execute(
+  /** Builds all instructions in contract-equivalent order as one unsigned transaction. */
+  protected async buildUnsigned(
+    chain: SolanaChain,
+    params: ParsedApplyChainUpdatesParams,
+  ): Promise<UnsignedSolanaTx> {
+    return {
+      family: ChainFamily.Solana,
+      instructions: (await this.buildInstructionGroups(chain, params)).flat(),
+      mainIndex: 0,
+    }
+  }
+
+  /** Builds one or more ordered transactions without splitting a per-chain update group. */
+  async generateBatch(
+    chain: SolanaChain,
+    params: GenerateApplyChainUpdatesParams,
+  ): Promise<GenerateApplyChainUpdatesResult> {
+    const parsed = this.prepare(params)
+    return packInstructionGroups(
+      new PublicKey(parsed.payer),
+      await this.buildInstructionGroups(chain, parsed),
+    )
+  }
+
+  /** Signs, submits, and confirms each packed transaction, returning every transaction hash. */
+  async executeBatch(
     chain: SolanaChain,
     params: ExecuteApplyChainUpdatesParams,
   ): Promise<ExecuteApplyChainUpdatesResult> {
     const { wallet, computeUnits, parsed } = this.prepareWalletExecution(params)
-
     validateAuthorityMatchesWallet(
       this.name,
       new PublicKey(parsed.authority),
@@ -219,6 +298,17 @@ export class ApplyChainUpdates extends SolanaOperation<
       'applyChainUpdates requires authority to be the executing wallet. Use generateUnsignedApplyChainUpdates for externally signed transactions.',
     )
 
-    return submit(chain, wallet, await this.buildUnsigned(chain, parsed), this.name, computeUnits)
+    const batches = packInstructionGroups(
+      wallet.publicKey,
+      await this.buildInstructionGroups(chain, parsed),
+    )
+    const hashes: string[] = []
+
+    for (const batch of batches) {
+      const tx = await submit(chain, wallet, batch, this.name, computeUnits)
+      hashes.push(tx.hash)
+    }
+
+    return { hashes }
   }
 }

--- a/ccip-sdk/src/cct/solana/token-pool/operations/delete-chain-remote-config.ts
+++ b/ccip-sdk/src/cct/solana/token-pool/operations/delete-chain-remote-config.ts
@@ -18,13 +18,12 @@ import {
 } from '../../programs/token-pool.ts'
 import { submit } from '../../submit.ts'
 import {
+  U64_MAX,
   parsePublicKey,
   resolvePoolProgram,
   validateAuthorityMatchesWallet,
   validateBigInt,
 } from '../../validate.ts'
-
-const U64_MAX = 0xffff_ffff_ffff_ffffn
 
 type DeleteChainRemoteConfigParams = PoolProgramRef & {
   /** Token mint address managed by the local pool. */

--- a/ccip-sdk/src/cct/solana/token-pool/operations/edit-chain-remote-config.ts
+++ b/ccip-sdk/src/cct/solana/token-pool/operations/edit-chain-remote-config.ts
@@ -21,15 +21,15 @@ import {
 } from '../../programs/token-pool.ts'
 import { submit } from '../../submit.ts'
 import {
+  U64_MAX,
   parseHexBytes,
+  parseNonEmptyHexBytes,
   parsePublicKey,
   resolvePoolProgram,
   validateAuthorityMatchesWallet,
   validateBigInt,
   validateInteger,
 } from '../../validate.ts'
-
-const U64_MAX = 0xffff_ffff_ffff_ffffn
 
 /** Parameters shared by Solana token pool remote-config editing generation and execution. */
 type EditChainRemoteConfigParams = PoolProgramRef & {
@@ -105,7 +105,7 @@ export class EditChainRemoteConfig extends SolanaOperation<
       throw new CCTParamsInvalidError(this.name, 'remotePoolAddresses', 'must be an array')
     }
     const remotePoolAddresses = params.remotePoolAddresses.map((address, i) =>
-      parseHexBytes(this.name, `remotePoolAddresses[${i}]`, address),
+      parseNonEmptyHexBytes(this.name, `remotePoolAddresses[${i}]`, address),
     )
 
     const payer = parsePublicKey(this.name, 'payer', params.payer)

--- a/ccip-sdk/src/cct/solana/token-pool/operations/index.ts
+++ b/ccip-sdk/src/cct/solana/token-pool/operations/index.ts
@@ -1,3 +1,4 @@
+export * from './apply-chain-updates.ts'
 export * from './configure-allowlist.ts'
 export * from './create-token-multisig.ts'
 export * from './deploy-token-pool.ts'

--- a/ccip-sdk/src/cct/solana/token-pool/operations/index.ts
+++ b/ccip-sdk/src/cct/solana/token-pool/operations/index.ts
@@ -1,3 +1,4 @@
+export * from './append-remote-pool-addresses.ts'
 export * from './apply-chain-updates.ts'
 export * from './configure-allowlist.ts'
 export * from './create-token-multisig.ts'

--- a/ccip-sdk/src/cct/solana/token-pool/operations/init-chain-remote-config.ts
+++ b/ccip-sdk/src/cct/solana/token-pool/operations/init-chain-remote-config.ts
@@ -21,6 +21,7 @@ import {
 } from '../../programs/token-pool.ts'
 import { submit } from '../../submit.ts'
 import {
+  U64_MAX,
   parseHexBytes,
   parsePublicKey,
   resolvePoolProgram,
@@ -28,8 +29,6 @@ import {
   validateBigInt,
   validateInteger,
 } from '../../validate.ts'
-
-const U64_MAX = 0xffff_ffff_ffff_ffffn
 
 /** Parameters shared by Solana token pool remote-config initialization generation and execution. */
 type InitChainRemoteConfigParams = PoolProgramRef & {

--- a/ccip-sdk/src/cct/solana/token-pool/operations/set-chain-rate-limit.ts
+++ b/ccip-sdk/src/cct/solana/token-pool/operations/set-chain-rate-limit.ts
@@ -19,13 +19,12 @@ import {
 } from '../../programs/token-pool.ts'
 import { submit } from '../../submit.ts'
 import {
+  U64_MAX,
   parsePublicKey,
   resolvePoolProgram,
   validateAuthorityMatchesWallet,
   validateBigInt,
 } from '../../validate.ts'
-
-const U64_MAX = 0xffff_ffff_ffff_ffffn
 
 /**
  * Configuration for one direction of a token pool rate limiter.

--- a/ccip-sdk/src/cct/solana/validate.test.ts
+++ b/ccip-sdk/src/cct/solana/validate.test.ts
@@ -5,6 +5,7 @@ import { PublicKey } from '@solana/web3.js'
 
 import {
   parseHexBytes,
+  parseNonEmptyHexBytes,
   parsePublicKey,
   resolvePoolProgram,
   validateBigInt,
@@ -35,6 +36,15 @@ describe('Validate (cct/solana)', () => {
         err.context.reason === 'must be a hex string of at most 2 bytes',
     )
     assert.throws(() => parseHexBytes('op', 'address', null), CCTParamsInvalidError)
+  })
+
+  it('rejects empty hex bytes when required', () => {
+    assert.deepEqual(parseNonEmptyHexBytes('op', 'address', '0x01'), Buffer.from([1]))
+    assert.throws(
+      () => parseNonEmptyHexBytes('op', 'address', ''),
+      (err: unknown) =>
+        err instanceof CCTParamsInvalidError && err.context.reason === 'must not be empty',
+    )
   })
 
   it('accepts valid public keys', () => {

--- a/ccip-sdk/src/cct/solana/validate.ts
+++ b/ccip-sdk/src/cct/solana/validate.ts
@@ -12,6 +12,9 @@ import {
   resolveTokenPoolProgram,
 } from './programs/token-pool.ts'
 
+/** Largest value representable by an unsigned 64-bit integer. */
+export const U64_MAX = 0xffff_ffff_ffff_ffffn
+
 /**
  * Parses `value` as a Solana public key.
  * @throws CCTParamsInvalidError if `value` is not a valid Solana public key string.
@@ -227,4 +230,19 @@ export function parseHexBytes(
     throw new CCTParamsInvalidError(operation, param, `must be a hex string${size}`)
   }
   return Buffer.from(hex, 'hex')
+}
+
+/**
+ * Parses a non-empty optionally `0x`-prefixed hex string into bytes.
+ * @throws CCTParamsInvalidError if `value` is not valid non-empty hex or exceeds the requested size.
+ */
+export function parseNonEmptyHexBytes(
+  operation: string,
+  param: string,
+  value: unknown,
+  maxBytes?: number,
+): Buffer {
+  const bytes = parseHexBytes(operation, param, value, maxBytes)
+  if (!bytes.length) throw new CCTParamsInvalidError(operation, param, 'must not be empty')
+  return bytes
 }


### PR DESCRIPTION
## What

- [DAPP-11040](https://smartcontract-it.atlassian.net/browse/DAPP-11040)
- Add Solana cct sdk operations to generate and execute `applyChainUpdates`
- Solana equivalent for EVM's `applyChainUpdates`
- Combination of `initChainRemoteConfig`, `editChainRemoteConfig`, `deleteChainRemoteConfig`, and `setChainRateLimit` operations

## Why

- Allow pool owners to set chain configurations in one transaction just like in EVM

[DAPP-11040]: https://smartcontract-it.atlassian.net/browse/DAPP-11040?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ