### PR TITLE
Fix/publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,6 +47,14 @@ jobs:
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org/
+        env:
+          # setup-node v7 no longer exports a placeholder NODE_AUTH_TOKEN when none is
+          # set (v6 did), while the registry npmrc it writes still references
+          # ${NODE_AUTH_TOKEN} — yarn (postman-code-generators deepinstall) then dies on
+          # the unresolved placeholder during npm ci. Restore v6 behavior: the real
+          # token when a secret exists, else the same dummy placeholder the last
+          # successful release (2026-08-19) ran with.
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN || 'XXXXX-XXXXX-XXXXX-XXXXX' }}
 
       # Ensure npm 11.5.1 or later is installed
       - name: Update npm
@@ -67,6 +75,14 @@ jobs:
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org/
+        env:
+          # setup-node v7 no longer exports a placeholder NODE_AUTH_TOKEN when none is
+          # set (v6 did), while the registry npmrc it writes still references
+          # ${NODE_AUTH_TOKEN} — yarn (postman-code-generators deepinstall) then dies on
+          # the unresolved placeholder during npm ci. Restore v6 behavior: the real
+          # token when a secret exists, else the same dummy placeholder the last
+          # successful release (2026-08-19) ran with.
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN || 'XXXXX-XXXXX-XXXXX-XXXXX' }}
 
       # Ensure npm 11.5.1 or later is installed
       - name: Update npm

