### PR TITLE
fix: caches

### DIFF
--- a/ccip-cli/src/commands/e2e-helpers.test.ts
+++ b/ccip-cli/src/commands/e2e-helpers.test.ts
@@ -6,11 +6,9 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url))
 export const CLI_PATH = path.join(__dirname, '..', 'index.ts')
 
 export const RPCS = [
-  // sepolia candidates, raced per family: ethPandaOps (public, archive-friendly)
-  // answers first reliably; publicnode/tenderly cover when it's unavailable
   process.env['RPC_SEPOLIA'] || 'https://rpc.sepolia.ethpandaops.io',
-  process.env['RPC_SEPOLIA_2'] || 'https://ethereum-sepolia-rpc.publicnode.com',
-  process.env['RPC_SEPOLIA_3'] || 'https://sepolia.gateway.tenderly.co',
+  process.env['RPC_SEPOLIA_2'] || 'https://0xrpc.io/sep',
+  process.env['RPC_SEPOLIA_3'] || 'https://gateway.tenderly.co/public/sepolia',
   process.env['RPC_AVAX'] || 'https://api.avax-test.network/ext/bc/C/rpc',
   // Aptos testnet fullnodes prune older txs/events; the archival endpoint
   // retains them, so it is the single default (kept alone on purpose: the

--- a/ccip-cli/src/commands/show.test.ts
+++ b/ccip-cli/src/commands/show.test.ts
@@ -31,7 +31,7 @@ describe('e2e command show EVM', () => {
         const args = buildShowArgs(TX_HASH)
         const result = await spawnCLI(args, 120000)
 
-        assert.equal(result.exitCode, 0)
+        assert.equal(result.exitCode, 0, result.stderr)
         const output = result.stdout
 
         // Lane information
@@ -114,7 +114,7 @@ describe('e2e command show EVM', () => {
         const args = buildShowArgs(TX_HASH, '--format', 'json')
         const result = await spawnCLI(args, 120000)
 
-        assert.equal(result.exitCode, 0)
+        assert.equal(result.exitCode, 0, result.stderr)
 
         // Should be a single parseable JSON envelope
         const envelope = JSON.parse(result.stdout)
@@ -146,7 +146,7 @@ describe('e2e command show EVM', () => {
       const args = buildShowArgs(TX_HASH, '--format', 'log')
       const result = await spawnCLI(args, 120000)
 
-      assert.equal(result.exitCode, 0)
+      assert.equal(result.exitCode, 0, result.stderr)
 
       // Log format should contain assignment operators
       assert.match(result.stdout, /message.*=/)
@@ -165,7 +165,7 @@ describe('e2e command show EVM', () => {
       const args = buildShowArgs(TX_HASH, '--verbose')
       const result = await spawnCLI(args, 120000)
 
-      assert.equal(result.exitCode, 0)
+      assert.equal(result.exitCode, 0, result.stderr)
       assert.ok(result.stdout.length > 0)
 
       // Should still contain main output

--- a/ccip-sdk/src/api/api.integration.test.ts
+++ b/ccip-sdk/src/api/api.integration.test.ts
@@ -30,12 +30,15 @@ describe(
     let api: CCIPAPIClient
 
     before(() => {
-      // Uses staging API by default (api.ccip.cldev.cloud)
-      api = CCIPAPIClient.fromUrl()
+      // Pin staging (api.ccip.cldev.cloud): the fromUrl() default is prod
+      // (api.ccip.chain.link), which can lack data for low-traffic testnet
+      // lanes (e.g. getLaneLatency -> INSUFFICIENT_DATA there, but not here).
+      api = CCIPAPIClient.fromUrl(STAGING_API_URL)
     })
 
     describe('getLaneLatency', () => {
       it('should return totalMs for valid testnet lane', { timeout: 30000 }, async () => {
+        // default window (no numOfBlocks); staging serves this lane, prod may not
         const result = await api.getLaneLatency(SEPOLIA_SELECTOR, FUJI_SELECTOR)
 
         assert.equal(typeof result.totalMs, 'number')

--- a/ccip-sdk/src/evm/dest-liquidity.fork.test.ts
+++ b/ccip-sdk/src/evm/dest-liquidity.fork.test.ts
@@ -33,7 +33,7 @@ import { CCIPDestExecutionRevertError } from '../errors/index.ts'
 
 // ── Chain constants ──
 
-const SEPOLIA_RPC = process.env['RPC_SEPOLIA'] || 'https://sepolia.gateway.tenderly.co'
+const SEPOLIA_RPC = process.env['RPC_SEPOLIA'] || 'https://rpc.sepolia.ethpandaops.io'
 const SEPOLIA_CHAIN_ID = 11155111
 const SEPOLIA_SELECTOR = 16015286601757825753n
 

--- a/ccip-sdk/src/evm/dest-liquidity.integration.test.ts
+++ b/ccip-sdk/src/evm/dest-liquidity.integration.test.ts
@@ -22,7 +22,7 @@ import { estimateReceiveExecution } from '../gas.ts'
 import { EVMChain } from './index.ts'
 import { simulateReleaseOrMint } from './simulate.ts'
 
-const SEPOLIA_RPC = process.env['RPC_SEPOLIA'] || 'https://sepolia.gateway.tenderly.co'
+const SEPOLIA_RPC = process.env['RPC_SEPOLIA'] || 'https://rpc.sepolia.ethpandaops.io'
 const SEPOLIA_SELECTOR = 16015286601757825753n
 
 const FUJI_RPC = process.env['RPC_FUJI'] || 'https://api.avax-test.network/ext/bc/C/rpc'

--- a/ccip-sdk/src/evm/fork.test.ts
+++ b/ccip-sdk/src/evm/fork.test.ts
@@ -3,7 +3,16 @@ import { execSync } from 'node:child_process'
 import { Console } from 'node:console'
 import { after, before, describe, it } from 'node:test'
 
-import { AbiCoder, Contract, JsonRpcProvider, Wallet, keccak256, parseUnits, toBeHex } from 'ethers'
+import {
+  AbiCoder,
+  Contract,
+  JsonRpcProvider,
+  Wallet,
+  ZeroAddress,
+  keccak256,
+  parseUnits,
+  toBeHex,
+} from 'ethers'
 import { Instance } from 'prool'
 import { createPublicClient, http } from 'viem'
 
@@ -21,7 +30,7 @@ import { ViemTransportProvider } from './viem/client-adapter.ts'
 
 // ── Chain constants ──
 
-const SEPOLIA_RPC = process.env['RPC_SEPOLIA'] || 'https://sepolia.gateway.tenderly.co'
+const SEPOLIA_RPC = process.env['RPC_SEPOLIA'] || 'https://rpc.sepolia.ethpandaops.io'
 const SEPOLIA_CHAIN_ID = 11155111
 const SEPOLIA_SELECTOR = 16015286601757825753n
 const SEPOLIA_ROUTER = '0x0BF3dE8c5D3e8A2B34D2BEeB17ABfCeBaf363A59'
@@ -31,6 +40,12 @@ const FUJI_CHAIN_ID = 43113
 
 const ARB_SEP_RPC = process.env['RPC_ARB_SEPOLIA'] || 'https://sepolia-rollup.arbitrum.io/rpc'
 const ARB_SEP_CHAIN_ID = 421614
+
+// Official HashIO JSON-RPC relay (Hedera testnet EVM), and the official CCIP
+// Router 1.2.0 from the CCIP Directory (https://docs.chain.link/ccip/directory/testnet)
+const HEDERA_TESTNET_RPC = process.env['RPC_HEDERA_TESTNET'] || 'https://testnet.hashio.io/api'
+const HEDERA_CHAIN_ID = 296
+const HEDERA_ROUTER = '0x802C5F84eAD128Ff36fD6a3f8a418e339f467Ce4'
 
 const ANVIL_PRIVATE_KEY = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'
 
@@ -119,10 +134,12 @@ const testLogger = new Console(process.stdout, process.stderr)
 if (!process.env.VERBOSE) testLogger.debug = () => {}
 
 describe('EVM Fork Tests', { skip, timeout: 180_000 }, () => {
+  let hederaChain: EVMChain | undefined
   let sepoliaChain: EVMChain | undefined
   let fujiChain: EVMChain | undefined
   let arbSepChain: EVMChain | undefined
   let wallet: Wallet
+  let hederaInstance: ReturnType<typeof Instance.anvil> | undefined
   let sepoliaInstance: ReturnType<typeof Instance.anvil> | undefined
   let fujiInstance: ReturnType<typeof Instance.anvil> | undefined
   let arbSepInstance: ReturnType<typeof Instance.anvil> | undefined
@@ -154,7 +171,16 @@ describe('EVM Fork Tests', { skip, timeout: 180_000 }, () => {
       { forkUrl: ARB_SEP_RPC, chainId: ARB_SEP_CHAIN_ID, port: 8644, ...forkOpts },
       {},
     )
-    await Promise.all([sepoliaInstance.start(), fujiInstance.start(), arbSepInstance.start()])
+    hederaInstance = Instance.anvil(
+      { forkUrl: HEDERA_TESTNET_RPC, chainId: HEDERA_CHAIN_ID, port: 8643, ...forkOpts },
+      {},
+    )
+    await Promise.all([
+      sepoliaInstance.start(),
+      fujiInstance.start(),
+      arbSepInstance.start(),
+      hederaInstance.start(),
+    ])
 
     const sepoliaProvider = new JsonRpcProvider(
       `http://${sepoliaInstance.host}:${sepoliaInstance.port}`,
@@ -162,6 +188,9 @@ describe('EVM Fork Tests', { skip, timeout: 180_000 }, () => {
     const fujiProvider = new JsonRpcProvider(`http://${fujiInstance.host}:${fujiInstance.port}`)
     const arbSepProvider = new JsonRpcProvider(
       `http://${arbSepInstance.host}:${arbSepInstance.port}`,
+    )
+    const hederaProvider = new JsonRpcProvider(
+      `http://${hederaInstance.host}:${hederaInstance.port}`,
     )
 
     sepoliaChain = await EVMChain.fromProvider(sepoliaProvider, {
@@ -173,14 +202,24 @@ describe('EVM Fork Tests', { skip, timeout: 180_000 }, () => {
       apiClient: null,
       logger: testLogger,
     })
+    hederaChain = await EVMChain.fromProvider(hederaProvider, {
+      apiClient: null,
+      logger: testLogger,
+    })
     wallet = new Wallet(ANVIL_PRIVATE_KEY, sepoliaProvider)
   })
 
   after(async () => {
+    hederaChain?.provider.destroy()
     sepoliaChain?.provider.destroy()
     fujiChain?.provider.destroy()
     arbSepChain?.provider.destroy()
-    await Promise.all([sepoliaInstance?.stop(), fujiInstance?.stop(), arbSepInstance?.stop()])
+    await Promise.all([
+      hederaInstance?.stop(),
+      sepoliaInstance?.stop(),
+      fujiInstance?.stop(),
+      arbSepInstance?.stop(),
+    ])
   })
 
   // ── State-mutating tests (sendMessage / execute / ViemTransportProvider) ──
@@ -295,6 +334,39 @@ describe('EVM Fork Tests', { skip, timeout: 180_000 }, () => {
       )
       assert.ok(tokenAmounts[0]!.sourcePoolAddress, 'v1.6 should have sourcePoolAddress')
       assert.ok(tokenAmounts[0]!.destTokenAddress, 'v1.6 should have destTokenAddress')
+    })
+  })
+
+  describe('generateUnsignedSendMessage (Hedera testnet)', () => {
+    // Hedera's EVM quotes native (WHBAR) fees in tinybars, i.e. with the native
+    // token's 8 decimals; return this tx's `value` to the SDK's 18-decimal wei
+    // representation by scaling the fee by 10^(18-8) = 10^10.
+    it('should scale the native fee by 10^10 (tinybar -> weibar) in the ccipSend value', async () => {
+      assert.ok(hederaChain, 'hedera chain should be initialized')
+      const sender = wallet.address
+      const message = { receiver: sender, data: '0x', feeToken: ZeroAddress }
+      const fee = await hederaChain.getFee({
+        router: HEDERA_ROUTER,
+        destChainSelector: SEPOLIA_SELECTOR,
+        message,
+      })
+      assert.ok(fee > 0n, `expected a positive fee on the live hedera->sepolia lane, got ${fee}`)
+
+      const unsigned = await hederaChain.generateUnsignedSendMessage({
+        sender,
+        router: HEDERA_ROUTER,
+        destChainSelector: SEPOLIA_SELECTOR,
+        message,
+      })
+      assert.equal(unsigned.transactions.length, 1, 'data-only send should not need approvals')
+      const [sendTx] = unsigned.transactions
+      assert.equal(sendTx?.to, HEDERA_ROUTER)
+      assert.equal(sendTx.from, sender)
+      assert.equal(
+        sendTx.value,
+        fee * 10n ** 10n,
+        'native msg.value should be the fee in tinybars scaled to weibar',
+      )
     })
   })
 

--- a/ccip-sdk/src/evm/index.ts
+++ b/ccip-sdk/src/evm/index.ts
@@ -1,4 +1,6 @@
 import {
+  type Block,
+  type BlockParams,
   type BytesLike,
   type JsonRpcApiProvider,
   type Log,
@@ -388,6 +390,21 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
           }),
         )
       return (this.provider.constructor as typeof JsonRpcApiProvider).prototype._wrapLog.call(
+        this.provider,
+        value,
+        network,
+      )
+    }
+    // fix tron-* evm chains returning `stateRoot="0x"` and breaking ethers
+    provider._wrapBlock = (value: BlockParams, network: Network): Block => {
+      if (
+        typeof value.stateRoot === 'string' &&
+        value.stateRoot !== ZeroHash &&
+        value.stateRoot.match(/^0x0*$/)
+      ) {
+        value.stateRoot = ZeroHash
+      }
+      return (this.provider.constructor as typeof JsonRpcApiProvider).prototype._wrapBlock.call(
         this.provider,
         value,
         network,

--- a/ccip-sdk/src/evm/integration.test.ts
+++ b/ccip-sdk/src/evm/integration.test.ts
@@ -20,9 +20,9 @@ import { EVMChain } from './index.ts'
 // ── Chain constants ──
 
 // Integration tests issue many live RPC calls (no anvil fork to absorb them), so the
-// defaults point at reliable public endpoints. Free gateways (tenderly, avax public)
+// defaults point at reliable public endpoints. Free gateways (avax public)
 // rate-limit/stall under this load and time out the suite. Override via RPC_* env vars.
-const SEPOLIA_RPC = process.env['RPC_SEPOLIA'] || 'https://sepolia.gateway.tenderly.co'
+const SEPOLIA_RPC = process.env['RPC_SEPOLIA'] || 'https://rpc.sepolia.ethpandaops.io'
 const SEPOLIA_SELECTOR = 16015286601757825753n
 const SEPOLIA_ROUTER = '0x0BF3dE8c5D3e8A2B34D2BEeB17ABfCeBaf363A59'
 

--- a/ccip-sdk/src/solana/__tests__/integration.test.ts
+++ b/ccip-sdk/src/solana/__tests__/integration.test.ts
@@ -17,7 +17,7 @@ import { SolanaChain } from '../index.ts'
 
 const FUJI_RPC = process.env.FUJI_RPC ?? 'https://api.avax-test.network/ext/bc/C/rpc'
 const SEPOLIA_RPC =
-  process.env.SEPOLIA_RPC ?? process.env.RPC_SEPOLIA ?? 'https://sepolia.gateway.tenderly.co'
+  process.env.SEPOLIA_RPC ?? process.env.RPC_SEPOLIA ?? 'https://rpc.sepolia.ethpandaops.io'
 // devnet.rpcpool.com: public, holds at least ~1 week of txs and doesn't 429 as
 // aggressively as onfinality's free tier; envs can override (e.g. onfinality,
 // which keeps the longest history but throttles hard)

--- a/ccip-sdk/src/sui/events.ts
+++ b/ccip-sdk/src/sui/events.ts
@@ -161,6 +161,13 @@ async function collectByCheckpointWalk<T>(
     const page = await withLookupRetry(() =>
       client.getCheckpoints({ cursor, limit: 100, descendingOrder: false }),
     )
+    // Walk mode fills the shared tx-meta cache directly, bypassing the cap check
+    // in resolveTxMetas — enforce the same bound here so long-running watch
+    // streams (e.g. after a queryEvents retention-boundary failure) can't grow
+    // it unboundedly. Lookups below only consume digests set on THIS page, so
+    // clearing an overfull cache just before inserting never evicts an entry
+    // still in flight.
+    if (txMetas.size > TX_META_CACHE_MAX) txMetas.clear()
     const digests: string[] = []
     let pastWindow = false
     for (const checkpoint of page.data) {

--- a/ccip-sdk/src/ton/index.ts
+++ b/ccip-sdk/src/ton/index.ts
@@ -12,6 +12,7 @@ import {
 } from './extra-args.ts'
 import { streamTransactionsForAddress } from './logs.ts'
 import { generateUnsignedCcipSend, getFee as getFeeImpl } from './send.ts'
+import { boundTonClientCaches } from './ton-cache.ts'
 import {
   type BlockInfo,
   type ChainContext,
@@ -144,6 +145,15 @@ export class TONChain extends Chain<typeof ChainFamily.TON> {
     // Entries expire TX_CACHE_TTL after the last fetch so a later burst restarts from
     // a fresh head and never serves reorged-away txs.
     const TX_CACHE_TTL = 5_000
+    // Watch-mode bounds: every active poll merges freshly fetched head pages into the
+    // window and refreshes the entry's TTL, so an uncapped window would grow with an
+    // account's entire transaction history for as long as the stream lives — and a
+    // stored Transaction carries its full parsed message cells. Trimming the oldest
+    // txs (and evicting the stalest address beyond the fan-out cap) only costs the
+    // next deep-cursor request a re-fetch: the contiguity/bottom invariants make the
+    // serve-or-refetch decision, and re-fetching is always correct.
+    const TX_CACHE_MAX_TXS_PER_ADDRESS = 500
+    const TX_CACHE_MAX_ADDRESSES = 16
     const txCache = new Map<string, Transaction[]>()
     const txCacheExpiry = new Map<string, number>()
     const origGetTransactions = this.provider.getTransactions.bind(this.provider)
@@ -202,7 +212,25 @@ export class TONChain extends Chain<typeof ChainFamily.TON> {
       const allTxsHashes = new Set(allTxs.map((tx) => tx.hash().toString('base64')))
       allTxs.push(...txs.filter((tx) => !allTxsHashes.has(tx.hash().toString('base64'))))
       allTxs.sort((a, b) => Number(b.lt - a.lt))
+      // Bounds (see constants above): the window keeps only its newest txs, and the
+      // stalest unused address beyond the cap is evicted. Degrades gracefully: the
+      // cursor hash for a trimmed tx misses the cache and re-fetches from the RPC.
+      if (allTxs.length > TX_CACHE_MAX_TXS_PER_ADDRESS) allTxs.length = TX_CACHE_MAX_TXS_PER_ADDRESS
       txCacheExpiry.set(key, Date.now() + TX_CACHE_TTL)
+      if (txCache.size > TX_CACHE_MAX_ADDRESSES) {
+        let victim: string | undefined
+        let victimExpiry = Infinity
+        for (const [addr, expiresAt] of txCacheExpiry) {
+          if (addr !== key && expiresAt < victimExpiry) {
+            victim = addr
+            victimExpiry = expiresAt
+          }
+        }
+        if (victim !== undefined) {
+          txCache.delete(victim)
+          txCacheExpiry.delete(victim)
+        }
+      }
       return txs
     }
 
@@ -307,6 +335,10 @@ export class TONChain extends Chain<typeof ChainFamily.TON> {
     const httpAdapter = createAxiosFetchAdapter(fetchFn, ctx?.abort)
 
     const client = new TonClient({ endpoint: url, httpAdapter })
+    // @ton/ton hardcodes a per-client unbounded InMemoryCache for its internal
+    // shard/block caches; swap it for bounded LRUs so long-lived workers with
+    // watch-mode getLogs don't accumulate seqno-keyed entries forever.
+    boundTonClientCaches(client)
     try {
       const chain =
         isMainnetHint !== undefined

--- a/ccip-sdk/src/ton/ton-cache.test.ts
+++ b/ccip-sdk/src/ton/ton-cache.test.ts
@@ -1,0 +1,103 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import { TonClient } from '@ton/ton'
+
+import { BoundedStringCache, boundTonClientCaches } from './ton-cache.ts'
+
+describe('BoundedStringCache', () => {
+  it('stores and retrieves by namespace+key; null deletes', async () => {
+    const c = new BoundedStringCache()
+    await c.set('ns', 'a', '1')
+    assert.equal(await c.get('ns', 'a'), '1')
+    assert.equal(await c.get('ns', 'b'), null)
+    assert.equal(await c.get('other', 'a'), null)
+    await c.set('ns', 'a', null)
+    assert.equal(await c.get('ns', 'a'), null)
+    assert.equal(c.size, 0)
+  })
+
+  it('evicts the oldest entries once maxEntries is exceeded', async () => {
+    const c = new BoundedStringCache({ maxEntries: 3 })
+    await c.set('n', 'k1', 'v') // byte-accounting disabled de-facto by huge byte cap
+    await c.set('n', 'k2', 'v')
+    await c.set('n', 'k3', 'v')
+    await c.set('n', 'k4', 'v')
+    assert.equal(await c.get('n', 'k1'), null)
+    assert.equal(await c.get('n', 'k2'), 'v')
+    assert.equal(c.size, 3)
+  })
+
+  it('get refreshes recency so hot entries outlive cold ones', async () => {
+    const c = new BoundedStringCache({ maxEntries: 2 })
+    await c.set('n', 'k1', 'v1')
+    await c.set('n', 'k2', 'v2')
+    assert.equal(await c.get('n', 'k1'), 'v1') // k1 becomes most recent
+    await c.set('n', 'k3', 'v3') // evicts k2
+    assert.equal(await c.get('n', 'k2'), null)
+    assert.equal(await c.get('n', 'k1'), 'v1')
+    assert.equal(await c.get('n', 'k3'), 'v3')
+  })
+
+  it('evicts the oldest entries once maxBytes is exceeded', async () => {
+    const c = new BoundedStringCache({ maxBytes: 128 })
+    // each entry: key 'n$$k#' + 20-byte value => (5 + 20) * 2 = 50 bytes
+    await c.set('n', 'k1', 'x'.repeat(20))
+    await c.set('n', 'k2', 'x'.repeat(20))
+    await c.set('n', 'k3', 'x'.repeat(20)) // 150 > 128 -> evicts oldest
+    assert.equal(await c.get('n', 'k1'), null)
+    assert.equal(await c.get('n', 'k2'), 'x'.repeat(20))
+    assert.equal(await c.get('n', 'k3'), 'x'.repeat(20))
+    assert.equal(c.size, 2)
+  })
+
+  it('re-set of an existing key stays within the byte budget', async () => {
+    const c = new BoundedStringCache({ maxBytes: 60 })
+    await c.set('n', 'k1', 'x'.repeat(20)) // (4 + 20) * 2 = 48 bytes
+    await c.set('n', 'k1', 'y'.repeat(20)) // replaces, not duplicates
+    assert.equal(c.size, 1)
+    assert.equal(await c.get('n', 'k1'), 'y'.repeat(20))
+  })
+})
+
+describe('boundTonClientCaches', () => {
+  it('re-points the TonClient HttpApi TypedCaches at bounded stores', async () => {
+    // Constructor makes no network calls; we only touch its runtime internals.
+    const client = new TonClient({ endpoint: 'https://invalid.example/jsonRPC' })
+
+    boundTonClientCaches(client)
+
+    const api = (
+      client as unknown as {
+        api?: {
+          shardCache?: { cache: unknown; set(key: unknown, value: unknown): Promise<void> }
+          shardTransactionsCache?: { cache: unknown }
+        }
+      }
+    ).api
+    assert.ok(api, 'TonClient exposes HttpApi at runtime')
+    const shard = api.shardCache
+    const shardTx = api.shardTransactionsCache
+    assert.ok(shard && shardTx, 'TonClient exposes its TypedCaches at runtime')
+    assert.ok(shard.cache instanceof BoundedStringCache)
+    assert.ok(shardTx.cache instanceof BoundedStringCache)
+
+    // TypedCache dispatches through its backing on every call: a set lands in
+    // the bounded store keyed `ton-shard$$<seqno>`, proving the swap worked end
+    // to end without depending on `@ton/ton` internals beyond those two fields.
+    const backing = shard.cache
+    await shard.set(123, [
+      {
+        '@type': 'ton.blockIdExt',
+        workchain: 0,
+        shard: '-9223372036854775808',
+        seqno: 123,
+        rootHash: '0'.repeat(64),
+        fileHash: '0'.repeat(64),
+      },
+    ])
+    const stored = await backing.get('ton-shard', '123')
+    assert.ok(stored !== null && stored.startsWith('['))
+    assert.equal(backing.size, 1)
+  })
+})

--- a/ccip-sdk/src/ton/ton-cache.ts
+++ b/ccip-sdk/src/ton/ton-cache.ts
@@ -1,0 +1,169 @@
+import type { TonClient } from '@ton/ton'
+
+// `@ton/ton`'s TonClient hardcodes an unbounded InMemoryCache for its internal
+// TypedCaches (see HttpApi): `shardCache` grows one entry per seqno forever and
+// `shardTransactionsCache` additionally serializes whole block responses.
+// On long-lived workers (TON watch activities) that accumulates without limit.
+//
+// The TypedCache instances read their backing store through a property at call
+// time (`this.cache.get(...)`), so re-pointing that property at a bounded LRU
+// is sufficient — no subclassing, no forked client, nothing else touched.
+
+/** Structural alias for the internal Cache interface of `@ton/ton` (not exported). */
+export interface TonStringCache {
+  get(namespace: string, key: string): Promise<string | null>
+  set(namespace: string, key: string, value: string | null): Promise<void>
+}
+
+/** Budgets applied to a {@link BoundedStringCache}. */
+export interface TonStringCacheLimits {
+  /** Maximum number of entries (default 10_000). */
+  maxEntries?: number
+  /** Maximum total payload size in bytes, keys included (default 2 MiB). */
+  maxBytes?: number
+}
+
+/**
+ * Bounded LRU over the JSON-string values that the `TypedCache` of `@ton/ton`
+ * stores. Backed by an insertion-ordered Map: `get` refreshes recency, and an
+ * overflowing `set` evicts the oldest entries until both budgets hold again.
+ * A `null` value deletes the entry, per the `@ton/ton` Cache contract.
+ */
+export class BoundedStringCache implements TonStringCache {
+  /** Maximum number of entries retained. */
+  readonly maxEntries: number
+  /** Maximum total payload size in bytes, keys included. */
+  readonly maxBytes: number
+
+  /** Underlying store; keys are `namespace$$key` (the `@ton/ton` convention). */
+  map = new Map<string, { value: string; bytes: number }>()
+  /** Current total payload size in bytes, keys included. */
+  bytes = 0
+
+  /**
+   * Creates an empty cache with the given budgets.
+   *
+   * @param limits - entry and byte budgets; omitted values fall back to
+   *   {@link TON_CLIENT_CACHE_DEFAULTS}-like sane defaults (10k / 2 MiB).
+   */
+  constructor(limits: TonStringCacheLimits = {}) {
+    this.maxEntries = limits.maxEntries ?? 10_000
+    this.maxBytes = limits.maxBytes ?? 2 * 1024 * 1024
+  }
+
+  /** Number of live entries. */
+  get size(): number {
+    return this.map.size
+  }
+
+  /**
+   * Fetches a value, refreshing its recency on a hit.
+   *
+   * @param namespace - cache namespace (e.g. `ton-shard`).
+   * @param key - namespace-scoped key (e.g. a seqno string).
+   * @returns the stored value, or `null` when absent.
+   */
+  async get(namespace: string, key: string): Promise<string | null> {
+    const k = `${namespace}$$$${key}`
+    const hit = this.map.get(k)
+    if (hit === undefined) return null
+    // refresh recency: re-inserting appends to the insertion order
+    this.map.delete(k)
+    this.map.set(k, hit)
+    return hit.value
+  }
+
+  /**
+   * Stores a value, evicting oldest-first until both budgets hold again.
+   *
+   * @param namespace - cache namespace (e.g. `ton-shard`).
+   * @param key - namespace-scoped key (e.g. a seqno string).
+   * @param value - value to store; `null` deletes the entry.
+   */
+  async set(namespace: string, key: string, value: string | null): Promise<void> {
+    const k = `${namespace}$$$${key}`
+    const prev = this.map.get(k)
+    if (prev !== undefined) {
+      this.map.delete(k)
+      this.bytes -= prev.bytes
+    }
+    if (value !== null) {
+      const entry = { value, bytes: (k.length + value.length) * 2 }
+      this.map.set(k, entry)
+      this.bytes += entry.bytes
+    }
+    this.trim()
+  }
+
+  /** Evicts oldest-first until both budgets hold again. */
+  private trim(): void {
+    while (this.map.size > this.maxEntries || this.bytes > this.maxBytes) {
+      const oldest = this.map.keys().next()
+      if (oldest.done) break
+      const dead = this.map.get(oldest.value)!
+      this.map.delete(oldest.value)
+      this.bytes -= dead.bytes
+    }
+  }
+}
+
+/** Per-cache budgets for {@link boundTonClientCaches}. */
+export interface BoundTonClientCacheLimits {
+  /** Entry cap for the shard-list cache (default 10_000). */
+  shardMaxEntries?: number
+  /** Byte cap for the shard-list cache (default 2 MiB). */
+  shardMaxBytes?: number
+  /** Entry cap for the shard-transactions cache (default 2_000). */
+  shardTxMaxEntries?: number
+  /** Byte cap for the shard-transactions cache (default 16 MiB). */
+  shardTxMaxBytes?: number
+}
+
+/** Default budgets for {@link boundTonClientCaches}. */
+export const TON_CLIENT_CACHE_DEFAULTS: Required<BoundTonClientCacheLimits> = {
+  shardMaxEntries: 10_000,
+  shardMaxBytes: 2 * 1024 * 1024, // blockIdExt heads are ~150 B
+  shardTxMaxEntries: 2_000,
+  shardTxMaxBytes: 16 * 1024 * 1024, // whole shard transaction lists
+}
+
+type TypedCacheBacking = { cache: TonStringCache }
+type TonClientInternals = {
+  api?: { shardCache?: TypedCacheBacking; shardTransactionsCache?: TypedCacheBacking }
+}
+
+/**
+ * Re-points the TonClient's internal TypedCaches (shard lists and whole shard
+ * transaction blocks) at bounded LRU stores, replacing the unbounded
+ * InMemoryCache `@ton/ton` hardcodes in `HttpApi`. Unknown layouts are ignored
+ * defensively (the client falls back to its default cache), so a future
+ * `@ton/ton` reshuffle degrades instead of breaking chain construction.
+ *
+ * `.api` is `protected` in the typings and the TypedCache backings are
+ * `private`, but all of them are plain runtime properties.
+ *
+ * @param client - the TonClient whose caches to bound (no network calls made).
+ * @param limits - optional per-cache budgets; see {@link TON_CLIENT_CACHE_DEFAULTS}.
+ */
+export function boundTonClientCaches(
+  client: TonClient,
+  limits: BoundTonClientCacheLimits = {},
+): void {
+  const { shardMaxEntries, shardMaxBytes, shardTxMaxEntries, shardTxMaxBytes } = {
+    ...TON_CLIENT_CACHE_DEFAULTS,
+    ...limits,
+  }
+  const internals = client as unknown as TonClientInternals
+  if (internals.api?.shardCache) {
+    internals.api.shardCache.cache = new BoundedStringCache({
+      maxEntries: shardMaxEntries,
+      maxBytes: shardMaxBytes,
+    })
+  }
+  if (internals.api?.shardTransactionsCache) {
+    internals.api.shardTransactionsCache.cache = new BoundedStringCache({
+      maxEntries: shardTxMaxEntries,
+      maxBytes: shardTxMaxBytes,
+    })
+  }
+}

--- a/ccip-sdk/src/ton/txcache.test.ts
+++ b/ccip-sdk/src/ton/txcache.test.ts
@@ -1,0 +1,104 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import { Address } from '@ton/core'
+import type { TonClient, Transaction } from '@ton/ton'
+
+import { networkInfo } from '../index.ts'
+import { TONChain } from './index.ts'
+
+// Regression tests for the per-address transaction window installed on the
+// provider by TONChain: long-lived getLogs watch streams used to grow the
+// window with the account's full history (each Transaction keeps its parsed
+// message cells), which showed up in production as hundreds of MB of retained
+// Cell/BitString objects on the workers hosting TON watch activities.
+describe('TONChain txCache bounds', () => {
+  const net = networkInfo('ton-testnet')
+
+  const addr = (i: number): Address => Address.parse('0:' + String(i).padStart(64, '0'))
+  const b64 = (s: string): string => Buffer.from(s, 'utf8').toString('base64')
+
+  function fakeTx(tag: string, lt: bigint, prevLt: bigint, a: Address): Transaction {
+    return {
+      address: a,
+      lt,
+      prevTransactionLt: prevLt,
+      hash: () => Buffer.from(tag, 'utf8'),
+    } as unknown as Transaction
+  }
+
+  it('trims the per-address window so the streamed history is not kept indefinitely', async () => {
+    // 501 consecutive head pages: the oldest tx must fall out of the 500-tx
+    // window, while the newest stays served from cache.
+    const a = addr(1)
+    let head = 0
+    let fetches = 0
+    const total = 501
+    const txs = Array.from({ length: total }, (_, i) =>
+      fakeTx('t' + i, 1_000_000n - BigInt(i), 999_999n - BigInt(i), a),
+    )
+    const client = {
+      getTransactions: async (_a: Address, opts: { hash?: string; limit?: number }) => {
+        fetches++
+        if (opts.hash) return [] // simulated deep-cursor fetch
+        const tx = txs[head++]
+        return tx ? [tx] : []
+      },
+    } as unknown as TonClient
+
+    const chain = new TONChain(client, net)
+    const wrapped = chain.provider.getTransactions.bind(chain.provider)
+    for (let i = 0; i < total; i++) await wrapped(a, { limit: 1 })
+
+    // Trimmed oldest cursor (the last head page fetched has the smallest lt):
+    // it must re-fetch from the RPC.
+    const before = fetches
+    await wrapped(a, { hash: b64('t' + (total - 1)), limit: 1 })
+    assert.equal(fetches, before + 1, 'trimmed cursor should re-fetch')
+
+    // Kept newest cursor: must be served from the window without an RPC call.
+    const before2 = fetches
+    await wrapped(a, { hash: b64('t0'), limit: 1 })
+    assert.equal(fetches, before2, 'cached cursor should not hit the RPC')
+  })
+
+  it('evicts the stalest address entry beyond the fan-out cap', async () => {
+    const perAddr = new Map<string, number>()
+    let fetches = 0
+    const client = {
+      getTransactions: async (a: Address, opts: { hash?: string; limit?: number }) => {
+        fetches++
+        if (opts.hash) return []
+        const n = perAddr.get(a.toString()) ?? 0
+        perAddr.set(a.toString(), n + 1)
+        return [
+          fakeTx(
+            `${a.toString()}:${n}`,
+            1_000_000n - BigInt(n) * 10n,
+            999_999n - BigInt(n) * 10n,
+            a,
+          ),
+        ]
+      },
+    } as unknown as TonClient
+
+    const chain = new TONChain(client, net)
+    const wrapped = chain.provider.getTransactions.bind(chain.provider)
+    const addresses = Array.from({ length: 17 }, (_, i) => addr(i))
+    for (const a of addresses) {
+      await wrapped(a, { limit: 1 })
+      await wrapped(a, { limit: 1 }) // two heads each, so the newest cursor is serveable
+    }
+
+    // The first (stalest) address was evicted: its cursor misses the cache.
+    const before = fetches
+    await wrapped(addresses[0]!, { hash: b64(`${addresses[0]!.toString()}:0`), limit: 1 })
+    assert.equal(fetches, before + 1, 'evicted address cursor should re-fetch')
+
+    // The most recent address is still cached and serves without an RPC call
+    // (cursor on its newest tx, asking for the one older).
+    const before2 = fetches
+    await wrapped(addresses[16]!, { hash: b64(`${addresses[16]!.toString()}:0`), limit: 1 })
+    assert.equal(fetches, before2, 'cached address cursor should not hit the RPC')
+  })
+})


### PR DESCRIPTION
- Fix a few caches which were running loose on long running processes:
  - Sui events
  - TON txs, client internal
- Fix tron-evm getBlock stateRoot="0x" being rejected by ethers (not valid hash)
- Implement fork test for Hedera tinybar -> weibar conversion
- Fix a few sources of flakyness on integration/e2e tests