### PR TITLE
Canton: pass message sender/receiver to EDS endpoints

### DIFF
--- a/ccip-sdk/src/canton/explicit-disclosures/eds.ts
+++ b/ccip-sdk/src/canton/explicit-disclosures/eds.ts
@@ -32,11 +32,13 @@ export interface EdsExecutor {
 export interface EdsTokenTransfer {
   token: EdsInstrumentId
   amount: string
+  holdingContractIds: string[]
 }
 
 /** CCIP message shape accepted by the global and external EDS endpoints. */
 export interface EdsMessage {
   destinationChainSelector: string
+  sender: string
   receiver: string
   payload: string
   tokenTransfer: EdsTokenTransfer | null
@@ -306,13 +308,13 @@ export class EdsDisclosureProvider {
   }
 
   /** Fetch global execute disclosures for an encoded CCIP message. */
-  async fetchExecutionDisclosures(encodedMessage: string): Promise<EdsExecuteResult> {
+  async fetchExecutionDisclosures(encodedMessage: string, receiver: string): Promise<EdsExecuteResult> {
     const resp = await post<EdsGlobalExecuteResponse>(
       this.edsBaseUrl,
       '/ccip/v1/global/message/execute',
       EDS_HEADERS,
       this.timeoutMs,
-      { encodedMessage },
+      { encodedMessage, receiver },
     )
     return {
       contextData: contextDataOrEmpty(resp.contextData),
@@ -325,13 +327,14 @@ export class EdsDisclosureProvider {
   async fetchTokenPoolExecuteDisclosure(
     address: string,
     encodedMessage: string,
+    receiver: string,
   ): Promise<EdsTokenPoolDisclosureResult> {
     const resp = await post<EdsTokenPoolDisclosureResponse>(
       this.externalBaseUrlFor(address),
       `/ccip/v1/external/tokenPool/${encodeURIComponent(address)}/execute`,
       EDS_HEADERS,
       this.timeoutMs,
-      { encodedMessage },
+      { encodedMessage, receiver },
     )
     return this.rawTokenPoolResult(resp)
   }
@@ -340,13 +343,14 @@ export class EdsDisclosureProvider {
   async fetchCcvExecuteDisclosure(
     address: string,
     encodedMessage: string,
+    receiver: string,
   ): Promise<EdsExternalDisclosureResult> {
     const resp = await post<EdsExternalDisclosureResponse>(
       this.externalBaseUrlFor(address),
       `/ccip/v1/external/ccv/${encodeURIComponent(address)}/execute`,
       EDS_HEADERS,
       this.timeoutMs,
-      { encodedMessage },
+      { encodedMessage, receiver },
     )
     return this.rawExternalResult(resp)
   }

--- a/ccip-sdk/src/canton/explicit-disclosures/eds.ts
+++ b/ccip-sdk/src/canton/explicit-disclosures/eds.ts
@@ -308,7 +308,10 @@ export class EdsDisclosureProvider {
   }
 
   /** Fetch global execute disclosures for an encoded CCIP message. */
-  async fetchExecutionDisclosures(encodedMessage: string, receiver: string): Promise<EdsExecuteResult> {
+  async fetchExecutionDisclosures(
+    encodedMessage: string,
+    receiver: string,
+  ): Promise<EdsExecuteResult> {
     const resp = await post<EdsGlobalExecuteResponse>(
       this.edsBaseUrl,
       '/ccip/v1/global/message/execute',

--- a/ccip-sdk/src/canton/index.ts
+++ b/ccip-sdk/src/canton/index.ts
@@ -764,10 +764,11 @@ export class CantonChain extends Chain<typeof ChainFamily.Canton> {
       })
 
       const tokenPoolSend = await this.edsDisclosureProvider.fetchTokenPoolSendDisclosure(
-          tokenPoolAddress,
-          tokenPoolEdsMessage,
-        ),
-        tokenPoolRequiredCCVs = tokenPoolSend.requiredCCVs
+        tokenPoolAddress,
+        tokenPoolEdsMessage,
+      )
+
+      tokenPoolRequiredCCVs = tokenPoolSend.requiredCCVs
       tokenTransferInput = {
         senderInputCids: tokenHoldings.map((holding) => holding.contractId),
         tokenPoolCid: tokenPoolSend.contractId,
@@ -854,10 +855,12 @@ export class CantonChain extends Chain<typeof ChainFamily.Canton> {
       message: {
         receiver: receiverHex,
         payload: payloadHex,
-        tokenTransfer: messageTokenTransfer ? {
-          token: messageTokenTransfer.token,
-          amount: messageTokenTransfer.amount,
-        } : null,
+        tokenTransfer: messageTokenTransfer
+          ? {
+              token: messageTokenTransfer.token,
+              amount: messageTokenTransfer.amount,
+            }
+          : null,
         feeToken: { admin: feeInstrument.admin, id: feeInstrument.id },
         extraArgs: {
           tag: 'V3',
@@ -1065,7 +1068,10 @@ export class CantonChain extends Chain<typeof ChainFamily.Canton> {
     const encodedMessageHex = stripHexPrefix(String(encodedMessage))
 
     this.logger.debug('CantonChain.generateUnsignedExecute: fetching global EDS execute data...')
-    const edsResult = await this.edsDisclosureProvider.fetchExecutionDisclosures(encodedMessageHex, payer)
+    const edsResult = await this.edsDisclosureProvider.fetchExecutionDisclosures(
+      encodedMessageHex,
+      payer,
+    )
     // Step 2 — Fetch same-party disclosures (PerPartyRouter + CCIPReceiver)
     // TODO: This should include receiverCid when provided. We need to figure out how to get that from the input or opts.
     this.logger.debug(
@@ -1083,7 +1089,11 @@ export class CantonChain extends Chain<typeof ChainFamily.Canton> {
           ccvAddress,
           verifierDestAddress: v.destAddress,
         })
-        return this.edsDisclosureProvider.fetchCcvExecuteDisclosure(ccvAddress, encodedMessageHex, payer)
+        return this.edsDisclosureProvider.fetchCcvExecuteDisclosure(
+          ccvAddress,
+          encodedMessageHex,
+          payer,
+        )
       }),
     )
 

--- a/ccip-sdk/src/canton/index.ts
+++ b/ccip-sdk/src/canton/index.ts
@@ -721,9 +721,18 @@ export class CantonChain extends Chain<typeof ChainFamily.Canton> {
 
       const tokenInstrument = parseCantonInstrumentId(tokenAmount.token)
       const tokenAmountDecimal = formatCantonDecimalAmountUnits(tokenAmount.amount)
+
+      const tokenHoldings = await this.resolveTokenTransferHoldings({
+        party: sender,
+        instrumentId: tokenInstrument,
+        explicitHoldingCids: cantonArgs.tokenTransferHoldingCids,
+        feeTokenHoldingCids,
+        requiredAmount: tokenAmount.amount,
+      })
       messageTokenTransfer = {
         token: { admin: tokenInstrument.admin, id: tokenInstrument.id },
         amount: tokenAmountDecimal,
+        holdingContractIds: tokenHoldings.map((holding) => holding.contractId),
       }
 
       const tokenPoolAddress = await this.edsDisclosureProvider.lookupTokenPool(
@@ -747,27 +756,18 @@ export class CantonChain extends Chain<typeof ChainFamily.Canton> {
 
       const tokenPoolEdsMessage = buildEdsMessage({
         destChainSelector,
+        senderParty: sender,
         receiverHex,
         payloadHex,
         feeInstrument,
         tokenTransfer: messageTokenTransfer,
       })
 
-      const [tokenHoldings, tokenPoolSend] = await Promise.all([
-        this.resolveTokenTransferHoldings({
-          party: sender,
-          instrumentId: tokenInstrument,
-          explicitHoldingCids: cantonArgs.tokenTransferHoldingCids,
-          feeTokenHoldingCids,
-          requiredAmount: tokenAmount.amount,
-        }),
-        this.edsDisclosureProvider.fetchTokenPoolSendDisclosure(
+      const tokenPoolSend = await this.edsDisclosureProvider.fetchTokenPoolSendDisclosure(
           tokenPoolAddress,
           tokenPoolEdsMessage,
         ),
-      ])
-
-      tokenPoolRequiredCCVs = tokenPoolSend.requiredCCVs
+        tokenPoolRequiredCCVs = tokenPoolSend.requiredCCVs
       tokenTransferInput = {
         senderInputCids: tokenHoldings.map((holding) => holding.contractId),
         tokenPoolCid: tokenPoolSend.contractId,
@@ -781,6 +781,7 @@ export class CantonChain extends Chain<typeof ChainFamily.Canton> {
 
     const edsMessage = buildEdsMessage({
       destChainSelector,
+      senderParty: sender,
       receiverHex,
       payloadHex,
       feeInstrument,
@@ -853,7 +854,10 @@ export class CantonChain extends Chain<typeof ChainFamily.Canton> {
       message: {
         receiver: receiverHex,
         payload: payloadHex,
-        tokenTransfer: messageTokenTransfer,
+        tokenTransfer: messageTokenTransfer ? {
+          token: messageTokenTransfer.token,
+          amount: messageTokenTransfer.amount,
+        } : null,
         feeToken: { admin: feeInstrument.admin, id: feeInstrument.id },
         extraArgs: {
           tag: 'V3',
@@ -1061,7 +1065,7 @@ export class CantonChain extends Chain<typeof ChainFamily.Canton> {
     const encodedMessageHex = stripHexPrefix(String(encodedMessage))
 
     this.logger.debug('CantonChain.generateUnsignedExecute: fetching global EDS execute data...')
-    const edsResult = await this.edsDisclosureProvider.fetchExecutionDisclosures(encodedMessageHex)
+    const edsResult = await this.edsDisclosureProvider.fetchExecutionDisclosures(encodedMessageHex, payer)
     // Step 2 — Fetch same-party disclosures (PerPartyRouter + CCIPReceiver)
     // TODO: This should include receiverCid when provided. We need to figure out how to get that from the input or opts.
     this.logger.debug(
@@ -1079,7 +1083,7 @@ export class CantonChain extends Chain<typeof ChainFamily.Canton> {
           ccvAddress,
           verifierDestAddress: v.destAddress,
         })
-        return this.edsDisclosureProvider.fetchCcvExecuteDisclosure(ccvAddress, encodedMessageHex)
+        return this.edsDisclosureProvider.fetchCcvExecuteDisclosure(ccvAddress, encodedMessageHex, payer)
       }),
     )
 
@@ -1101,6 +1105,7 @@ export class CantonChain extends Chain<typeof ChainFamily.Canton> {
       const tokenPoolExecute = await this.edsDisclosureProvider.fetchTokenPoolExecuteDisclosure(
         edsResult.tokenPool,
         encodedMessageHex,
+        payer,
       )
       assertRequiredCcvsCovered(
         tokenPoolExecute.requiredCCVs,
@@ -2361,12 +2366,14 @@ function formatInstrumentId(instrumentId: CantonInstrumentId): string {
 
 function buildEdsMessage({
   destChainSelector,
+  senderParty,
   receiverHex,
   payloadHex,
   feeInstrument,
   tokenTransfer,
 }: {
   destChainSelector: bigint
+  senderParty: string
   receiverHex: string
   payloadHex: string
   feeInstrument: CantonInstrumentId
@@ -2374,6 +2381,7 @@ function buildEdsMessage({
 }): EdsMessage {
   return {
     destinationChainSelector: destChainSelector.toString(),
+    sender: senderParty,
     receiver: receiverHex,
     payload: payloadHex,
     tokenTransfer: tokenTransfer as EdsMessage['tokenTransfer'],


### PR DESCRIPTION
Depends on: https://github.com/smartcontractkit/chainlink-canton/pull/855

This updates the Canton implementation to pass the sender/receiver party to EDS.