### PR TITLE
test: classify networked suites and lock live-network runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,68 +14,71 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
     steps:
-    - name: Check out repository
-      uses: actions/checkout@v5.0.0
+      - name: Check out repository
+        uses: actions/checkout@v7.0.1
 
-    - name: Set up Node.js
-      uses: actions/setup-node@v6.0.0
-      with:
-        node-version: 24
+      - name: Set up Node.js
+        uses: actions/setup-node@v7.0.0
+        with:
+          node-version: 24
 
-    - name: Install Foundry (anvil for fork tests)
-      uses: foundry-rs/foundry-toolchain@8789b3e21e6c11b2697f5eb56eddae542f746c10 # v1.7.0
+      # Older foundry-toolchain pins ran foundryup via `bash` and broke when it became
+      # a compiled binary ("cannot execute binary file"); v1.9.1 executes it directly
+      # and pins the foundryup installer internally, so no vendor script is piped here.
+      - name: Install Foundry (anvil for fork tests)
+        uses: foundry-rs/foundry-toolchain@908c540300062bd5a7e473851cdb4282204cee09 # v1.9.1
 
-    - name: Verify anvil is available
-      run: anvil --version
+      - name: Verify anvil is available
+        run: anvil --version
 
-    - name: Install Surfpool v1.1.2 (for SVM fork tests)
-      run: |
-        curl -sSL https://github.com/solana-foundation/surfpool/releases/download/v1.1.2/surfpool-linux-x64.tar.gz \
-          | tar xz -C /usr/local/bin
+      - name: Install Surfpool v1.1.2 (for SVM fork tests)
+        run: |
+          curl -sSL https://github.com/solana-foundation/surfpool/releases/download/v1.1.2/surfpool-linux-x64.tar.gz \
+            | tar xz -C /usr/local/bin
 
-    - name: Verify surfpool is available
-      run: surfpool --version
+      - name: Verify surfpool is available
+        run: surfpool --version
 
-    - name: Install dependencies and build
-      run: npm ci
+      - name: Install dependencies and build
+        run: npm ci
 
-    - name: Run lint
-      run: npm run check
+      - name: Run lint
+        run: npm run check
 
-    - name: Validate package exports
-      working-directory: ccip-sdk
-      run: |
-        # publint - check package.json exports and module format
-        npx publint
+      - name: Validate package exports
+        working-directory: ccip-sdk
+        run: |
+          # publint - check package.json exports and module format
+          npx publint
 
-        # attw - check TypeScript types resolution (informational)
-        # Note: CJS resolution warnings are expected for ESM-only packages
-        npx @arethetypeswrong/cli --pack . --profile esm-only || true
+          # attw - check TypeScript types resolution (informational)
+          # Note: CJS resolution warnings are expected for ESM-only packages
+          npx @arethetypeswrong/cli --pack . --profile esm-only || true
 
-    - name: Run tests with coverage
-      env:
-        # Temporary: pipe surfpool stdout/stderr to diagnose Solana fork test failures in CI
-        VERBOSE: '1'
-      run: |
-        set -o pipefail
-        npm test 2>&1 | tee coverage-summary.txt
+      - name: Run tests with coverage
+        env:
+          # Temporary: pipe surfpool stdout/stderr to diagnose Solana fork test failures in CI
+          VERBOSE: '1'
+        run: |
+          set -o pipefail
+          npm test 2>&1 | tee coverage-summary.txt
 
-    - name: Upload coverage report
-      if: "always() && hashFiles('.coverage/**') != ''"
-      uses: actions/upload-artifact@v5.0.0
-      with:
-        name: coverage-report
-        path: .coverage
+      - name: Upload coverage report
+        if: "always() && hashFiles('.coverage/**') != ''"
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: coverage-report
+          path: .coverage
 
-    - name: Upload coverage summary
-      if: always()
-      uses: actions/upload-artifact@v5.0.0
-      with:
-        name: coverage-summary
-        path: coverage-summary.txt
+      - name: Upload coverage summary
+        if: always()
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: coverage-summary
+          path: coverage-summary.txt
 
-    - name: Smoke test cli
-      run: npx $PWD/ccip-cli --help
+      - name: Smoke test cli
+        run: npx $PWD/ccip-cli --help
 
   coverage-comment:
     needs: build-and-test
@@ -90,60 +93,60 @@ jobs:
     if: github.event_name == 'pull_request'
 
     steps:
-    - name: Download coverage summary
-      uses: actions/download-artifact@v5.0.0
-      with:
-        name: coverage-summary
-        path: .
+      - name: Download coverage summary
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: coverage-summary
+          path: .
 
-    - name: Post or update PR comment with coverage summary
-      uses: actions/github-script@v8.0.0
-      with:
-        script: |
-          const fs = require('fs');
+      - name: Post or update PR comment with coverage summary
+        uses: actions/github-script@v9.0.0
+        with:
+          script: |
+            const fs = require('fs');
 
-          let coverageSummary = fs.readFileSync('coverage-summary.txt', 'utf8').split('\n');
-          coverageSummary = coverageSummary.slice(
-            coverageSummary.findIndex(line => line.match(/^ℹ/))
-          ).join('\n');
+            let coverageSummary = fs.readFileSync('coverage-summary.txt', 'utf8').split('\n');
+            coverageSummary = coverageSummary.slice(
+              coverageSummary.findIndex(line => line.match(/^ℹ/))
+            ).join('\n');
 