--- a/ccip-sdk/src/fetch.test.ts
+++ b/ccip-sdk/src/fetch.test.ts
@@ -10,6 +10,7 @@ import {
   getEndpointTopicLimit,
   originKey,
   parseLogRangeError,
+  registerEndpointBase,
   parseRateLimitHeaders,
   parseRetryAfter,
   parseTopicLimitError,
@@ -155,35 +156,57 @@ describe('parseRateLimitHeaders', () => {
 // ---------------------------------------------------------------------------
 
 describe('endpointKey', () => {
-  it('strips query params from string URL', () => {
-    const key = endpointKey('https://api.example.com/v1/rpc?key=secret&foo=bar')
-    assert.equal(key, 'https://api.example.com/v1/rpc')
+  it('falls back to origin when no base is registered', () => {
+    assert.equal(endpointKey('https://api.example.com/v1/rpc'), 'https://api.example.com')
+    assert.equal(
+      endpointKey('https://api.example.com/v1/rpc?key=secret&foo=bar'),
+      'https://api.example.com',
+    )
+    assert.equal(endpointKey('https://api.example.com/v1/rpc#fragment'), 'https://api.example.com')
+    assert.equal(
+      endpointKey(new URL('https://api.example.com/rpc?foo=bar')),
+      'https://api.example.com',
+    )
+    assert.equal(
+      endpointKey(new Request('https://api.example.com/rpc?foo=bar')),
+      'https://api.example.com',
+    )
   })
 
-  it('strips hash from string URL', () => {
-    const key = endpointKey('https://api.example.com/v1/rpc#fragment')
-    assert.equal(key, 'https://api.example.com/v1/rpc')
-  })
-
-  it('preserves path', () => {
-    const key = endpointKey('https://api.example.com/v1/rpc')
-    assert.equal(key, 'https://api.example.com/v1/rpc')
-  })
-
-  it('handles URL object', () => {
-    const key = endpointKey(new URL('https://api.example.com/rpc?foo=bar'))
-    assert.equal(key, 'https://api.example.com/rpc')
-  })
-
-  it('handles Request object', () => {
-    const key = endpointKey(new Request('https://api.example.com/rpc?foo=bar'))
-    assert.equal(key, 'https://api.example.com/rpc')
-  })
-
-  it('two URLs with different queries share the same key', () => {
-    const k1 = endpointKey('https://api.example.com/rpc?a=1')
-    const k2 = endpointKey('https://api.example.com/rpc?b=2')
+  it('resolves to the longest registered base prefix', () => {
+    registerEndpointBase('https://rpc.example.com/aptos/mainnet/alchemy1')
+    registerEndpointBase('https://rpc.example.com/aptos/mainnet/archive/alchemy1')
+    const base = endpointKey('https://rpc.example.com/aptos/mainnet/alchemy1')
+    assert.equal(base, 'https://rpc.example.com/aptos/mainnet/alchemy1')
+    const k1 = endpointKey(
+      'https://rpc.example.com/aptos/mainnet/alchemy1/transactions/by_version/6934979110',
+    )
+    const k2 = endpointKey(
+      'https://rpc.example.com/aptos/mainnet/alchemy1/transactions/by_version/6934980851',
+    )
+    assert.equal(k1, base)
     assert.equal(k1, k2)
+    // matching is boundary-aware: /alchemy1x must NOT resolve to /alchemy1 → origin fallback
+    assert.equal(
+      endpointKey('https://rpc.example.com/aptos/mainnet/alchemy1x/transactions'),
+      'https://rpc.example.com',
+    )
+    // the archive variant resolves to its own registered base
+    assert.equal(
+      endpointKey(
+        'https://rpc.example.com/aptos/mainnet/archive/alchemy1/transactions/by_version/1',
+      ),
+      'https://rpc.example.com/aptos/mainnet/archive/alchemy1',
+    )
+  })
+
+  it('register is idempotent and longest-prefix wins over shorter bases', () => {
+    registerEndpointBase('https://rpc.example.com/aptos/mainnet/alchemy1')
+    registerEndpointBase('https://rpc.example.com')
+    assert.equal(
+      endpointKey('https://rpc.example.com/aptos/mainnet/alchemy1/x'),
+      'https://rpc.example.com/aptos/mainnet/alchemy1',
+    )
   })
 })
 
@@ -202,9 +225,14 @@ describe('originKey', () => {
       originKey('https://testnet.toncenter.com/api/v3/messages'),
       originKey('https://toncenter.com/api/v3/messages'),
     )
-    // path-keying remains the default for callers that want it: distinct
-    // backends behind one proxy host stay separate under endpointKey, while
-    // originKey is the opt-in for hosts throttled per-origin.
+    // Distinct backends behind one proxy host stay separate under endpointKey
+    // once their base URLs are registered (as chain constructors do via
+    // fetchProfileForUrl); unregistered paths fall back to origin.
+    registerEndpointBase('https://gateway.example/ton/testnet/node1/jsonRPC')
+    assert.equal(
+      endpointKey('https://gateway.example/ton/testnet/node1/jsonRPC'),
+      'https://gateway.example/ton/testnet/node1/jsonRPC',
+    )
     assert.notEqual(
       endpointKey('https://gateway.example/ton/testnet/node1/jsonRPC'),
       endpointKey('https://gateway.example/ton/testnet/node2/jsonRPC'),

--- a/ccip-sdk/src/fetch.ts
+++ b/ccip-sdk/src/fetch.ts
@@ -233,25 +233,80 @@ interface EndpointState {
   topicLimit?: { maxTopics: number; source: 'error' | 'success' }
 }
 
-/** Module-global registry keyed by origin + pathname (query/hash stripped). */
+/** Module-global registry keyed by {@link endpointKey} (query/hash stripped). */
 const endpointRegistry = new Map<string, EndpointState>()
 
-/** Derive a stable key from a fetch input (string | URL | Request). */
-export function endpointKey(input: Parameters<typeof fetch>[0]): string {
+/**
+ * Chain base URLs registered by the chain constructors (`registerEndpointBase`)
+ * so deep REST paths (e.g. aptos `/transactions/by_version/<ledger version>`)
+ * resolve to the same endpoint state as the chain's own URL instead of minting
+ * one state per resource identifier. Sorted by path length descending per
+ * origin for longest-prefix lookup.
+ */
+const endpointBases = new Map<string, string[]>()
+
+/** Parse a fetch input into a URL, or null when unparseable. */
+function toURL(input: Parameters<typeof fetch>[0]): URL | null {
   try {
-    let url: URL
-    if (typeof input === 'string') {
-      url = new URL(input)
-    } else if (input instanceof Request) {
-      url = new URL(input.url)
-    } else {
-      url = input
-    }
-    return url.origin + url.pathname
+    if (typeof input === 'string') return new URL(input)
+    if (input instanceof Request) return new URL(input.url)
+    return input instanceof URL ? input : new URL(String(input))
   } catch {
-    // oxlint-disable-next-line typescript/no-base-to-string
-    return typeof input === 'string' ? input : String(input)
+    return null
   }
+}
+
+/** Normalize a base URL: origin + path with trailing slashes stripped (root → origin). */
+function normalizeBase(url: URL): string {
+  const path = url.pathname === '/' ? '' : url.pathname.replace(/\/+$/, '')
+  return url.origin + path
+}
+
+/**
+ * Register a chain endpoint's base URL. Every fetch whose URL is this origin
+ * with this path prefix resolves to the same {@link endpointKey} — the longest
+ * registered prefix wins, so per-endpoint limiters stay precise while REST
+ * resource paths under a chain share its limiter. Returns the normalized base.
+ *
+ * @param input - The chain's endpoint URL (string | URL | Request).
+ */
+export function registerEndpointBase(input: Parameters<typeof fetch>[0]): string {
+  const url = toURL(input)
+  if (!url) return typeof input === 'string' ? input : String(input)
+  const base = normalizeBase(url)
+  const list = endpointBases.get(url.origin)
+  if (list) {
+    if (!list.includes(base)) {
+      list.push(base)
+      list.sort((a, b) => b.length - a.length)
+    }
+  } else {
+    endpointBases.set(url.origin, [base])
+  }
+  return base
+}
+
+/**
+ * Derive a stable key from a fetch input (string | URL | Request).
+ *
+ * Resolves to the LONGEST registered chain base URL that prefixes the input
+ * path (boundary-aware: `/base` matches `/base/…` but not `/basex/…`); when no
+ * registered base matches, falls back to the origin alone. This keeps the
+ * endpoint-state key space bounded by the registered chain endpoints while
+ * never minting states for per-resource REST paths.
+ */
+export function endpointKey(input: Parameters<typeof fetch>[0]): string {
+  const url = toURL(input)
+  if (!url) return typeof input === 'string' ? input : String(input)
+  const bases = endpointBases.get(url.origin)
+  if (bases) {
+    const path = url.pathname.replace(/\/+$/, '') || '/'
+    for (const base of bases) {
+      const basePath = base.slice(url.origin.length) || '/'
+      if (path === basePath || path.startsWith(basePath === '/' ? '/' : basePath + '/')) return base
+    }
+  }
+  return url.origin
 }
 
 /** Key by origin only; unparseable input falls back to {@link endpointKey}. */
@@ -438,6 +493,11 @@ function extractRateHint(response: Response, method?: string): RateHint {
  * @returns Partial RateLimitOpts (optionally with a `seed`) for the host.
  */
 export function fetchProfileForUrl(url: string): Partial<RateLimitOpts> {
+  // Every chain endpoint flows through here: register it as an endpoint base
+  // so deep REST paths under it (e.g. aptos `/transactions/by_version/<ledger
+  // version>`) resolve to the chain's own endpoint state instead of minting
+  // one per resource identifier. No-op for unparseable URLs.
+  registerEndpointBase(url)
   try {
     const { hostname } = new URL(url)
     // TON public gateways genuinely cap at ~1 req/sec and 429 constantly from a


### PR DESCRIPTION
- v1.13.0 failed to publish due to some env var required by a transient dependency on `npm ci`
- also, include a quick hotfix for `fetch` AdaptiveSync spamming on aptos paths methods