### PR TITLE
fix(cct-sdk): Refactor parse and validations for old solana ops

### DIFF
--- a/ccip-sdk/src/cct/solana/operation.ts
+++ b/ccip-sdk/src/cct/solana/operation.ts
@@ -20,7 +20,6 @@ export type SolanaExecuteParams<P extends object> = P & {
   computeUnits?: number
 }
 
-// TODO: migrate remaining Solana operations to parse normalized params.
 /**
  * Solana CCT write base. Subclasses supply {@link parse} and {@link buildUnsigned}.
  *

--- a/ccip-sdk/src/cct/solana/token-admin-registry/operations/append-to-lookup-table.ts
+++ b/ccip-sdk/src/cct/solana/token-admin-registry/operations/append-to-lookup-table.ts
@@ -1,9 +1,12 @@
-import { type TransactionInstruction, AddressLookupTableProgram, PublicKey } from '@solana/web3.js'
+import {
+  type PublicKey,
+  type TransactionInstruction,
+  AddressLookupTableProgram,
+} from '@solana/web3.js'
 
-import { CCIPWalletInvalidError } from '../../../../errors/index.ts'
 import { ChainFamily } from '../../../../networks.ts'
 import type { SolanaChain } from '../../../../solana/index.ts'
-import { type UnsignedSolanaTx, isWallet } from '../../../../solana/types.ts'
+import type { UnsignedSolanaTx } from '../../../../solana/types.ts'
 import { CCTParamsInvalidError } from '../../../errors.ts'
 import type { TransactionResult } from '../../../operation.ts'
 import {
@@ -15,10 +18,9 @@ import { deriveCcipLookupTableAddresses } from '../../programs/alt.ts'
 import type { PoolProgramRef } from '../../programs/token-pool.ts'
 import { submit } from '../../submit.ts'
 import {
+  parsePublicKey,
   resolvePoolProgram,
   validateAuthorityMatchesWallet,
-  validateOptionalPublicKey,
-  validatePublicKey,
 } from '../../validate.ts'
 
 const MAX_ALT_ADDRESSES = 256
@@ -53,6 +55,15 @@ type AppendToLookupTableParams = {
 /** Parameters for unsigned Solana lookup table append generation. */
 export type GenerateAppendToLookupTableParams = SolanaGenerateParams<AppendToLookupTableParams>
 
+type ParsedAppendToLookupTableParams = {
+  payer: PublicKey
+  authority: PublicKey
+  lookupTableAddress: PublicKey
+  additionalAddresses: PublicKey[]
+  tokenMint?: PublicKey
+  poolProgram?: PublicKey
+}
+
 /** Unsigned append lookup table result. */
 export type GenerateAppendToLookupTableResult = UnsignedSolanaTx
 
@@ -65,17 +76,25 @@ export type ExecuteAppendToLookupTableResult = TransactionResult
 /** Builds and submits Solana ALT extend instructions for token pool setup. */
 export class AppendToLookupTable extends SolanaOperation<
   AppendToLookupTableParams,
-  GenerateAppendToLookupTableResult
+  GenerateAppendToLookupTableResult,
+  ParsedAppendToLookupTableParams
 > {
   readonly name = 'appendToLookupTable'
 
   /** Parses all public keys before any RPC. */
   protected override parse(
     params: GenerateAppendToLookupTableParams,
-  ): GenerateAppendToLookupTableParams {
-    validatePublicKey(this.name, 'lookupTableAddress', params.lookupTableAddress)
-    validatePublicKey(this.name, 'payer', params.payer)
-    validateOptionalPublicKey(this.name, 'authority', params.authority)
+  ): ParsedAppendToLookupTableParams {
+    const payer = parsePublicKey(this.name, 'payer', params.payer)
+    const authority =
+      params.authority === undefined
+        ? payer
+        : parsePublicKey(this.name, 'authority', params.authority)
+    const lookupTableAddress = parsePublicKey(
+      this.name,
+      'lookupTableAddress',
+      params.lookupTableAddress,
+    )
 
     const hasTokenAddress = params.tokenAddress !== undefined
     const hasPoolProgramAddress = params.poolProgramAddress !== undefined
@@ -87,11 +106,14 @@ export class AppendToLookupTable extends SolanaOperation<
         'tokenAddress and exactly one of poolType or poolProgramAddress must be provided together',
       )
     }
-    validateOptionalPublicKey(this.name, 'tokenAddress', params.tokenAddress)
-    if (hasPoolProgram) resolvePoolProgram(this.name, params)
-    for (const [i, address] of (params.additionalAddresses ?? []).entries()) {
-      validatePublicKey(this.name, `additionalAddresses[${i}]`, address)
-    }
+    const tokenMint =
+      params.tokenAddress === undefined
+        ? undefined
+        : parsePublicKey(this.name, 'tokenAddress', params.tokenAddress)
+    const poolProgram = hasPoolProgram ? resolvePoolProgram(this.name, params) : undefined
+    const additionalAddresses = (params.additionalAddresses ?? []).map((address, i) =>
+      parsePublicKey(this.name, `additionalAddresses[${i}]`, address),
+    )
 
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (params.tokenAddress === undefined && !params.additionalAddresses?.length) {
@@ -101,19 +123,22 @@ export class AppendToLookupTable extends SolanaOperation<
         'must provide tokenAddress/poolProgramAddress or additionalAddresses',
       )
     }
-    return params
+    return {
+      payer,
+      authority,
+      lookupTableAddress,
+      additionalAddresses,
+      ...(tokenMint !== undefined && { tokenMint }),
+      ...(poolProgram !== undefined && { poolProgram }),
+    }
   }
 
   /** Builds unsigned ALT extend instructions. */
   protected async buildUnsigned(
     chain: SolanaChain,
-    opts: GenerateAppendToLookupTableParams,
+    opts: ParsedAppendToLookupTableParams,
   ): Promise<GenerateAppendToLookupTableResult> {
-    const payer = new PublicKey(opts.payer)
-    const authority = new PublicKey(opts.authority ?? opts.payer)
-    const lookupTableAddress = new PublicKey(opts.lookupTableAddress)
-    const poolProgram =
-      opts.tokenAddress !== undefined ? resolvePoolProgram(this.name, opts) : undefined
+    const { payer, authority, lookupTableAddress, poolProgram } = opts
     const lookupTable = await chain.connection.getAddressLookupTable(lookupTableAddress)
 
     if (!lookupTable.value) {
@@ -132,10 +157,10 @@ export class AppendToLookupTable extends SolanaOperation<
       )
     }
 
-    const addresses = [...(opts.additionalAddresses ?? []).map((a) => new PublicKey(a))]
+    const addresses = [...opts.additionalAddresses]
 