-          if (coverageSummary.trim().length === 0) {
-            console.log('No coverage data found');
-            process.exit(1);
-          }
+            if (coverageSummary.trim().length === 0) {
+              console.log('No coverage data found');
+              process.exit(1);
+            }
 
-          const prNumber = context.payload.pull_request
-            ? context.payload.pull_request.number
-            : null;
+            const prNumber = context.payload.pull_request
+              ? context.payload.pull_request.number
+              : null;
 
-          if (!prNumber) {
-            console.log('No PR number found, skipping comment.');
-            return;
-          }
+            if (!prNumber) {
+              console.log('No PR number found, skipping comment.');
+              return;
+            }
 
-          const commentBody = `## Coverage Report\n\n\`\`\`\n${coverageSummary}\n\`\`\``;
+            const commentBody = `## Coverage Report\n\n\`\`\`\n${coverageSummary}\n\`\`\``;
 
-          const { data: comments } = await github.rest.issues.listComments({
-            ...context.repo,
-            issue_number: prNumber,
-          });
-
-          const botComment = comments.find(
-            comment =>
-              comment.user.login === 'github-actions[bot]' &&
-              comment.body.includes('## Coverage Report')
-          );
-
-          if (botComment) {
-            await github.rest.issues.updateComment({
-              ...context.repo,
-              comment_id: botComment.id,
-              body: commentBody,
-            });
-          } else {
-            await github.rest.issues.createComment({
+            const { data: comments } = await github.rest.issues.listComments({
               ...context.repo,
               issue_number: prNumber,
-              body: commentBody,
             });
-          }
+
+            const botComment = comments.find(
+              comment =>
+                comment.user.login === 'github-actions[bot]' &&
+                comment.body.includes('## Coverage Report')
+            );
+
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                ...context.repo,
+                comment_id: botComment.id,
+                body: commentBody,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: prNumber,
+                body: commentBody,
+              });
+            }

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,10 +24,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7.0.0
         with:
           node-version: 24
           cache: 'npm'
@@ -46,7 +46,7 @@ jobs:
 
       - name: Upload build artifact
         if: github.ref == 'refs/heads/main'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: docs-build
           path: ccip-api-ref/build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out repository
-      uses: actions/checkout@v5.0.0
+      uses: actions/checkout@v7.0.1
 
     - name: Set up Node.js
-      uses: actions/setup-node@v6.0.0
+      uses: actions/setup-node@v7.0.0
       with:
         node-version: 24
 
@@ -42,8 +42,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: publish
     steps:
-      - uses: actions/checkout@v5.0.0
-      - uses: actions/setup-node@v6.0.0
+      - uses: actions/checkout@v7.0.1
+      - uses: actions/setup-node@v7.0.0
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org/
@@ -62,8 +62,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: publish
     steps:
-      - uses: actions/checkout@v5.0.0
-      - uses: actions/setup-node@v6.0.0
+      - uses: actions/checkout@v7.0.1
+      - uses: actions/setup-node@v7.0.0
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Tests: networked suites (`*.integration.test.ts`, `*.e2e.test.ts`, `*.fork.test.ts`) take per-network OS locks via the new `useResource` test helper, so concurrent `node --test` file runs never share a live RPC endpoint (suites declare the networks they talk to and wait on each other instead of rate-limiting public gateways); `npm run test:unit` now runs only offline unit tests
 - TON: `getLogs` cold backfills (startTime-only, watermark-less polls) seed from the TonCenter v3 index instead of walking the account's whole tx history: one strictly-filtered `/messages` page (plus a briefly-cached tip for the lag guard), paged `/transactions` meta joins event txs by hash, and raw event txs hydrate from the v2 RPC by `(lt, hash)`
   - Index calls use a dedicated paced, fail-fast fetch (a caller-provided `fetch` is reused verbatim; override via the TON-local `v3Fetch` context option); index inconsistencies truncate the scan like a chain gap, and the caller resumes from `since`
   - Deep v2 walks (`startBlock`/`since` over long windows) stamp block numbers via a lazily-engaged index meta oracle after 16 txs — one index page per ~100 txs instead of 2-3 RPCs per tx (24h windows: ~130s → ~17s); shallow polls never touch the index

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,8 +10,9 @@ For project overview and architecture, see the [documentation](docs/index.md).
 ## Quick Start
 
 ```bash
-npm ci          # Install dependencies
-npm test        # Run all tests
+npm ci           # Install dependencies
+npm run test:unit  # Unit tests only (no network access; integration/e2e/fork excluded)
+npm test         # Run all tests (unit + integration + e2e + fork)
 npm run check   # Lint + typecheck
 ```
 
@@ -22,11 +23,45 @@ Run before submitting a PR:
 ```bash
 npm run lint        # Prettier + ESLint
 npm run typecheck   # TypeScript validation
+npm run test:unit   # Unit tests only with coverage
 npm run test        # All tests with coverage
 npm run build       # Full build
 ```
 
 CI runs: `npm ci` → `npm run check` → `npm test`
