### PR TITLE
fix(cct-sdk): Export Solana CCT configuration constants

### DIFF
--- a/ccip-sdk/src/cct/solana/index.test.ts
+++ b/ccip-sdk/src/cct/solana/index.test.ts
@@ -3,7 +3,14 @@ import { describe, it } from 'node:test'
 
 import { Connection } from '@solana/web3.js'
 
-import { type TokenAuthorityType, SolanaTokenManager, TOKEN_AUTHORITY_TYPES } from './index.ts'
+import {
+  type RegisterAdminMethod,
+  type TokenAuthorityType,
+  DEFAULT_WRITABLE_INDEXES,
+  REGISTER_ADMIN_METHODS,
+  SolanaTokenManager,
+  TOKEN_AUTHORITY_TYPES,
+} from './index.ts'
 import type {
   GetTokenPoolStateParams,
   GetTokenPoolStateResult,
@@ -78,11 +85,15 @@ describe('SolanaTokenManager (cct/solana)', () => {
     assert.equal(typeof cct.getTokenPoolState, 'function')
   })
 
-  it('exports public token authority constants', () => {
+  it('exports public CCT constants', () => {
     const authorityType: TokenAuthorityType = TOKEN_AUTHORITY_TYPES.MINT
+    const method: RegisterAdminMethod = REGISTER_ADMIN_METHODS.OWNER
 
     assert.equal(authorityType, 'mint')
     assert.equal(TOKEN_AUTHORITY_TYPES.FREEZE, 'freeze')
+    assert.equal(method, 'owner')
+    assert.equal(REGISTER_ADMIN_METHODS.CCIP_ADMIN, 'ccip-admin')
+    assert.deepEqual(DEFAULT_WRITABLE_INDEXES, [3, 4, 7])
   })
 
   it('creates from a connection provider', async (t) => {

--- a/ccip-sdk/src/cct/solana/index.test.ts
+++ b/ccip-sdk/src/cct/solana/index.test.ts
@@ -7,7 +7,7 @@ import {
   type RegisterAdminMethod,
   type TokenAuthorityType,
   DEFAULT_WRITABLE_INDEXES,
-  REGISTER_ADMIN_METHODS,
+  REGISTRATION_METHODS,
   SolanaTokenManager,
   TOKEN_AUTHORITY_TYPES,
 } from './index.ts'
@@ -87,12 +87,12 @@ describe('SolanaTokenManager (cct/solana)', () => {
 
   it('exports public CCT constants', () => {
     const authorityType: TokenAuthorityType = TOKEN_AUTHORITY_TYPES.MINT
-    const method: RegisterAdminMethod = REGISTER_ADMIN_METHODS.OWNER
+    const method: RegisterAdminMethod = REGISTRATION_METHODS.OWNER
 
     assert.equal(authorityType, 'mint')
     assert.equal(TOKEN_AUTHORITY_TYPES.FREEZE, 'freeze')
     assert.equal(method, 'owner')
-    assert.equal(REGISTER_ADMIN_METHODS.CCIP_ADMIN, 'ccip-admin')
+    assert.equal(REGISTRATION_METHODS.CCIP_ADMIN, 'ccip-admin')
     assert.deepEqual(DEFAULT_WRITABLE_INDEXES, [3, 4, 7])
   })
 

--- a/ccip-sdk/src/cct/solana/index.ts
+++ b/ccip-sdk/src/cct/solana/index.ts
@@ -1825,7 +1825,11 @@ export {
   deriveTokenPoolSignerPda,
   resolveTokenPoolProgram,
 } from './programs/token-pool.ts'
-export { TOKEN_AUTHORITY_TYPES } from './token/operations/set-token-authority.ts'
+export { TOKEN_AUTHORITY_TYPES } from './token/constants.ts'
+export {
+  DEFAULT_WRITABLE_INDEXES,
+  REGISTER_ADMIN_METHODS,
+} from './token-admin-registry/constants.ts'
 export type { TransactionResult } from '../operation.ts'
 export type { SerializedSolanaTxEncoding } from './serialize.ts'
 export type * from './token/operations/index.ts'

--- a/ccip-sdk/src/cct/solana/index.ts
+++ b/ccip-sdk/src/cct/solana/index.ts
@@ -1826,10 +1826,7 @@ export {
   resolveTokenPoolProgram,
 } from './programs/token-pool.ts'
 export { TOKEN_AUTHORITY_TYPES } from './token/constants.ts'
-export {
-  DEFAULT_WRITABLE_INDEXES,
-  REGISTER_ADMIN_METHODS,
-} from './token-admin-registry/constants.ts'
+export { DEFAULT_WRITABLE_INDEXES, REGISTRATION_METHODS } from './token-admin-registry/constants.ts'
 export type { TransactionResult } from '../operation.ts'
 export type { SerializedSolanaTxEncoding } from './serialize.ts'
 export type * from './token/operations/index.ts'

--- a/ccip-sdk/src/cct/solana/token-admin-registry/constants.ts
+++ b/ccip-sdk/src/cct/solana/token-admin-registry/constants.ts
@@ -1,0 +1,8 @@
+/** Authorization paths used to register a token in the TokenAdminRegistry. */
+export const REGISTER_ADMIN_METHODS = {
+  OWNER: 'owner',
+  CCIP_ADMIN: 'ccip-admin',
+} as const
+
+/** Standard BurnMint/LockRelease pool ALT writable positions. */
+export const DEFAULT_WRITABLE_INDEXES = [3, 4, 7] as const

--- a/ccip-sdk/src/cct/solana/token-admin-registry/constants.ts
+++ b/ccip-sdk/src/cct/solana/token-admin-registry/constants.ts
@@ -1,8 +1,11 @@
 /** Authorization paths used to register a token in the TokenAdminRegistry. */
-export const REGISTER_ADMIN_METHODS = {
+export const REGISTRATION_METHODS = {
   OWNER: 'owner',
   CCIP_ADMIN: 'ccip-admin',
 } as const
 
-/** Standard BurnMint/LockRelease pool ALT writable positions. */
+/**
+ * Positions of `poolConfig` (3), `poolTokenAta` (4), and `tokenMint` (7) in the pool ALT built
+ * by `createLookupTable`. Custom pools must extend this, e.g. `[...DEFAULT_WRITABLE_INDEXES, n]`.
+ */
 export const DEFAULT_WRITABLE_INDEXES = [3, 4, 7] as const

--- a/ccip-sdk/src/cct/solana/token-admin-registry/operations/register-admin.ts
+++ b/ccip-sdk/src/cct/solana/token-admin-registry/operations/register-admin.ts
@@ -19,11 +19,10 @@ import {
 } from '../../programs/router.ts'
 import { submit } from '../../submit.ts'
 import { parsePublicKey, validateAuthorityMatchesWallet } from '../../validate.ts'
-import { REGISTER_ADMIN_METHODS } from '../constants.ts'
+import { REGISTRATION_METHODS } from '../constants.ts'
 
 /** Authorization path used to register a token in the TokenAdminRegistry. */
-export type RegisterAdminMethod =
-  (typeof REGISTER_ADMIN_METHODS)[keyof typeof REGISTER_ADMIN_METHODS]
+export type RegisterAdminMethod = (typeof REGISTRATION_METHODS)[keyof typeof REGISTRATION_METHODS]
 
 type RegisterAdminParams = {
   /** Token mint to register. The proposed administrator remains pending until accepted. */
@@ -141,7 +140,7 @@ export class RegisterAdmin extends SolanaOperation<
   protected override parse(params: GenerateRegisterAdminParams): ParsedRegisterAdminParams {
     if (
       params.registrationMethod !== undefined &&
-      !Object.values(REGISTER_ADMIN_METHODS).includes(params.registrationMethod)
+      !Object.values(REGISTRATION_METHODS).includes(params.registrationMethod)
     ) {
       throw new CCTParamsInvalidError(
         this.name,
@@ -161,7 +160,7 @@ export class RegisterAdmin extends SolanaOperation<
       ...(params.administrator !== undefined && {
         administrator: parsePublicKey(this.name, 'administrator', params.administrator),
       }),
-      method: params.registrationMethod ?? REGISTER_ADMIN_METHODS.OWNER,
+      method: params.registrationMethod ?? REGISTRATION_METHODS.OWNER,
     }
   }
 
@@ -199,12 +198,12 @@ export class RegisterAdmin extends SolanaOperation<
 
     const instructions: TransactionInstruction[] = []
     switch (method) {
-      case REGISTER_ADMIN_METHODS.OWNER: {
+      case REGISTRATION_METHODS.OWNER: {
         const ownerIx = await buildOwnerInstruction(program, accounts, mintAuthority, administrator)
         instructions.push(ownerIx)
         break
       }
-      case REGISTER_ADMIN_METHODS.CCIP_ADMIN: {
+      case REGISTRATION_METHODS.CCIP_ADMIN: {
         const ccipAdminIx = await buildCcipAdminInstruction(program, accounts, administrator)
         instructions.push(ccipAdminIx)
         break

--- a/ccip-sdk/src/cct/solana/token-admin-registry/operations/register-admin.ts
+++ b/ccip-sdk/src/cct/solana/token-admin-registry/operations/register-admin.ts
@@ -19,12 +19,7 @@ import {
 } from '../../programs/router.ts'
 import { submit } from '../../submit.ts'
 import { parsePublicKey, validateAuthorityMatchesWallet } from '../../validate.ts'
-
-/** Authorization paths used to register a token in the TokenAdminRegistry. */
-const REGISTER_ADMIN_METHODS = {
-  OWNER: 'owner',
-  CCIP_ADMIN: 'ccip-admin',
-} as const
+import { REGISTER_ADMIN_METHODS } from '../constants.ts'
 
 /** Authorization path used to register a token in the TokenAdminRegistry. */
 export type RegisterAdminMethod =

--- a/ccip-sdk/src/cct/solana/token-admin-registry/operations/set-pool.test.ts
+++ b/ccip-sdk/src/cct/solana/token-admin-registry/operations/set-pool.test.ts
@@ -7,7 +7,7 @@ import { CCIPWalletInvalidError } from '../../../../errors/index.ts'
 import { ChainFamily } from '../../../../networks.ts'
 import type { SolanaChain } from '../../../../solana/index.ts'
 import { CCTParamsInvalidError } from '../../../errors.ts'
-import { SolanaTokenManager } from '../../index.ts'
+import { DEFAULT_WRITABLE_INDEXES, SolanaTokenManager } from '../../index.ts'
 
 const BLOCKHASH = PublicKey.default.toBase58()
 const TOKEN = Keypair.generate().publicKey.toBase58()
@@ -56,6 +56,12 @@ describe('SetPool (cct/solana)', () => {
       assert.ok(instruction.keys.some((key) => key.pubkey.toBase58() === TOKEN))
       assert.ok(instruction.keys.some((key) => key.pubkey.toBase58() === POOL_LOOKUP_TABLE))
       assert.ok(instruction.keys.some((key) => key.pubkey.toBase58() === PAYER))
+    })
+
+    it('accepts the default writable indexes directly', async () => {
+      const unsigned = await generate({ writableIndexes: DEFAULT_WRITABLE_INDEXES })
+
+      assert.equal(unsigned.instructions[0]!.data.toString('hex'), '771e0eb473e1a7ee03000000030407')
     })
 
     it('uses caller-provided writable indexes', async () => {

--- a/ccip-sdk/src/cct/solana/token-admin-registry/operations/set-pool.ts
+++ b/ccip-sdk/src/cct/solana/token-admin-registry/operations/set-pool.ts
@@ -35,7 +35,7 @@ type SetPoolParams = {
    * pools; custom pools with extra accounts MUST extend this or the pool CPI gets wrong
    * write-permissions and fails at execution. Each entry is a byte (0–255).
    */
-  writableIndexes?: number[]
+  writableIndexes?: readonly number[]
   /**
    * Token admin authority. Defaults to `payer` for single-signer transactions.
    * Multisig/Squads flows should pass the admin/vault authority explicitly.
@@ -85,7 +85,7 @@ export class SetPool extends SolanaOperation<SetPoolParams, UnsignedSolanaTx, Pa
         params.authority === undefined
           ? payer
           : parsePublicKey(this.name, 'authority', params.authority),
-      writableIndexes: params.writableIndexes ?? [...DEFAULT_WRITABLE_INDEXES],
+      writableIndexes: [...(params.writableIndexes ?? DEFAULT_WRITABLE_INDEXES)],
     }
   }
 

--- a/ccip-sdk/src/cct/solana/token-admin-registry/operations/set-pool.ts
+++ b/ccip-sdk/src/cct/solana/token-admin-registry/operations/set-pool.ts
@@ -17,9 +17,7 @@ import {
   deriveTokenAdminRegistryPda,
 } from '../../programs/router.ts'
 import { parsePublicKey, validateWritableIndexes } from '../../validate.ts'
-
-/** Standard BurnMint/LockRelease pool ALT writable positions. */
-export const DEFAULT_WRITABLE_INDEXES = [3, 4, 7] as const
+import { DEFAULT_WRITABLE_INDEXES } from '../constants.ts'
 
 /** Parameters shared by Solana TokenAdminRegistry `setPool` generation and execution. */
 type SetPoolParams = {

--- a/ccip-sdk/src/cct/solana/token/constants.ts
+++ b/ccip-sdk/src/cct/solana/token/constants.ts
@@ -1,0 +1,5 @@
+/** SPL Token authority roles that can be set. */
+export const TOKEN_AUTHORITY_TYPES = {
+  MINT: 'mint',
+  FREEZE: 'freeze',
+} as const

--- a/ccip-sdk/src/cct/solana/token/operations/index.ts
+++ b/ccip-sdk/src/cct/solana/token/operations/index.ts
@@ -1,11 +1,4 @@
 export * from './create-token-account.ts'
 export * from './deploy-token.ts'
 export * from './mint-tokens.ts'
-export { SetTokenAuthority } from './set-token-authority.ts'
-export type {
-  ExecuteSetTokenAuthorityParams,
-  ExecuteSetTokenAuthorityResult,
-  GenerateSetTokenAuthorityParams,
-  GenerateSetTokenAuthorityResult,
-  TokenAuthorityType,
-} from './set-token-authority.ts'
+export * from './set-token-authority.ts'

--- a/ccip-sdk/src/cct/solana/token/operations/set-token-authority.ts
+++ b/ccip-sdk/src/cct/solana/token/operations/set-token-authority.ts
@@ -14,12 +14,7 @@ import {
 } from '../../operation.ts'
 import { submit } from '../../submit.ts'
 import { parsePublicKey, validateAuthorityMatchesWallet } from '../../validate.ts'
-
-/** SPL Token authority roles that can be set. */
-export const TOKEN_AUTHORITY_TYPES = {
-  MINT: 'mint',
-  FREEZE: 'freeze',
-} as const
+import { TOKEN_AUTHORITY_TYPES } from '../constants.ts'
 
 /** SPL Token authority role that can be set. */
 export type TokenAuthorityType = (typeof TOKEN_AUTHORITY_TYPES)[keyof typeof TOKEN_AUTHORITY_TYPES]


### PR DESCRIPTION
## What

- Export Solana CCT registration methods and default pool writable indexes from the public SDK entrypoint
- Move token and token-admin-registry public constants into domain-local constants modules

## Why

- Let SDK consumers use supported configuration values without importing operation implementation files