-    if (opts.tokenAddress !== undefined && poolProgram) {
-      const tokenMint = new PublicKey(opts.tokenAddress)
+    if (opts.tokenMint && poolProgram) {
+      const { tokenMint } = opts
       const ccipAddresses = await deriveCcipLookupTableAddresses(chain, {
         lookupTableAddress,
         tokenMint,
@@ -192,24 +217,18 @@ export class AppendToLookupTable extends SolanaOperation<
     chain: SolanaChain,
     params: ExecuteAppendToLookupTableParams,
   ): Promise<ExecuteAppendToLookupTableResult> {
-    const { wallet, computeUnits, ...rest } = params
-    if (!isWallet(wallet)) throw new CCIPWalletInvalidError(wallet)
+    const { wallet, computeUnits, parsed } = this.prepareWalletExecution(params)
 
-    const payer = wallet.publicKey.toBase58()
-    const generateParams: GenerateAppendToLookupTableParams = { ...rest, payer }
-    this.parse(generateParams)
-
-    const authority = params.authority !== undefined ? new PublicKey(params.authority) : undefined
-    if (authority) {
+    if (params.authority !== undefined) {
       validateAuthorityMatchesWallet(
         this.name,
-        authority,
+        parsed.authority,
         wallet.publicKey,
         'appendToLookupTable requires authority to be the executing wallet. Use generateUnsignedAppendToLookupTable for vault-owned ALTs and have the vault sign/execute it.',
       )
     }
 
-    const tx = await this.buildUnsigned(chain, generateParams)
+    const tx = await this.buildUnsigned(chain, parsed)
     return submit(chain, wallet, tx, this.name, computeUnits)
   }
 }

--- a/ccip-sdk/src/cct/solana/token-admin-registry/operations/create-lookup-table.ts
+++ b/ccip-sdk/src/cct/solana/token-admin-registry/operations/create-lookup-table.ts
@@ -1,9 +1,12 @@
-import { type TransactionInstruction, AddressLookupTableProgram, PublicKey } from '@solana/web3.js'
+import {
+  type PublicKey,
+  type TransactionInstruction,
+  AddressLookupTableProgram,
+} from '@solana/web3.js'
 
-import { CCIPWalletInvalidError } from '../../../../errors/index.ts'
 import { ChainFamily } from '../../../../networks.ts'
 import type { SolanaChain } from '../../../../solana/index.ts'
-import { type UnsignedSolanaTx, isWallet } from '../../../../solana/types.ts'
+import type { UnsignedSolanaTx } from '../../../../solana/types.ts'
 import { CCTParamsInvalidError } from '../../../errors.ts'
 import type { TransactionResult } from '../../../operation.ts'
 import {
@@ -18,10 +21,9 @@ import {
 import type { PoolProgramRef } from '../../programs/token-pool.ts'
 import { submit } from '../../submit.ts'
 import {
+  parsePublicKey,
   resolvePoolProgram,
   validateAuthorityMatchesWallet,
-  validateOptionalPublicKey,
-  validatePublicKey,
 } from '../../validate.ts'
 
 const MAX_ALT_ADDRESSES = 256
@@ -49,6 +51,17 @@ type CreateLookupTableParams =
 /** Parameters for unsigned Solana lookup table generation. */
 export type GenerateCreateLookupTableParams = SolanaGenerateParams<CreateLookupTableParams>
 
+type ParsedCreateLookupTableParams =
+  | { mode: 'createEmpty'; payer: PublicKey; authority: PublicKey }
+  | {
+      mode: 'createAndExtend'
+      payer: PublicKey
+      authority: PublicKey
+      tokenMint: PublicKey
+      poolProgram: PublicKey
+      additionalAddresses: PublicKey[]
+    }
+
 /** Unsigned create lookup table result, including the derived ALT address. */
 export type GenerateCreateLookupTableResult = UnsignedSolanaTx & {
   lookupTableAddress: string
@@ -63,33 +76,38 @@ export type ExecuteCreateLookupTableResult = TransactionResult & { lookupTableAd
 /** Builds and submits Solana ALT create instructions, optionally with extend instructions. */
 export class CreateLookupTable extends SolanaOperation<
   CreateLookupTableParams,
-  GenerateCreateLookupTableResult
+  GenerateCreateLookupTableResult,
+  ParsedCreateLookupTableParams
 > {
   readonly name = 'createLookupTable'
 
   /** Parses params before `buildUnsigned()` performs any RPC. */
-  protected override parse(
-    params: GenerateCreateLookupTableParams,
-  ): GenerateCreateLookupTableParams {
-    validatePublicKey(this.name, 'payer', params.payer)
-    validateOptionalPublicKey(this.name, 'authority', params.authority)
-    if (params.mode === 'createEmpty') return params
+  protected override parse(params: GenerateCreateLookupTableParams): ParsedCreateLookupTableParams {
+    const payer = parsePublicKey(this.name, 'payer', params.payer)
+    const authority =
+      params.authority === undefined
+        ? payer
+        : parsePublicKey(this.name, 'authority', params.authority)
+    if (params.mode === 'createEmpty') return { mode: 'createEmpty', payer, authority }
 
-    validatePublicKey(this.name, 'tokenAddress', params.tokenAddress)
-    resolvePoolProgram(this.name, params)
-    for (const [i, address] of (params.additionalAddresses ?? []).entries()) {
-      validatePublicKey(this.name, `additionalAddresses[${i}]`, address)
+    return {
+      mode: 'createAndExtend',
+      payer,
+      authority,
+      tokenMint: parsePublicKey(this.name, 'tokenAddress', params.tokenAddress),
+      poolProgram: resolvePoolProgram(this.name, params),
+      additionalAddresses: (params.additionalAddresses ?? []).map((address, i) =>
+        parsePublicKey(this.name, `additionalAddresses[${i}]`, address),
+      ),
     }
-    return params
   }
 
   /** Builds unsigned ALT create instructions, optionally with extend instructions. */
   protected async buildUnsigned(
     chain: SolanaChain,
-    opts: GenerateCreateLookupTableParams,
+    opts: ParsedCreateLookupTableParams,
   ): Promise<GenerateCreateLookupTableResult> {
-    const payer = new PublicKey(opts.payer)
-    const authority = new PublicKey(opts.authority ?? opts.payer)
+    const { payer, authority } = opts
 
     if (opts.mode === 'createEmpty') {
       const { instruction: createIx, lookupTableAddress } = buildCreateLookupTableInstruction({
@@ -108,10 +126,7 @@ export class CreateLookupTable extends SolanaOperation<
       }
     }
 
-    // Validate and parse the pool program before calling slot RPC below.
-    const poolProgram = resolvePoolProgram(this.name, opts)
-    const tokenMint = new PublicKey(opts.tokenAddress)
-    const additionalAddresses = (opts.additionalAddresses ?? []).map((a) => new PublicKey(a))
+    const { poolProgram, tokenMint, additionalAddresses } = opts
 
     const { instruction: createIx, lookupTableAddress } = buildCreateLookupTableInstruction({
       authority,
@@ -162,25 +177,18 @@ export class CreateLookupTable extends SolanaOperation<
     chain: SolanaChain,
     params: ExecuteCreateLookupTableParams,
   ): Promise<ExecuteCreateLookupTableResult> {
-    const { wallet, computeUnits, ...rest } = params
-    if (!isWallet(wallet)) throw new CCIPWalletInvalidError(wallet)
+    const { wallet, computeUnits, parsed } = this.prepareWalletExecution(params)
 
-    const payer = wallet.publicKey.toBase58()
-    const generateParams: GenerateCreateLookupTableParams = { ...rest, payer }
-
-    this.parse(generateParams)
-
-    const authority = params.authority !== undefined ? new PublicKey(params.authority) : undefined
-    if (params.mode !== 'createEmpty' && authority) {
+    if (params.mode !== 'createEmpty' && params.authority !== undefined) {
       validateAuthorityMatchesWallet(
         this.name,
-        authority,
+        parsed.authority,
         wallet.publicKey,
         "createAndExtend requires authority to be the executing wallet. Use 'createEmpty' mode for vault-owned ALTs.",
       )
     }
 
-    const tx = await this.buildUnsigned(chain, generateParams)
+    const tx = await this.buildUnsigned(chain, parsed)
     const hash = await submit(chain, wallet, tx, this.name, computeUnits)
     return { ...hash, lookupTableAddress: tx.lookupTableAddress }
   }

--- a/ccip-sdk/src/cct/solana/token-admin-registry/operations/register-admin.ts
+++ b/ccip-sdk/src/cct/solana/token-admin-registry/operations/register-admin.ts
@@ -1,10 +1,9 @@
 import { unpackMint } from '@solana/spl-token'
 import { type TransactionInstruction, PublicKey } from '@solana/web3.js'
 
-import { CCIPWalletInvalidError } from '../../../../errors/index.ts'
 import { ChainFamily } from '../../../../networks.ts'
 import type { SolanaChain } from '../../../../solana/index.ts'
-import { type UnsignedSolanaTx, isWallet } from '../../../../solana/types.ts'
+import type { UnsignedSolanaTx } from '../../../../solana/types.ts'
 import { resolveTokenMint } from '../../../../solana/utils.ts'
 import { CCTParamsInvalidError } from '../../../errors.ts'
 import type { TransactionResult } from '../../../operation.ts'
@@ -19,11 +18,7 @@ import {
   deriveTokenAdminRegistryPda,
 } from '../../programs/router.ts'
 import { submit } from '../../submit.ts'
-import {
-  validateAuthorityMatchesWallet,
-  validateOptionalPublicKey,
-  validatePublicKey,
-} from '../../validate.ts'
+import { parsePublicKey, validateAuthorityMatchesWallet } from '../../validate.ts'
 
 /** Authorization paths used to register a token in the TokenAdminRegistry. */
 const REGISTER_ADMIN_METHODS = {
@@ -56,6 +51,15 @@ type RegisterAdminParams = {
 
 /** Parameters for unsigned Solana token registration generation. */
 export type GenerateRegisterAdminParams = SolanaGenerateParams<RegisterAdminParams>
+
+type ParsedRegisterAdminParams = {
+  tokenMint: PublicKey
+  address: PublicKey
+  payer: PublicKey
+  authority: PublicKey
+  administrator?: PublicKey
+  method: RegisterAdminMethod
+}
 
 /** Unsigned Solana token registration result. */
 export type GenerateRegisterAdminResult = UnsignedSolanaTx
@@ -131,16 +135,15 @@ async function buildCcipAdminInstruction(
 }
 
 /** Registers a token through either its mint authority or the Router CCIP admin. */
-export class RegisterAdmin extends SolanaOperation<RegisterAdminParams> {
+export class RegisterAdmin extends SolanaOperation<
+  RegisterAdminParams,
+  UnsignedSolanaTx,
+  ParsedRegisterAdminParams
+> {
   readonly name = 'registerAdmin'
 
   /** Parses all caller-supplied parameters before RPC. */
-  protected override parse(params: GenerateRegisterAdminParams): GenerateRegisterAdminParams {
-    validatePublicKey(this.name, 'tokenAddress', params.tokenAddress)
-    validatePublicKey(this.name, 'address', params.address)
-    validatePublicKey(this.name, 'payer', params.payer)
-    validateOptionalPublicKey(this.name, 'administrator', params.administrator)
-    validateOptionalPublicKey(this.name, 'authority', params.authority)
+  protected override parse(params: GenerateRegisterAdminParams): ParsedRegisterAdminParams {
     if (
       params.registrationMethod !== undefined &&
       !Object.values(REGISTER_ADMIN_METHODS).includes(params.registrationMethod)
@@ -151,25 +154,33 @@ export class RegisterAdmin extends SolanaOperation<RegisterAdminParams> {
         'must be owner or ccip-admin',
       )
     }
-    return params
+    const payer = parsePublicKey(this.name, 'payer', params.payer)
+    return {
+      tokenMint: parsePublicKey(this.name, 'tokenAddress', params.tokenAddress),
+      address: parsePublicKey(this.name, 'address', params.address),
+      payer,
+      authority:
+        params.authority === undefined
+          ? payer
+          : parsePublicKey(this.name, 'authority', params.authority),
+      ...(params.administrator !== undefined && {
+        administrator: parsePublicKey(this.name, 'administrator', params.administrator),
+      }),
+      method: params.registrationMethod ?? REGISTER_ADMIN_METHODS.OWNER,
+    }
   }
 
   /** Builds an unsigned token registration instruction. */
   protected async buildUnsigned(
     chain: SolanaChain,
-    opts: GenerateRegisterAdminParams,
+    opts: ParsedRegisterAdminParams,
   ): Promise<UnsignedSolanaTx> {
-    const routerAddress = await chain.getTokenAdminRegistryFor(opts.address)
-    const router = new PublicKey(routerAddress)
-    const tokenMint = new PublicKey(opts.tokenAddress)
-    const payer = new PublicKey(opts.payer)
-    const authority = new PublicKey(opts.authority ?? opts.payer)
+    const router = new PublicKey(await chain.getTokenAdminRegistryFor(opts.address.toBase58()))
+    const { tokenMint, payer, authority, method } = opts
 
     const mintAccount = await resolveTokenMint(chain.connection, tokenMint)
     const { mintAuthority } = unpackMint(tokenMint, mintAccount, mintAccount.owner)
-    const administrator =
-      opts.administrator !== undefined ? new PublicKey(opts.administrator) : mintAuthority
-    const method = opts.registrationMethod ?? REGISTER_ADMIN_METHODS.OWNER
+    const administrator = opts.administrator ?? mintAuthority
     const config = deriveRouterConfigPda(router)
     const tokenAdminRegistry = deriveTokenAdminRegistryPda(router, tokenMint)
     if (await chain.connection.getAccountInfo(tokenAdminRegistry)) {
@@ -223,24 +234,18 @@ export class RegisterAdmin extends SolanaOperation<RegisterAdminParams> {
     chain: SolanaChain,
     params: ExecuteRegisterAdminParams,
   ): Promise<ExecuteRegisterAdminResult> {
-    const { wallet, computeUnits, ...rest } = params
-    if (!isWallet(wallet)) throw new CCIPWalletInvalidError(wallet)
+    const { wallet, computeUnits, parsed } = this.prepareWalletExecution(params)
 
-    const payer = wallet.publicKey.toBase58()
-    const generateParams: GenerateRegisterAdminParams = { ...rest, payer }
-    this.parse(generateParams)
-
-    const authority = params.authority !== undefined ? new PublicKey(params.authority) : undefined
-    if (authority) {
+    if (params.authority !== undefined) {
       validateAuthorityMatchesWallet(
         this.name,
-        authority,
+        parsed.authority,
         wallet.publicKey,
         'registerAdmin requires authority to be the executing wallet. Use generateUnsignedRegisterAdmin for externally signed transactions.',
       )
     }
 
-    const tx = await this.buildUnsigned(chain, generateParams)
+    const tx = await this.buildUnsigned(chain, parsed)
     return submit(chain, wallet, tx, this.name, computeUnits)
   }
 }

--- a/ccip-sdk/src/cct/solana/token-admin-registry/operations/set-pool.ts
+++ b/ccip-sdk/src/cct/solana/token-admin-registry/operations/set-pool.ts
@@ -16,11 +16,7 @@ import {
   deriveRouterConfigPda,
   deriveTokenAdminRegistryPda,
 } from '../../programs/router.ts'
-import {
-  validateOptionalPublicKey,
-  validatePublicKey,
-  validateWritableIndexes,
-} from '../../validate.ts'
+import { parsePublicKey, validateWritableIndexes } from '../../validate.ts'
 
 /** Standard BurnMint/LockRelease pool ALT writable positions. */
 export const DEFAULT_WRITABLE_INDEXES = [3, 4, 7] as const
@@ -52,6 +48,15 @@ type SetPoolParams = {
 /** Parameters for unsigned Solana TokenAdminRegistry `setPool` generation. */
 export type GenerateSetPoolParams = SolanaGenerateParams<SetPoolParams>
 
+type ParsedSetPoolParams = {
+  tokenMint: PublicKey
+  address: PublicKey
+  lookupTable: PublicKey
+  payer: PublicKey
+  authority: PublicKey
+  writableIndexes: number[]
+}
+
 /** Unsigned Solana TokenAdminRegistry `setPool` result. */
 export type GenerateSetPoolResult = UnsignedSolanaTx
 
@@ -62,39 +67,44 @@ export type ExecuteSetPoolParams = SolanaExecuteParams<SetPoolParams>
 export type ExecuteSetPoolResult = TransactionResult
 
 /** Solana TokenAdminRegistry `setPool` operation. */
-export class SetPool extends SolanaOperation<SetPoolParams> {
+export class SetPool extends SolanaOperation<SetPoolParams, UnsignedSolanaTx, ParsedSetPoolParams> {
   readonly name = 'setPool'
 
   /** Parses all public keys before any RPC. */
-  protected override parse(params: GenerateSetPoolParams): GenerateSetPoolParams {
-    validatePublicKey(this.name, 'tokenAddress', params.tokenAddress)
-    validatePublicKey(this.name, 'address', params.address)
-    validatePublicKey(this.name, 'poolLookupTableAddress', params.poolLookupTableAddress)
-    validatePublicKey(this.name, 'payer', params.payer)
-    validateOptionalPublicKey(this.name, 'authority', params.authority)
+  protected override parse(params: GenerateSetPoolParams): ParsedSetPoolParams {
     validateWritableIndexes(this.name, 'writableIndexes', params.writableIndexes)
-    return params
+    const payer = parsePublicKey(this.name, 'payer', params.payer)
+    return {
+      tokenMint: parsePublicKey(this.name, 'tokenAddress', params.tokenAddress),
+      address: parsePublicKey(this.name, 'address', params.address),
+      lookupTable: parsePublicKey(
+        this.name,
+        'poolLookupTableAddress',
+        params.poolLookupTableAddress,
+      ),
+      payer,
+      authority:
+        params.authority === undefined
+          ? payer
+          : parsePublicKey(this.name, 'authority', params.authority),
+      writableIndexes: params.writableIndexes ?? [...DEFAULT_WRITABLE_INDEXES],
+    }
   }
 
   /** Builds the unsigned Solana `setPool` instruction set. */
   protected async buildUnsigned(
     chain: SolanaChain,
-    opts: GenerateSetPoolParams,
+    opts: ParsedSetPoolParams,
   ): Promise<UnsignedSolanaTx> {
-    const routerAddress = await chain.getTokenAdminRegistryFor(opts.address)
-    const router = new PublicKey(routerAddress)
-    const tokenMint = new PublicKey(opts.tokenAddress)
-    const payer = new PublicKey(opts.payer)
-    const authority = new PublicKey(opts.authority ?? opts.payer)
-    const lookupTable = new PublicKey(opts.poolLookupTableAddress)
+    const router = new PublicKey(await chain.getTokenAdminRegistryFor(opts.address.toBase58()))
+    const { tokenMint, payer, authority, lookupTable } = opts
 
     const routerProgram = createRouterProgram(chain, router, payer)
     const config = deriveRouterConfigPda(router)
     const tokenAdminRegistry = deriveTokenAdminRegistryPda(router, tokenMint)
 
-    const writableIndexes = opts.writableIndexes ?? [...DEFAULT_WRITABLE_INDEXES]
     const instruction = await routerProgram.methods
-      .setPool(Buffer.from(writableIndexes))
+      .setPool(Buffer.from(opts.writableIndexes))
       .accounts({
         config,
         tokenAdminRegistry,

--- a/ccip-sdk/src/cct/solana/token-admin-registry/operations/transfer-admin.ts
+++ b/ccip-sdk/src/cct/solana/token-admin-registry/operations/transfer-admin.ts
@@ -1,9 +1,8 @@
 import { PublicKey } from '@solana/web3.js'
 
-import { CCIPWalletInvalidError } from '../../../../errors/index.ts'
 import { ChainFamily } from '../../../../networks.ts'
 import type { SolanaChain } from '../../../../solana/index.ts'
-import { type UnsignedSolanaTx, isWallet } from '../../../../solana/types.ts'
+import type { UnsignedSolanaTx } from '../../../../solana/types.ts'
 import { CCTParamsInvalidError } from '../../../errors.ts'
 import type { TransactionResult } from '../../../operation.ts'
 import {
@@ -17,11 +16,7 @@ import {
   deriveTokenAdminRegistryPda,
 } from '../../programs/router.ts'
 import { submit } from '../../submit.ts'
-import {
-  validateAuthorityMatchesWallet,
-  validateOptionalPublicKey,
-  validatePublicKey,
-} from '../../validate.ts'
+import { parsePublicKey, validateAuthorityMatchesWallet } from '../../validate.ts'
 
 /** Parameters shared by Solana TokenAdminRegistry `transferAdmin` generation and execution. */
 type TransferAdminParams = {
@@ -40,6 +35,14 @@ type TransferAdminParams = {
 /** Parameters for unsigned Solana TokenAdminRegistry `transferAdmin` generation. */
 export type GenerateTransferAdminParams = SolanaGenerateParams<TransferAdminParams>
 
+type ParsedTransferAdminParams = {
+  tokenMint: PublicKey
+  address: PublicKey
+  newAdmin: PublicKey
+  payer: PublicKey
+  authority: PublicKey
+}
+
 /** Unsigned Solana TokenAdminRegistry `transferAdmin` result. */
 export type GenerateTransferAdminResult = UnsignedSolanaTx
 
@@ -50,29 +53,35 @@ export type ExecuteTransferAdminParams = SolanaExecuteParams<TransferAdminParams
 export type ExecuteTransferAdminResult = TransactionResult
 
 /** Transfers a TokenAdminRegistry administrator role. The proposed admin must accept separately. */
-export class TransferAdmin extends SolanaOperation<TransferAdminParams> {
+export class TransferAdmin extends SolanaOperation<
+  TransferAdminParams,
+  UnsignedSolanaTx,
+  ParsedTransferAdminParams
+> {
   readonly name = 'transferAdmin'
 
   /** Parses all public keys before any RPC. */
-  protected override parse(params: GenerateTransferAdminParams): GenerateTransferAdminParams {
-    validatePublicKey(this.name, 'tokenAddress', params.tokenAddress)
-    validatePublicKey(this.name, 'address', params.address)
-    validatePublicKey(this.name, 'newAdmin', params.newAdmin)
-    validatePublicKey(this.name, 'payer', params.payer)
-    validateOptionalPublicKey(this.name, 'authority', params.authority)
-    return params
+  protected override parse(params: GenerateTransferAdminParams): ParsedTransferAdminParams {
+    const payer = parsePublicKey(this.name, 'payer', params.payer)
+    return {
+      tokenMint: parsePublicKey(this.name, 'tokenAddress', params.tokenAddress),
+      address: parsePublicKey(this.name, 'address', params.address),
+      newAdmin: parsePublicKey(this.name, 'newAdmin', params.newAdmin),
+      payer,
+      authority:
+        params.authority === undefined
+          ? payer
+          : parsePublicKey(this.name, 'authority', params.authority),
+    }
   }
 
   /** Builds the unsigned instruction after confirming the caller is the current admin. */
   protected async buildUnsigned(
     chain: SolanaChain,
-    opts: GenerateTransferAdminParams,
+    opts: ParsedTransferAdminParams,
   ): Promise<UnsignedSolanaTx> {
-    const tokenMint = new PublicKey(opts.tokenAddress)
-    const payer = new PublicKey(opts.payer)
-    const authority = new PublicKey(opts.authority ?? opts.payer)
-    const newAdmin = new PublicKey(opts.newAdmin)
-    const router = new PublicKey(await chain.getTokenAdminRegistryFor(opts.address))
+    const { tokenMint, payer, authority, newAdmin } = opts
+    const router = new PublicKey(await chain.getTokenAdminRegistryFor(opts.address.toBase58()))
     const tokenConfig = await chain.getRegistryTokenConfig(router.toBase58(), tokenMint.toBase58())
 
     if (!new PublicKey(tokenConfig.administrator).equals(authority)) {
@@ -107,28 +116,17 @@ export class TransferAdmin extends SolanaOperation<TransferAdminParams> {
     chain: SolanaChain,
     params: ExecuteTransferAdminParams,
   ): Promise<ExecuteTransferAdminResult> {
-    const { wallet, computeUnits, ...rest } = params
-    if (!isWallet(wallet)) throw new CCIPWalletInvalidError(wallet)
-
-    const payer = wallet.publicKey.toBase58()
-    const generateParams: GenerateTransferAdminParams = { ...rest, payer }
-    this.parse(generateParams)
+    const { wallet, computeUnits, parsed } = this.prepareWalletExecution(params)
 
     if (params.authority !== undefined) {
       validateAuthorityMatchesWallet(
         this.name,
-        new PublicKey(params.authority),
+        parsed.authority,
         wallet.publicKey,
         'transferAdmin requires authority to be the executing wallet. Use generateUnsignedTransferAdmin for externally signed transactions.',
       )
     }
 
-    return submit(
-      chain,
-      wallet,
-      await this.buildUnsigned(chain, generateParams),
-      this.name,
-      computeUnits,
-    )
+    return submit(chain, wallet, await this.buildUnsigned(chain, parsed), this.name, computeUnits)
   }
 }

--- a/ccip-sdk/src/cct/solana/token-pool/operations/create-token-multisig.ts
+++ b/ccip-sdk/src/cct/solana/token-pool/operations/create-token-multisig.ts
@@ -2,10 +2,9 @@ import { MULTISIG_SIZE, createInitializeMultisigInstruction, unpackMint } from '
 import { PublicKey, SystemProgram } from '@solana/web3.js'
 import { concat, hexlify, randomBytes, sha256, toUtf8Bytes } from 'ethers'
 
-import { CCIPWalletInvalidError } from '../../../../errors/index.ts'
 import { ChainFamily } from '../../../../networks.ts'
 import type { SolanaChain } from '../../../../solana/index.ts'
-import { type UnsignedSolanaTx, isWallet } from '../../../../solana/types.ts'
+import type { UnsignedSolanaTx } from '../../../../solana/types.ts'
 import { resolveTokenMint } from '../../../../solana/utils.ts'
 import { CCTParamsInvalidError } from '../../../errors.ts'
 import type { TransactionResult } from '../../../operation.ts'
@@ -21,12 +20,11 @@ import {
 } from '../../programs/token-pool.ts'
 import { submit } from '../../submit.ts'
 import {
+  parsePublicKey,
   validateAuthorityMatchesWallet,
   validateInteger,
   validateNonEmptyString,
   validatePoolType,
-  validatePublicKey,
-  validatePublicKeys,
 } from '../../validate.ts'
 
 export const SOLANA_MULTISIG_MAX_SIGNERS = 11
@@ -51,6 +49,15 @@ type CreateTokenMultisigParams = {
 
 /** Parameters for unsigned Solana token multisig generation. */
 export type GenerateCreateTokenMultisigParams = SolanaGenerateParams<CreateTokenMultisigParams>
+
+type ParsedCreateTokenMultisigParams = {
+  tokenMint: PublicKey
+  poolProgram: PublicKey
+  payer: PublicKey
+  threshold: number
+  additionalSigners: PublicKey[]
+  seed?: string
+}
 
 /** Unsigned token multisig transaction plus the created multisig address. */
 export type GenerateCreateTokenMultisigResult = UnsignedSolanaTx & { multisigAddress: string }
@@ -129,34 +136,38 @@ function getMintAuthority(
  */
 export class CreateTokenMultisig extends SolanaOperation<
   CreateTokenMultisigParams,
-  GenerateCreateTokenMultisigResult
+  GenerateCreateTokenMultisigResult,
+  ParsedCreateTokenMultisigParams
 > {
   readonly name = 'createTokenMultisig'
 
   /** Parses public keys, threshold, and optional seed before mint/account RPCs. */
   protected override parse(
     params: GenerateCreateTokenMultisigParams,
-  ): GenerateCreateTokenMultisigParams {
-    validatePublicKey(this.name, 'tokenAddress', params.tokenAddress)
+  ): ParsedCreateTokenMultisigParams {
     validatePoolType(this.name, 'poolType', params.poolType)
-    validatePublicKey(this.name, 'payer', params.payer)
-    if (params.additionalSigners !== undefined) {
-      validatePublicKeys(this.name, 'additionalSigners', params.additionalSigners)
-    }
     validateInteger(this.name, 'threshold', params.threshold, 1, SOLANA_MULTISIG_MAX_SIGNERS)
     if (params.seed !== undefined) validateNonEmptyString(this.name, 'seed', params.seed)
-    return params
+
+    return {
+      tokenMint: parsePublicKey(this.name, 'tokenAddress', params.tokenAddress),
+      poolProgram: resolveTokenPoolProgram(params.poolType),
+      payer: parsePublicKey(this.name, 'payer', params.payer),
+      threshold: params.threshold,
+      additionalSigners: (params.additionalSigners ?? []).map((signer, i) =>
+        parsePublicKey(this.name, `additionalSigners[${i}]`, signer),
+      ),
+      ...(params.seed !== undefined && { seed: params.seed }),
+    }
   }
 
   /** Builds create-with-seed and initialize-multisig instructions. */
   protected async buildUnsigned(
     chain: SolanaChain,
-    opts: GenerateCreateTokenMultisigParams,
+    opts: ParsedCreateTokenMultisigParams,
     mintContext?: { account: MintAccount; authority: PublicKey },
   ): Promise<GenerateCreateTokenMultisigResult> {
-    const payer = new PublicKey(opts.payer)
-    const tokenMint = new PublicKey(opts.tokenAddress)
-    const poolProgram = resolveTokenPoolProgram(opts.poolType)
+    const { payer, tokenMint, poolProgram } = opts
     const mintAccount =
       mintContext?.account ?? (await resolveTokenMint(chain.connection, tokenMint))
 
@@ -165,10 +176,9 @@ export class CreateTokenMultisig extends SolanaOperation<
       mintContext?.authority ?? getMintAuthority(this.name, tokenMint, mintAccount, tokenProgram)
 
     const poolSigner = deriveTokenPoolSignerPda(poolProgram, tokenMint)
-    const nonPoolSigners = dedupePublicKeys([
-      authority,
-      ...(opts.additionalSigners ?? []).map((signer) => new PublicKey(signer)),
-    ]).filter((signer) => !signer.equals(poolSigner))
+    const nonPoolSigners = dedupePublicKeys([authority, ...opts.additionalSigners]).filter(
+      (signer) => !signer.equals(poolSigner),
+    )
 
     const signers = [...Array.from({ length: opts.threshold }, () => poolSigner), ...nonPoolSigners]
     validatePoolMultisigConfig(this.name, signers, poolSigner, opts.threshold)
@@ -209,20 +219,11 @@ export class CreateTokenMultisig extends SolanaOperation<
     chain: SolanaChain,
     params: ExecuteCreateTokenMultisigParams,
   ): Promise<ExecuteCreateTokenMultisigResult> {
-    const { wallet, computeUnits, ...rest } = params
-    if (!isWallet(wallet)) throw new CCIPWalletInvalidError(wallet)
-
-    const generateParams: GenerateCreateTokenMultisigParams = {
-      ...rest,
-      payer: wallet.publicKey.toBase58(),
-    }
-    this.parse(generateParams)
-
-    const tokenMint = new PublicKey(generateParams.tokenAddress)
-    const mintAccount = await resolveTokenMint(chain.connection, tokenMint)
+    const { wallet, computeUnits, parsed } = this.prepareWalletExecution(params)
+    const mintAccount = await resolveTokenMint(chain.connection, parsed.tokenMint)
 
     const tokenProgram = mintAccount.owner
-    const mintAuthority = getMintAuthority(this.name, tokenMint, mintAccount, tokenProgram)
+    const mintAuthority = getMintAuthority(this.name, parsed.tokenMint, mintAccount, tokenProgram)
     validateAuthorityMatchesWallet(
       this.name,
       mintAuthority,
@@ -230,7 +231,7 @@ export class CreateTokenMultisig extends SolanaOperation<
       'createTokenMultisig requires the executing wallet to be the mint authority. Use generateUnsignedCreateTokenMultisig for vault-owned mints and have the vault sign/execute it.',
     )
 
-    const tx = await this.buildUnsigned(chain, generateParams, {
+    const tx = await this.buildUnsigned(chain, parsed, {
       account: mintAccount,
       authority: mintAuthority,
     })

--- a/ccip-sdk/src/cct/solana/token-pool/operations/create-token-multisig.ts
+++ b/ccip-sdk/src/cct/solana/token-pool/operations/create-token-multisig.ts
@@ -146,6 +146,9 @@ export class CreateTokenMultisig extends SolanaOperation<
     params: GenerateCreateTokenMultisigParams,
   ): ParsedCreateTokenMultisigParams {
     validatePoolType(this.name, 'poolType', params.poolType)
+    if (params.additionalSigners !== undefined && !Array.isArray(params.additionalSigners)) {
+      throw new CCTParamsInvalidError(this.name, 'additionalSigners', 'must be an array')
+    }
     validateInteger(this.name, 'threshold', params.threshold, 1, SOLANA_MULTISIG_MAX_SIGNERS)
     if (params.seed !== undefined) validateNonEmptyString(this.name, 'seed', params.seed)
 

--- a/ccip-sdk/src/cct/solana/token-pool/operations/deploy-token-pool.ts
+++ b/ccip-sdk/src/cct/solana/token-pool/operations/deploy-token-pool.ts
@@ -3,6 +3,7 @@ import { type PublicKey, SystemProgram } from '@solana/web3.js'
 import { ChainFamily } from '../../../../networks.ts'
 import type { SolanaChain } from '../../../../solana/index.ts'
 import type { UnsignedSolanaTx } from '../../../../solana/types.ts'
+import { CCTParamsInvalidError } from '../../../errors.ts'
 import type { TransactionResult } from '../../../operation.ts'
 import {
   type SolanaExecuteParams,
@@ -82,6 +83,9 @@ export class DeployTokenPool extends SolanaOperation<
   /** Parses all public keys before any RPC. */
   protected override parse(params: GenerateDeployTokenPoolParams): ParsedDeployTokenPoolParams {
     validatePoolType(this.name, 'poolType', params.poolType)
+    if (params.allowlist !== undefined && !Array.isArray(params.allowlist)) {
+      throw new CCTParamsInvalidError(this.name, 'allowlist', 'must be an array')
+    }
 
     const payer = parsePublicKey(this.name, 'payer', params.payer)
     return {

--- a/ccip-sdk/src/cct/solana/token-pool/operations/deploy-token-pool.ts
+++ b/ccip-sdk/src/cct/solana/token-pool/operations/deploy-token-pool.ts
@@ -1,9 +1,8 @@
-import { PublicKey, SystemProgram } from '@solana/web3.js'
+import { type PublicKey, SystemProgram } from '@solana/web3.js'
 
-import { CCIPWalletInvalidError } from '../../../../errors/index.ts'
 import { ChainFamily } from '../../../../networks.ts'
 import type { SolanaChain } from '../../../../solana/index.ts'
-import { type UnsignedSolanaTx, isWallet } from '../../../../solana/types.ts'
+import type { UnsignedSolanaTx } from '../../../../solana/types.ts'
 import type { TransactionResult } from '../../../operation.ts'
 import {
   type SolanaExecuteParams,
@@ -20,13 +19,7 @@ import {
   resolveTokenPoolProgram,
 } from '../../programs/token-pool.ts'
 import { submit } from '../../submit.ts'
-import {
-  validateAuthorityMatchesWallet,
-  validateOptionalPublicKey,
-  validatePoolType,
-  validatePublicKey,
-  validatePublicKeys,
-} from '../../validate.ts'
+import { parsePublicKey, validateAuthorityMatchesWallet, validatePoolType } from '../../validate.ts'
 
 /**
  * Parameters for initializing a Solana token pool, optionally with an allowlist.
@@ -55,6 +48,14 @@ type DeployTokenPoolParams = {
 /** Parameters for unsigned Solana token pool deploy generation. */
 export type GenerateDeployTokenPoolParams = SolanaGenerateParams<DeployTokenPoolParams>
 
+type ParsedDeployTokenPoolParams = {
+  tokenMint: PublicKey
+  poolProgram: PublicKey
+  payer: PublicKey
+  authority: PublicKey
+  allowlist: PublicKey[]
+}
+
 /** Unsigned Solana token pool deploy result plus derived pool PDAs. */
 export type GenerateDeployTokenPoolResult = UnsignedSolanaTx & {
   poolAddress: string
@@ -73,29 +74,36 @@ export type ExecuteDeployTokenPoolResult = TransactionResult & {
 /** Initializes a Solana token pool, optionally configuring an allowlist. */
 export class DeployTokenPool extends SolanaOperation<
   DeployTokenPoolParams,
-  GenerateDeployTokenPoolResult
+  GenerateDeployTokenPoolResult,
+  ParsedDeployTokenPoolParams
 > {
   readonly name = 'deployTokenPool'
 
   /** Parses all public keys before any RPC. */
-  protected override parse(params: GenerateDeployTokenPoolParams): GenerateDeployTokenPoolParams {
-    validatePublicKey(this.name, 'tokenAddress', params.tokenAddress)
+  protected override parse(params: GenerateDeployTokenPoolParams): ParsedDeployTokenPoolParams {
     validatePoolType(this.name, 'poolType', params.poolType)
-    validatePublicKey(this.name, 'payer', params.payer)
-    validateOptionalPublicKey(this.name, 'authority', params.authority)
-    if (params.allowlist !== undefined) validatePublicKeys(this.name, 'allowlist', params.allowlist)
-    return params
+
+    const payer = parsePublicKey(this.name, 'payer', params.payer)
+    return {
+      tokenMint: parsePublicKey(this.name, 'tokenAddress', params.tokenAddress),
+      poolProgram: resolveTokenPoolProgram(params.poolType),
+      payer,
+      authority:
+        params.authority === undefined
+          ? payer
+          : parsePublicKey(this.name, 'authority', params.authority),
+      allowlist: (params.allowlist ?? []).map((address, i) =>
+        parsePublicKey(this.name, `allowlist[${i}]`, address),
+      ),
+    }
   }
 
   /** Builds the unsigned Solana token pool initialize instruction set. */
   protected async buildUnsigned(
     chain: SolanaChain,
-    opts: GenerateDeployTokenPoolParams,
+    opts: ParsedDeployTokenPoolParams,
   ): Promise<GenerateDeployTokenPoolResult> {
-    const tokenMint = new PublicKey(opts.tokenAddress)
-    const poolProgram = resolveTokenPoolProgram(opts.poolType)
-    const payer = new PublicKey(opts.payer)
-    const authority = new PublicKey(opts.authority ?? opts.payer)
+    const { tokenMint, poolProgram, payer, authority, allowlist } = opts
     const program = createTokenPoolProgram(chain, poolProgram, payer)
     const state = deriveTokenPoolConfigPda(poolProgram, tokenMint)
     const poolSigner = deriveTokenPoolSignerPda(poolProgram, tokenMint)
@@ -115,7 +123,6 @@ export class DeployTokenPool extends SolanaOperation<
         .instruction(),
     ]
 
-    const allowlist = (opts.allowlist ?? []).map((a) => new PublicKey(a))
     if (allowlist.length) {
       instructions.push(
         await program.methods
@@ -147,24 +154,18 @@ export class DeployTokenPool extends SolanaOperation<
     chain: SolanaChain,
     params: ExecuteDeployTokenPoolParams,
   ): Promise<ExecuteDeployTokenPoolResult> {
-    const { wallet, computeUnits, ...rest } = params
-    if (!isWallet(wallet)) throw new CCIPWalletInvalidError(wallet)
+    const { wallet, computeUnits, parsed } = this.prepareWalletExecution(params)
 
-    const payer = wallet.publicKey.toBase58()
-    const generateParams: GenerateDeployTokenPoolParams = { ...rest, payer }
-    this.parse(generateParams)
-
-    const authority = params.authority !== undefined ? new PublicKey(params.authority) : undefined
-    if (authority) {
+    if (params.authority !== undefined) {
       validateAuthorityMatchesWallet(
         this.name,
-        authority,
+        parsed.authority,
         wallet.publicKey,
         'deployTokenPool requires authority to be the executing wallet. Use generateUnsignedDeployTokenPool for vault-owned pools and have the vault sign/execute it.',
       )
     }
 
-    const tx = await this.buildUnsigned(chain, generateParams)
+    const tx = await this.buildUnsigned(chain, parsed)
     const hash = await submit(chain, wallet, tx, this.name, computeUnits)
     return {
       ...hash,

--- a/ccip-sdk/src/cct/solana/token/operations/create-token-account.ts
+++ b/ccip-sdk/src/cct/solana/token/operations/create-token-account.ts
@@ -1,10 +1,9 @@
 import { createAssociatedTokenAccountIdempotentInstruction } from '@solana/spl-token'
-import { PublicKey } from '@solana/web3.js'
+import type { PublicKey } from '@solana/web3.js'
 
-import { CCIPWalletInvalidError } from '../../../../errors/index.ts'
 import { ChainFamily } from '../../../../networks.ts'
 import type { SolanaChain } from '../../../../solana/index.ts'
-import { type UnsignedSolanaTx, isWallet } from '../../../../solana/types.ts'
+import type { UnsignedSolanaTx } from '../../../../solana/types.ts'
 import { resolveATA } from '../../../../solana/utils.ts'
 import type { TransactionResult } from '../../../operation.ts'
 import {
@@ -13,7 +12,7 @@ import {
   SolanaOperation,
 } from '../../operation.ts'
 import { submit } from '../../submit.ts'
-import { validatePublicKey } from '../../validate.ts'
+import { parsePublicKey } from '../../validate.ts'
 
 /** Parameters for deriving and creating a Solana associated token account. */
 type CreateTokenAccountParams = {
@@ -25,6 +24,12 @@ type CreateTokenAccountParams = {
 
 /** Parameters for unsigned Solana associated token account creation. */
 export type GenerateCreateTokenAccountParams = SolanaGenerateParams<CreateTokenAccountParams>
+
+type ParsedCreateTokenAccountParams = {
+  payer: PublicKey
+  tokenAddress: PublicKey
+  ownerAddress: PublicKey
+}
 
 /** Unsigned associated token account creation tx plus the derived token account address. */
 export type GenerateCreateTokenAccountResult = UnsignedSolanaTx & { tokenAccountAddress: string }
@@ -38,28 +43,28 @@ export type ExecuteCreateTokenAccountResult = TransactionResult & { tokenAccount
 /** Creates an Associated Token Account for any wallet or PDA owner. */
 export class CreateTokenAccount extends SolanaOperation<
   CreateTokenAccountParams,
-  GenerateCreateTokenAccountResult
+  GenerateCreateTokenAccountResult,
+  ParsedCreateTokenAccountParams
 > {
   readonly name = 'createTokenAccount'
 
   /** Parses create-token-account parameters. */
   protected override parse(
     params: GenerateCreateTokenAccountParams,
-  ): GenerateCreateTokenAccountParams {
-    validatePublicKey(this.name, 'payer', params.payer)
-    validatePublicKey(this.name, 'tokenAddress', params.tokenAddress)
-    validatePublicKey(this.name, 'ownerAddress', params.ownerAddress)
-    return params
+  ): ParsedCreateTokenAccountParams {
+    return {
+      payer: parsePublicKey(this.name, 'payer', params.payer),
+      tokenAddress: parsePublicKey(this.name, 'tokenAddress', params.tokenAddress),
+      ownerAddress: parsePublicKey(this.name, 'ownerAddress', params.ownerAddress),
+    }
   }
 
   /** Builds an unsigned idempotent associated token account creation transaction. */
   protected async buildUnsigned(
     chain: SolanaChain,
-    params: GenerateCreateTokenAccountParams,
+    params: ParsedCreateTokenAccountParams,
   ): Promise<GenerateCreateTokenAccountResult> {
-    const payer = new PublicKey(params.payer)
-    const mint = new PublicKey(params.tokenAddress)
-    const owner = new PublicKey(params.ownerAddress)
+    const { payer, tokenAddress: mint, ownerAddress: owner } = params
     const { ata: tokenAccount, tokenProgram } = await resolveATA(chain.connection, mint, owner)
 
     chain.logger.debug(
@@ -87,11 +92,11 @@ export class CreateTokenAccount extends SolanaOperation<
     chain: SolanaChain,
     params: ExecuteCreateTokenAccountParams,
   ): Promise<ExecuteCreateTokenAccountResult> {
-    const { wallet, computeUnits, ...rest } = params
-    if (!isWallet(wallet)) throw new CCIPWalletInvalidError(wallet)
+    const { wallet, computeUnits, parsed } = this.prepareWalletExecution(params)
 
-    const tx = await this.generate(chain, { ...rest, payer: wallet.publicKey.toBase58() })
+    const tx = await this.buildUnsigned(chain, parsed)
     const hash = await submit(chain, wallet, tx, this.name, computeUnits)
+
     return { ...hash, tokenAccountAddress: tx.tokenAccountAddress }
   }
 }

--- a/ccip-sdk/src/cct/solana/token/operations/deploy-token.ts
+++ b/ccip-sdk/src/cct/solana/token/operations/deploy-token.ts
@@ -9,10 +9,9 @@ import {
 } from '@solana/spl-token'
 import { type TransactionInstruction, PublicKey, SystemProgram } from '@solana/web3.js'
 
-import { CCIPWalletInvalidError } from '../../../../errors/index.ts'
 import { ChainFamily } from '../../../../networks.ts'
 import type { SolanaChain } from '../../../../solana/index.ts'
-import { type UnsignedSolanaTx, isWallet } from '../../../../solana/types.ts'
+import type { UnsignedSolanaTx } from '../../../../solana/types.ts'
 import { CCTParamsInvalidError } from '../../../errors.ts'
 import type { TransactionResult } from '../../../operation.ts'
 import {
@@ -156,6 +155,8 @@ type DeployTokenConfig = {
   seed: string
 }
 
+type ParsedDeployTokenParams = GenerateDeployTokenParams & { config: DeployTokenConfig }
+
 function resolveDeployTokenConfig(params: GenerateDeployTokenParams): DeployTokenConfig {
   const payer = new PublicKey(params.payer)
   return {
@@ -293,23 +294,27 @@ function validateMetaplexParams(operation: string, params: GenerateDeployTokenPa
 }
 
 /** Creates a Solana SPL mint, optionally with Metaplex metadata and initial supply. */
-export class DeployToken extends SolanaOperation<DeployTokenParams, GenerateDeployTokenResult> {
+export class DeployToken extends SolanaOperation<
+  DeployTokenParams,
+  GenerateDeployTokenResult,
+  ParsedDeployTokenParams
+> {
   readonly name = 'deployToken'
 
   /** Parses mint and metadata params before any RPC. */
-  protected override parse(params: GenerateDeployTokenParams): GenerateDeployTokenParams {
+  protected override parse(params: GenerateDeployTokenParams): ParsedDeployTokenParams {
     validateBaseParams(this.name, params)
     validatePreMintParams(this.name, params)
     validateMetaplexParams(this.name, params)
-    return params
+    return { ...params, config: resolveDeployTokenConfig(params) }
   }
 
   /** Builds the unsigned Solana mint creation instruction set. */
   protected async buildUnsigned(
     chain: SolanaChain,
-    params: GenerateDeployTokenParams,
+    params: ParsedDeployTokenParams,
   ): Promise<GenerateDeployTokenResult> {
-    const config = resolveDeployTokenConfig(params)
+    const { config } = params
     const mint = await PublicKey.createWithSeed(config.payer, config.seed, config.tokenProgram)
     const lamports = await chain.connection.getMinimumBalanceForRentExemption(getMintLen([]))
     const instructions = createMintInstructions(mint, lamports, params.decimals, config)
@@ -351,11 +356,9 @@ export class DeployToken extends SolanaOperation<DeployTokenParams, GenerateDepl
     chain: SolanaChain,
     params: ExecuteDeployTokenParams,
   ): Promise<ExecuteDeployTokenResult> {
-    const { wallet, computeUnits, ...rest } = params
-    if (!isWallet(wallet)) throw new CCIPWalletInvalidError(wallet)
+    const { wallet, computeUnits, parsed } = this.prepareWalletExecution(params)
+    const externalSigner = getExternalMintAuthoritySigner(parsed, parsed.payer)
 
-    const payer = wallet.publicKey.toBase58()
-    const externalSigner = getExternalMintAuthoritySigner(rest, payer)
     if (externalSigner) {
       throw new CCTParamsInvalidError(
         this.name,
@@ -364,7 +367,7 @@ export class DeployToken extends SolanaOperation<DeployTokenParams, GenerateDepl
       )
     }
 
-    const tx = await this.generate(chain, { ...rest, payer })
+    const tx = await this.buildUnsigned(chain, parsed)
     const hash = await submit(chain, wallet, tx, this.name, computeUnits)
     return {
       ...hash,


### PR DESCRIPTION
## What

- Refactor legacy Solana CCT token, token-pool, and token-admin-registry operations to parse normalized validated values
- Reuse shared wallet-execution preparation for applicable operations

## Why

- Centralize validation and normalization before instruction construction, avoiding repeated public-key parsing