+
+## Test Suite Layout
+
+Test files are classified by filename suffix:
+
+| Suffix | Category | Included in `test:unit` |
+| --- | --- | --- |
+| `*.test.ts` | Unit — mocked, no network access | ✅ |
+| `*.integration.test.ts` | Integration — live RPCs / staging API | ❌ |
+| `*.e2e.test.ts` | End-to-end — CLI spawned against live networks | ❌ |
+| `*.fork.test.ts` | Fork — anvil/surfpool forking live state | ❌ |
+
+A bare `integration.test.ts` (e.g. `src/evm/integration.test.ts`) is recognized as integration exactly like `logs.integration.test.ts` — the suffix is what matters, and `fork.test.data.ts` is a data helper, not a test.
+
+### Networked tests and the `useResource` lock
+
+`node --test` runs every test file concurrently, so networked suites that share public RPC endpoints would trip their rate limiters. Each networked suite instead declares the networks it talks to with an OS-level lock:
+
+```ts
+import { useResource } from '../../../scripts/useResource.ts'
+
+// Module top-level: the suite's tests do not start before every lock is held.
+await useResource(['sepolia', 'fuji'])
+```
+
+Each network tag is a directory in a well-known lock root (`<tmpdir>/ccip-tools-ts-network-locks`), created atomically with `fs.mkdir`, so exactly one test process holds a tag at a time. The filesystem is the queue: when a suite finishes, its tags release and the next suite waiting on them starts immediately — there is no batch/round scheduling. Locks auto-release on process exit; crashed holders are detected by pid liveness (or owner-file age) and self-heal on the next acquisition.
+
+Locks are per-machine, so all networked suites must run inside a single CI job/runner. Configure via env:
+
+| Variable | Effect |
+| --- | --- |
+| `CCIP_TOOLS_TEST_LOCK_DIR` | Lock root directory (default: `<os.tmpdir()>/ccip-tools-ts-network-locks`) |
+| `CCIP_TOOLS_TEST_LOCK_TIMEOUT_MS` | Max wait for all locks before failing (default: 60 min) |
 
 ## Fork Tests
 

--- a/ccip-cli/package.json
+++ b/ccip-cli/package.json
@@ -23,6 +23,7 @@
   },
   "scripts": {
     "test": "node --test",
+    "test:unit": "node ../scripts/run-tests.mjs src --exclude integration,e2e,fork",
     "lint": "prettier --check ./src && eslint ./src",
     "lint:fix": "prettier --write ./src && eslint --fix ./src",
     "typecheck": "tsc --noEmit",

--- a/ccip-cli/src/commands/e2e-helpers.test.ts
+++ b/ccip-cli/src/commands/e2e-helpers.test.ts
@@ -22,6 +22,11 @@ export const RPCS = [
   process.env['RPC_TON'] || 'https://testnet.toncenter.com/api/v2',
 ]
 
+/**
+ * Spawns the CLI in-process as a child of node, capturing its stdout/stderr.
+ * Resolves with the captured output and exit code, or rejects if it hangs past
+ * `timeout` (killing the child).
+ */
 export async function spawnCLI(
   args: string[],
   timeout = 60000,
@@ -32,8 +37,8 @@ export async function spawnCLI(
     let stdout = ''
     let stderr = ''
 
-    child.stdout.on('data', (data) => (stdout += data.toString()))
-    child.stderr.on('data', (data) => (stderr += data.toString()))
+    child.stdout.on('data', (data: Buffer) => (stdout += data.toString()))
+    child.stderr.on('data', (data: Buffer) => (stderr += data.toString()))
 
     const timeoutId = setTimeout(() => {
       child.kill('SIGTERM')

--- a/ccip-cli/src/commands/lane.e2e.test.ts
+++ b/ccip-cli/src/commands/lane.e2e.test.ts
@@ -2,6 +2,10 @@ import assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 
 import { RPCS, spawnCLI } from './e2e-helpers.test.ts'
+import { useResource } from '../../../scripts/useResource.ts'
+
+// Cross-family lanes make the CLI resolve Aptos/Solana/TON endpoints too.
+await useResource(['sepolia', 'fuji', 'aptos-testnet', 'solana-devnet', 'ton-testnet'])
 
 function buildLaneArgs(
   source: string,

--- a/ccip-cli/src/commands/show.e2e.test.ts
+++ b/ccip-cli/src/commands/show.e2e.test.ts
@@ -2,6 +2,11 @@ import assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 
 import { RPCS, spawnCLI } from './e2e-helpers.test.ts'
+import { useResource } from '../../../scripts/useResource.ts'
+
+// The CLI is pointed at these endpoints via the shared RPCS list (e2e-helpers.ts), and
+// `show` also resolves 32-byte tx hashes through the default CCIP API (show.ts).
+await useResource(['sepolia', 'fuji', 'aptos-testnet', 'solana-devnet', 'ton-testnet', 'api'])
 
 function buildShowArgs(txHash: string, ...additionalArgs: string[]): string[] {
   return [

--- a/ccip-sdk/package.json
+++ b/ccip-sdk/package.json
@@ -32,6 +32,7 @@
   },
   "scripts": {
     "test": "node --test",
+    "test:unit": "node ../scripts/run-tests.mjs src --exclude integration,e2e,fork",
     "lint": "prettier --check ./src && eslint ./src",
     "lint:fix": "prettier --write ./src && eslint --fix ./src",
     "typecheck": "tsc --noEmit",

--- a/ccip-sdk/src/api/api.integration.test.ts
+++ b/ccip-sdk/src/api/api.integration.test.ts
@@ -4,12 +4,16 @@ import { before, describe, it } from 'node:test'
 import '../index.ts'
 
 import { CCIPAPIClient } from './index.ts'
+import { useResource } from '../../../scripts/useResource.ts'
 import {
   CCIPLaneNotFoundError,
   CCIPMessageIdNotFoundError,
   CCIPMessageNotFoundInTxError,
 } from '../errors/index.ts'
 import { MessageStatus } from '../types.ts'
+
+// The suite only talks to the staging CCIP API — the selectors below are data, not endpoints.
+await useResource(['api'])
 
 // Test data from CLI E2E tests (show.test.ts)
 const SEPOLIA_SELECTOR = 16015286601757825753n

--- a/ccip-sdk/src/evm/dest-liquidity.fork.test.ts
+++ b/ccip-sdk/src/evm/dest-liquidity.fork.test.ts
@@ -29,7 +29,11 @@ import { getErrorData, parseWithFragment } from './errors.ts'
 import { findBalancesSlot } from './gas.ts'
 import { EVMChain } from './index.ts'
 import { isTransientReleaseOrMintRevert, simulateReleaseOrMint } from './simulate.ts'
+import { useResource } from '../../../scripts/useResource.ts'
 import { CCIPDestExecutionRevertError } from '../errors/index.ts'
+
+// Forks run atop live Sepolia/Fuji RPCs (anvil fetches state from the upstream lazily).
+await useResource(['sepolia', 'fuji'])
 
 // ── Chain constants ──
 

--- a/ccip-sdk/src/evm/dest-liquidity.integration.test.ts
+++ b/ccip-sdk/src/evm/dest-liquidity.integration.test.ts
@@ -21,6 +21,10 @@ import { CCIPDestSimulationUnavailableError } from '../errors/index.ts'
 import { estimateReceiveExecution } from '../gas.ts'
 import { EVMChain } from './index.ts'
 import { simulateReleaseOrMint } from './simulate.ts'
+import { useResource } from '../../../scripts/useResource.ts'
+
+// Live RPCs: the isolated v2.0 staging lane (Sepolia → Fuji) and the LBTC prod-testnet lanes.
+await useResource(['sepolia', 'fuji'])
 
 const SEPOLIA_RPC = process.env['RPC_SEPOLIA'] || 'https://rpc.sepolia.ethpandaops.io'
 const SEPOLIA_SELECTOR = 16015286601757825753n

--- a/ccip-sdk/src/evm/fork.test.ts
+++ b/ccip-sdk/src/evm/fork.test.ts
@@ -27,6 +27,11 @@ import { interfaces } from './const.ts'
 import { FUJI_TO_SEPOLIA, SOLANA_DEVNET_TO_SEPOLIA, TON_TO_SEPOLIA } from './fork.test.data.ts'
 import { EVMChain } from './index.ts'
 import { ViemTransportProvider } from './viem/client-adapter.ts'
+import { useResource } from '../../../scripts/useResource.ts'
+
+// Forks fetch live state from Sepolia/Fuji/Arb-Sepolia/Hedera-testnet upstreams; several
+// execution paths also hit the staging CCIP API.
+await useResource(['sepolia', 'fuji', 'arbitrum-sepolia', 'hedera-testnet', 'api'])
 
 // ── Chain constants ──
 

--- a/ccip-sdk/src/evm/integration.test.ts
+++ b/ccip-sdk/src/evm/integration.test.ts
@@ -16,6 +16,10 @@ import { ExecutionState, MessageStatus } from '../types.ts'
 import { interfaces } from './const.ts'
 import { FUJI_TO_SEPOLIA, SEPOLIA_TO_FUJI } from './fork.test.data.ts'
 import { EVMChain } from './index.ts'
+import { useResource } from '../../../scripts/useResource.ts'
+
+// Live RPCs: Sepolia, Fuji, Arbitrum Sepolia — plus the CCIP API (prod default + staging in places).
+await useResource(['sepolia', 'fuji', 'arbitrum-sepolia', 'api'])
 
 // ── Chain constants ──
 

--- a/ccip-sdk/src/solana/__tests__/integration.test.ts
+++ b/ccip-sdk/src/solana/__tests__/integration.test.ts
@@ -4,6 +4,7 @@ import { after, before, describe, it } from 'node:test'
 
 import { Connection, PublicKey } from '@solana/web3.js'
 
+import { useResource } from '../../../../scripts/useResource.ts'
 import { EVMChain } from '../../evm/index.ts'
 import { discoverOffRamp } from '../../execution.ts'
 import { networkInfo } from '../../index.ts'
@@ -14,6 +15,10 @@ import {
   SOLANA_TO_ETHEREUM,
 } from '../fork.test.data.ts'
 import { SolanaChain } from '../index.ts'
+
+// Live lanes exercised: Solana devnet (send/execute fixtures) and Solana mainnet
+// (getTokenInfo / mainnet CCIP message suites), plus Fuji/Sepolia RPCs for lane data.
+await useResource(['sepolia', 'fuji', 'solana-devnet', 'solana-mainnet'])
 
 const FUJI_RPC = process.env.FUJI_RPC ?? 'https://api.avax-test.network/ext/bc/C/rpc'
 const SEPOLIA_RPC =

--- a/ccip-sdk/src/solana/fork.test.ts
+++ b/ccip-sdk/src/solana/fork.test.ts
@@ -10,7 +10,11 @@ import { CCIPAPIClient } from '../api/index.ts'
 import { ExecutionState, MessageStatus } from '../types.ts'
 import { ETHEREUM_TO_SOLANA } from './fork.test.data.ts'
 import { SolanaChain } from './index.ts'
+import { useResource } from '../../../scripts/useResource.ts'
 import { networkInfo } from '../index.ts'
+
+// Surfpool forks live Solana mainnet state; the API-driven execution path uses the staging API.
+await useResource(['solana-mainnet', 'api'])
 
 // ── Constants ──
 

--- a/ccip-sdk/src/sui/integration.test.ts
+++ b/ccip-sdk/src/sui/integration.test.ts
@@ -11,8 +11,12 @@ import {
   getOffRampForCcip,
 } from './discovery.ts'
 import { SuiChain } from './index.ts'
+import { useResource } from '../../../scripts/useResource.ts'
 import { EVMChain } from '../evm/index.ts'
 import { discoverOffRamp } from '../execution.ts'
+
+// Live RPCs: sui-testnet (BlockVision archival gateway) and Fuji (lane data).
+await useResource(['fuji', 'sui-testnet'])
 
 // Integration tests issue live RPC calls against public endpoints. Sui's public
 // JSON-RPC fullnodes were deprecated; the default is BlockVision's public

--- a/ccip-sdk/src/ton/index.integration.test.ts
+++ b/ccip-sdk/src/ton/index.integration.test.ts
@@ -6,8 +6,11 @@ import { Address } from '@ton/core'
 import '../index.ts'
 import { TONChain } from './index.ts'
 import { crc32 } from './utils.ts'
+import { useResource } from '../../../scripts/useResource.ts'
 import type { CCIPMessage_V1_6_EVM } from '../evm/messages.ts'
 import type { CCIPMessage, CCIPVersion } from '../types.ts'
+
+await useResource(['ton-testnet'])
 
 // CRC32 hex values for TON external message topics
 const CCIP_MESSAGE_SENT_TOPIC = crc32('CCIPMessageSent') // 0xa45d293c

--- a/ccip-sdk/src/ton/logs.integration.test.ts
+++ b/ccip-sdk/src/ton/logs.integration.test.ts
@@ -3,11 +3,14 @@ import { after, before, describe, it } from 'node:test'
 
 import { TONChain } from './index.ts'
 import { V3_MAX_INDEX_LAG, tonV3BaseUrl } from './logs.ts'
+import { useResource } from '../../../scripts/useResource.ts'
 import { CCIPLogsStreamInconsistentError } from '../errors/index.ts'
 import { NetworkType } from '../networks.ts'
 import { sleep } from '../utils.ts'
 import { crc32 } from './utils.ts'
 import type { ChainLog } from '../types.ts'
+
+await useResource(['ton-testnet'])
 
 /**
  * Live-testnet coverage of the three getLogs scan shapes the ccip-o11y Temporal

--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
   ],
   "scripts": {
     "test": "npm run clean:coverage && c8 npm test -w ccip-sdk -w ccip-cli",
-    "test:unit": "npm run clean:coverage && c8 npm test -w ccip-sdk",
-    "test:e2e": "npm run clean:coverage && c8 npm test -w ccip-cli",
+    "test:unit": "npm run clean:coverage && c8 npm run test:unit -w ccip-sdk -w ccip-cli",
     "lint": "npm run lint --workspaces && npm run generate:lint",
     "lint:fix": "npm run lint:fix --workspaces && npm run generate",
     "typecheck": "npm run typecheck --workspaces",

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+/**
+ * Runs `node --test` over a filtered subset of a workspace's test files.
+ *
+ * Test files are classified purely by filename suffix:
+ *   *.integration.test.ts  → tag: integration
+ *   *.e2e.test.ts          → tag: e2e
+ *   *.fork.test.ts         → tag: fork
+ *   anything else matching *.test.ts → unit
+ *
+ * This keeps plain `integration.test.ts` recognized exactly like
+ * `logs.integration.test.ts` — the suffix is what matters, not the stem.
+ *
+ * Usage (npm workspace scripts run with cwd = the workspace root):
+ *   node ../scripts/run-tests.mjs <dir>                # every *.test.ts under <dir>
+ *   node ../scripts/run-tests.mjs <dir> --exclude integration,e2e,fork   # unit only
+ *   node ../scripts/run-tests.mjs <dir> --tags integration,fork          # tagged only
+ *   node ../scripts/run-tests.mjs <dir> --dry                            # print the selection, run nothing
+ *
+ * Exit code mirrors the node --test run (0 = all pass, 1 = any failure).
+ */
+import { spawn } from 'node:child_process'
+import { readdirSync, statSync } from 'node:fs'
+import { join, relative } from 'node:path'
+
+const TEST_FILE_RE = /\.test\.(?:ts|mts|cts)$/i
+// Filename stem suffixes: a bare `integration.test.ts` classifies exactly like
+// `logs.integration.test.ts`, while `fork.test.data.ts` (data helper) and names like
+// `notintegration.test.ts` (no dot boundary) match nothing.
+const TAG_SUFFIXES = {
+  integration: 'integration.test.ts',
+  e2e: 'e2e.test.ts',
+  fork: 'fork.test.ts',
+}
+
+function tagsOf(filePath) {
+  const name = filePath.split('/').at(-1) ?? ''
+  const lower = name.toLowerCase()
+  return Object.entries(TAG_SUFFIXES)
+    .filter(([, suffix]) => lower === suffix || lower.endsWith('.' + suffix))
+    .map(([tag]) => tag)
+}
+
+/** Recursively collect test files under dir, sorted for deterministic ordering. */
+function collectTestFiles(dir, files = []) {
+  for (const entry of readdirSync(dir).sort()) {
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) {
+      collectTestFiles(full, files)
+    } else if (TEST_FILE_RE.test(entry)) {
+      files.push(full)
+    }
+  }
+  return files
+}
+
+function parseArgs(argv) {
+  const positional = []
+  const flags = { exclude: new Set(), tags: new Set(), dry: false }
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]
+    if (arg === '--dry') {
+      flags.dry = true
+    } else if (arg === '--exclude' || arg === '--tags') {
+      for (const value of (argv[i + 1] ?? '').split(',').filter(Boolean)) {
+        if (!(value in TAG_SUFFIXES)) {
+          console.error(
+            `[run-tests] unknown tag "${value}" — expected one of: ${Object.keys(TAG_SUFFIXES).join(', ')}`,
+          )
+          process.exit(1)
+        }
+        flags[arg.slice(2)].add(value)
+      }
+      i++
+    } else {
+      positional.push(arg)
+    }
+  }
+  return { dir: positional[0], flags }
+}
+
+function main() {
+  const { dir, flags } = parseArgs(process.argv.slice(2))
+  if (!dir) {
+    console.error('usage: node scripts/run-tests.mjs <dir> [--exclude a,b] [--tags a,b]')
+    process.exit(1)
+  }
+  if (!statSync(dir).isDirectory()) {
+    console.error(`[run-tests] not a directory: ${dir}`)
+    process.exit(1)
+  }
+
+  const files = collectTestFiles(dir).filter((file) => {
+    const tags = tagsOf(file)
+    if (flags.tags.size > 0 && !tags.some((tag) => flags.tags.has(tag))) return false
+    if (flags.exclude.size > 0 && tags.some((tag) => flags.exclude.has(tag))) return false
+    return true
+  })
+
+  if (files.length === 0) {
+    console.error('[run-tests] no test files matched')
+    process.exit(flags.tags.size > 0 ? 1 : 0)
+  }
+
+  const relativeFiles = files.map((file) => relative(process.cwd(), file))
+  console.error(`[run-tests] running ${relativeFiles.length} test file(s)`)
+  for (const file of relativeFiles) console.error(`  ${file}`)
+  if (flags.dry) process.exit(0)
+  const child = spawn(process.execPath, ['--test', ...relativeFiles], {
+    cwd: process.cwd(),
+    stdio: 'inherit',
+  })
+  for (const signal of ['SIGINT', 'SIGTERM']) {
+    process.on(signal, () => {
+      child.kill(signal)
+    })
+  }
+  child.on('exit', (code) => {
+    process.exit(code ?? 1)
+  })
+}
+
+main()

--- a/scripts/useResource.ts
+++ b/scripts/useResource.ts
@@ -1,0 +1,290 @@
+/**
+ * OS-level network locks for the networked test suites (integration / e2e / fork).
+ *
+ * `node --test` spawns one child process per test file and runs them all
+ * concurrently, so suites that share a public RPC endpoint can trip its rate
+ * limiter. Each network tag is a directory under a well-known lock root:
+ * `fs.mkdir` is atomic on POSIX and NTFS, so exactly one process can hold a tag
+ * at a time and any other acquirer simply waits for it to be released — the
+ * filesystem itself is the queue, and a waiting suite starts the moment the
+ * previous holder finishes, with no batch scheduling at all.
+ *
+ * Usage — module top-level of a networked test file (the file's tests do not
+ * start until every requested lock is held; the locks auto-release on process
+ * exit, or earlier via the returned handle):
+ *
+ * ```ts
+ * import { useResource } from '../../../scripts/useResource.ts'
+ * await useResource(['sepolia', 'fuji'])
+ * ```
+ *
+ * Staleness: crashed holders self-heal. The next acquirer steals the directory
+ * when the recorded owner process is no longer alive, or — when the owner file
+ * is unreadable — when the directory is older than `UNOWNED_STALE_MS`. A lock
+ * held by a live process is never stolen, no matter its age.
+ *
+ * Locks are per-machine (a directory cannot arbitrate across hosts), so all
+ * networked suites must run inside a single CI job/runner.
+ *
+ * Env overrides:
+ *   CCIP_TOOLS_TEST_LOCK_DIR         lock root (default: `<os.tmpdir()>/ccip-tools-ts-network-locks`)
+ *   CCIP_TOOLS_TEST_LOCK_TIMEOUT_MS  max total wait for all requested locks (default: 60 min)
+ */
+import {
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+const LOCK_ROOT =
+  process.env['CCIP_TOOLS_TEST_LOCK_DIR'] || join(tmpdir(), 'ccip-tools-ts-network-locks')
+const TIMEOUT_MS = Number(process.env['CCIP_TOOLS_TEST_LOCK_TIMEOUT_MS']) || 3_600_000
+const POLL_MS = 200
+const LOG_INTERVAL_MS = 5_000
+/** A lock directory without a readable owner.json is stolen once this old. */
+const UNOWNED_STALE_MS = 10 * 60_000
+
+const RESOURCE_NAME_RE = /^[a-z0-9][a-z0-9-]*$/
+
+/** resource tag → number of times this process has acquired it (refcounted). */
+const held = new Map<string, number>()
+
+export interface ResourceHandle {
+  /** Releases the requested locks (idempotent). */
+  release(): Promise<void>
+}
+
+function lockDir(resource: string): string {
+  return join(LOCK_ROOT, resource)
+}
+
+function log(message: string): void {
+  console.error(`[network-locks] ${message}`)
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function isHeldHere(resource: string): boolean {
+  return (held.get(resource) ?? 0) > 0
+}
+
+function describeHolder(resource: string): string {
+  try {
+    const info = JSON.parse(readFileSync(join(lockDir(resource), 'owner.json'), 'utf8')) as {
+      pid?: unknown
+      startedAt?: unknown
+    }
+    const startedAt =
+      typeof info.startedAt === 'number' ? new Date(info.startedAt).toISOString() : '?'
+    return `pid ${String(info.pid)} since ${startedAt}`
+  } catch {
+    return 'unknown owner'
+  }
+}
+
+/**
+ * A directory is stale when its recorded owner process is dead, or when no
+ * readable owner is recorded and the directory is old enough that its creator
+ * must have crashed mid-write (or the owner file was tampered with).
+ */
+function isStale(resource: string): boolean {
+  const dir = lockDir(resource)
+  let ownerPid: number | undefined
+  try {
+    const info = JSON.parse(readFileSync(join(dir, 'owner.json'), 'utf8')) as { pid?: unknown }
+    if (typeof info.pid === 'number') ownerPid = info.pid
+  } catch {
+    // missing/corrupt owner.json → fall through to the mtime heuristic
+  }
+  if (ownerPid !== undefined) {
+    try {
+      process.kill(ownerPid, 0) // same-machine pid: locks are per-machine
+      return false // alive → never steal, regardless of age
+    } catch (err) {
+      return (err as NodeJS.ErrnoException).code === 'ESRCH' // dead → stale
+    }
+  }
+  try {
+    return Date.now() - statSync(dir).mtimeMs > UNOWNED_STALE_MS
+  } catch {
+    return false // dir vanished (racing acquirer) → not stale, just retry
+  }
+}
+
+/**
+ * The lock root and tag dirs live at predictable names in the OS temp dir, which is
+ * the point (unrelated test processes must find each other's locks) — so they are
+ * hardened instead of randomized: restrictive perms, and a real, owned directory
+ * that is never a planted symlink.
+ */
+function assertSafeLockPath(dir: string, what: string): void {
+  const st = lstatSync(dir)
+  if (!st.isDirectory() || (process.platform !== 'win32' && st.uid !== process.getuid?.())) {
+    throw new Error(
+      `refusing to use ${what} at ${dir}: not an own directory (symlink or foreign ownership)`,
+    )
+  }
+}
+
+/** Creates the coordination root if needed, with owner-only permissions. */
+function ensureLockRoot(): void {
+  mkdirSync(LOCK_ROOT, { recursive: true, mode: 0o700 })
+  assertSafeLockPath(LOCK_ROOT, 'lock root')
+  // Sweep abandoned stale-steal tombstones (renamed dead locks) that are older than
+  // an hour; recent ones may still be the subject of an in-flight claim.
+  const now = Date.now()
+  for (const entry of readdirSync(LOCK_ROOT)) {
+    if (!entry.startsWith('.tombstone-')) continue
+    const tomb = join(LOCK_ROOT, entry)
+    try {
+      if (now - statSync(tomb).mtimeMs > 3_600_000) rmSync(tomb, { recursive: true, force: true })
+    } catch {
+      // raced away
+    }
+  }
+}
+
+/** Tries to take the lock; `false` means contended or stolen-just-now (retry). */
+function tryAcquire(resource: string): boolean {
+  const dir = lockDir(resource)
+  if (isHeldHere(resource)) return true
+  try {
+    mkdirSync(dir, { mode: 0o700 })
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err
+    // A planted symlink must never be followed — remove the link itself and retry.
+    try {
+      if (lstatSync(dir).isSymbolicLink()) {
+        rmSync(dir, { force: true })
+        log(`removed symlink planted at lock path "${resource}"`)
+        return false
+      }
+    } catch {
+      // raced away; the retry loop re-checks
+    }
+    if (!isStale(resource)) return false
+    const holder = describeHolder(resource)
+    // Steal atomically: rename the stale dir to a unique tombstone so only one
+    // waiter can claim it (a concurrent stealer's rename fails ENOENT). Without
+    // this, two waiters can both see staleness and one can delete the other's
+    // freshly re-created live lock, letting both proceed as owners.
+    try {
+      renameSync(dir, join(LOCK_ROOT, `.tombstone-${process.pid}-${Date.now()}`))
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return false // another waiter claimed it
+      throw err
+    }
+    log(`stale lock stolen for "${resource}" (${holder})`)
+    return false // outer loop retries immediately
+  }
+  try {
+    // Predictable names in os.tmpdir() are required for cross-process coordination, so
+    // the path is hardened instead: every dir above is validated owned+non-symlink
+    // (assertSafeLockPath) and created 0o700, and the marker file itself is
+    // owner-only (never readable/writable by other users).
+    writeFileSync(
+      join(dir, 'owner.json'),
+      JSON.stringify({ pid: process.pid, startedAt: Date.now() }),
+      { mode: 0o600 },
+    )
+  } catch {
+    // owner.json write failed (e.g. disk error) — drop the dir and retry
+    rmSync(dir, { recursive: true, force: true })
+    throw new Error(`failed to write lock owner file for "${resource}" in ${dir}`)
+  }
+  log(`acquired "${resource}"`)
+  return true
+}
+
+/**
+ * Waits until every requested network is locked by this process, then returns.
+ * Acquisition is all-or-nothing: if any single lock is contended the attempt is
+ * rolled back and retried, which makes lock-order deadlocks impossible (two
+ * processes each holding one lock the other wants can never wedge).
+ */
+export async function useResource(resources: string[]): Promise<ResourceHandle> {
+  // The root may live under an env-overridden or sandboxed tmpdir that does not exist yet.
+  ensureLockRoot()
+  const wanted = [...new Set(resources)].sort()
+  for (const resource of wanted) {
+    if (!RESOURCE_NAME_RE.test(resource)) {
+      throw new Error(`invalid network lock resource name: ${JSON.stringify(resource)}`)
+    }
+  }
+  const deadline = Date.now() + TIMEOUT_MS
+  let lastLogAt = 0
+  for (;;) {
+    const fresh: string[] = []
+    let contended: string | undefined
+    for (const resource of wanted) {
+      if (isHeldHere(resource)) continue // already owned by this process: counted below
+      if (tryAcquire(resource)) {
+        fresh.push(resource)
+      } else {
+        contended = resource
+        break
+      }
+    }
+    if (contended === undefined) {
+      // Count every requested resource against THIS handle — freshly acquired ones
+      // and pre-held ones alike — so each handle's release withdraws exactly its
+      // own share and the lock survives while any handle is still active.
+      for (const resource of wanted) held.set(resource, (held.get(resource) ?? 0) + 1)
+      let released = false
+      return {
+        release: async () => {
+          if (released) return // idempotent: a second release must not touch shared state
+          released = true
+          for (const resource of [...wanted].reverse()) {
+            const remaining = (held.get(resource) ?? 0) - 1
+            if (remaining <= 0) {
+              held.delete(resource)
+              rmSync(lockDir(resource), { recursive: true, force: true })
+              log(`released "${resource}"`)
+            } else {
+              held.set(resource, remaining)
+            }
+          }
+        },
+      }
+    }
+    // Roll back the partial attempt so other acquirers never see a half-set.
+    // Only the freshly acquired dirs (never pre-held, never counted) are removed.
+    for (const resource of fresh) {
+      held.delete(resource)
+      rmSync(lockDir(resource), { recursive: true, force: true })
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `timed out after ${TIMEOUT_MS} ms waiting for network lock "${contended}" ` +
+          `(currently held by ${describeHolder(contended)} in ${lockDir(contended)}), ` +
+          `lock root: ${LOCK_ROOT}`,
+      )
+    }
+    if (Date.now() - lastLogAt >= LOG_INTERVAL_MS) {
+      lastLogAt = Date.now()
+      log(`waiting for "${contended}" — held by ${describeHolder(contended)}`)
+    }
+    await sleep(POLL_MS)
+  }
+}
+
+/** Best-effort cleanup so crashed children self-heal on the next acquirer. */
+process.on('exit', () => {
+  for (const resource of held.keys()) {
+    try {
+      rmSync(lockDir(resource), { recursive: true, force: true })
+    } catch {
+      // noop — next acquirer's staleness check handles leftovers
+    }
+  }
+})


### PR DESCRIPTION
## What

A small test-infra refactor: every networked test suite is classified by filename suffix and serializes its live-network access through OS-level locks, so `node --test`'s concurrent file runs stop rate-limiting shared public RPCs.

## Changes

- **Naming** — CLI e2e suites renamed `show.test.ts → show.e2e.test.ts`, `lane.test.ts → lane.e2e.test.ts`. Test files are classified purely by suffix (`*.integration.test.ts`, `*.e2e.test.ts`, `*.fork.test.ts`), so a bare `integration.test.ts` counts as integration exactly like `logs.integration.test.ts`.
- **`npm run test:unit`** — new script (root + both workspaces) running only offline unit tests via `scripts/run-tests.mjs` (filename-only filtering; `--exclude`/`--tags`/`--dry`). `npm test` is unchanged and still runs everything.
- **Network locks** — `scripts/useResource.ts`. Networked suites declare the networks they talk to:
  ```ts
  import { useResource } from '../../../scripts/useResource.ts'
  await useResource(['sepolia', 'fuji'])
  ```
  Each tag is a directory under `<tmpdir>/ccip-tools-ts-network-locks`, created atomically with `fs.mkdir`; exactly one process holds a tag at a time, and a waiting suite starts the moment the holder finishes — there is no batch/wave scheduling, the filesystem is the queue. Acquisition is all-or-nothing (deadlock-free), locks auto-release on process exit, and crashed holders self-heal via pid-liveness (a lock held by a live process is never stolen). All 13 networked suites are wired with tags verified against the endpoints they actually call.
- **CI** — unchanged: `npm test` still runs everything in one job, and network contention is now resolved by the locks themselves (locks are per-machine, so the networked suites intentionally stay on the single CI runner rather than splitting across jobs).
- **Docs** — `CONTRIBUTING.md` gained "Test Suite Layout" + "Networked tests and the `useResource` lock" sections; `CHANGELOG.md` Unreleased entry added.

## Validation

- `npm run check` clean (lint 0 warnings, typecheck, `generate:lint` up-to-date)
- `npm run test:unit` — 1313 tests, 0 failures
- Full `npm test` (CI parity) — 1327 sdk + 117 cli, 0 failures; lock contention observed and resolved during the run (e.g. `waiting for "fuji"` heartbeats), zero lock residue afterwards
- Fork suites self-skip without anvil/surfpool (existing behavior; CI installs both)
