### PR TITLE
feat(cct-sdk): Add get token pool remotes evm query

### DIFF
--- a/ccip-sdk/src/cct/evm/index.ts
+++ b/ccip-sdk/src/cct/evm/index.ts
@@ -49,6 +49,11 @@ import {
   DeployTokenPool,
 } from './token-pool/operations/deploy-token-pool.ts'
 import {
+  type GetTokenPoolRemotesParams,
+  type GetTokenPoolRemotesResult,
+  GetTokenPoolRemotes,
+} from './token-pool/operations/get-token-pool-remotes.ts'
+import {
   type GetTokenPoolStateParams,
   type GetTokenPoolStateResult,
   GetTokenPoolState,
@@ -76,6 +81,7 @@ export class EVMTokenManager extends TokenManager<typeof ChainFamily.EVM> {
   readonly #deployTokenPool = new DeployTokenPool()
   readonly #transferOwnership = new TransferOwnership()
   readonly #getTokenPoolState = new GetTokenPoolState()
+  readonly #getTokenPoolRemotes = new GetTokenPoolRemotes()
 
   // Lockbox operations
   readonly #deployLockbox = new DeployLockbox()
@@ -592,6 +598,32 @@ export class EVMTokenManager extends TokenManager<typeof ChainFamily.EVM> {
   getTokenPoolState(opts: GetTokenPoolStateParams): Promise<GetTokenPoolStateResult> {
     return this.#getTokenPoolState.query(this.chain, opts)
   }
+
+  /**
+   * Reads a pool's remote-lane configuration, v1.5.0 through v2.0.0: for each configured remote
+   * chain, the `remoteToken`, the `remotePools` authorized to mint/release against it, and the
+   * inbound/outbound rate-limiter buckets. Keyed by remote network name.
+   * @remarks Omit `remoteChainSelector` to scan every lane the pool reports through
+   * `getSupportedChains()`; pass one to read a single lane. `inboundRateLimiterState` /
+   * `outboundRateLimiterState` are `null` when that direction is unlimited, and their amounts are
+   * in the *local* token's smallest unit; v2.0.0 pools add `fast*RateLimiterState` for
+   * Faster-Than-Finality and safe-finality (FCR) transfers.
+   * @throws {@link CCTParamsInvalidError} if `poolAddress` is not a valid address, or
+   * `remoteChainSelector` is given and is not a `uint64`
+   * @throws {@link CCIPTokenPoolChainConfigNotFoundError} if a lane read has no remote token
+   * configured — including a `remoteChainSelector` the pool knows nothing about
+   * @example
+   * ```typescript
+   * const remotes = await cct.getTokenPoolRemotes({ poolAddress: '0xPool...' })
+   * for (const [network, lane] of Object.entries(remotes)) {
+   *   // inboundRateLimiterState is null when inbound transfers are unlimited
+   *   console.log(network, lane.remoteToken, lane.inboundRateLimiterState?.capacity)
+   * }
+   * ```
+   */
+  getTokenPoolRemotes(opts: GetTokenPoolRemotesParams): Promise<GetTokenPoolRemotesResult> {
+    return this.#getTokenPoolRemotes.query(this.chain, opts)
+  }
 }
 
 export * from '../errors.ts'
@@ -623,6 +655,12 @@ export type {
   LockReleaseTokenPoolStateV2_0_0,
   TokenPoolStateV2_0_0,
 } from './token-pool/operations/get-token-pool-state.ts'
+export type {
+  GetTokenPoolRemotesParams,
+  GetTokenPoolRemotesResult,
+} from './token-pool/operations/get-token-pool-remotes.ts'
+/** The lane types `GetTokenPoolRemotesResult` is keyed over; shared with `Chain.getTokenPoolRemotes`. */
+export type { RateLimiterState, TokenPoolRemote } from '../../chain.ts'
 export type { DeployLockboxParams } from './lockbox/operations/deploy-lockbox.ts'
 export type { AuthorizeLockboxCallersParams } from './lockbox/operations/authorize-callers.ts'
 export type {

--- a/ccip-sdk/src/cct/evm/token-pool/operations/get-token-pool-remotes.test.ts
+++ b/ccip-sdk/src/cct/evm/token-pool/operations/get-token-pool-remotes.test.ts
@@ -1,0 +1,121 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import { GetTokenPoolRemotes } from './get-token-pool-remotes.ts'
+import type { TokenPoolRemote } from '../../../../chain.ts'
+import type { EVMChain } from '../../../../evm/index.ts'
+import { CCTParamsInvalidError } from '../../../errors.ts'
+
+const POOL = '0x' + '11'.repeat(20)
+const SELECTOR = 5009297550715157269n
+
+const REMOTES: Record<string, TokenPoolRemote> = {
+  'ethereum-mainnet': {
+    remoteToken: '0x' + '22'.repeat(20),
+    remotePools: ['0x' + '33'.repeat(20)],
+    inboundRateLimiterState: { tokens: 25n, capacity: 50n, rate: 5n },
+    outboundRateLimiterState: null,
+  },
+}
+
+/** Records every `getTokenPoolRemotes` call so tests can assert forwarding and RPC-freeness. */
+function stubChain(calls: Array<[string, bigint | undefined]> = []): EVMChain {
+  return {
+    getTokenPoolRemotes: (tokenPool: string, remoteChainSelector?: bigint) => {
+      calls.push([tokenPool, remoteChainSelector])
+      return Promise.resolve(REMOTES)
+    },
+  } as unknown as EVMChain
+}
+
+describe('GetTokenPoolRemotes (cct/evm)', () => {
+  describe('query', () => {
+    it('forwards poolAddress and the selector to chain.getTokenPoolRemotes', async () => {
+      const calls: Array<[string, bigint | undefined]> = []
+      const result = await new GetTokenPoolRemotes().query(stubChain(calls), {
+        poolAddress: POOL,
+        remoteChainSelector: SELECTOR,
+      })
+
+      assert.equal(result, REMOTES)
+      assert.deepEqual(calls, [[POOL, SELECTOR]])
+    })
+
+    it('omits the selector to scan every configured lane', async () => {
+      const calls: Array<[string, bigint | undefined]> = []
+      const result = await new GetTokenPoolRemotes().query(stubChain(calls), { poolAddress: POOL })
+
+      assert.equal(result, REMOTES)
+      assert.deepEqual(calls, [[POOL, undefined]], 'no selector is forwarded as undefined')
+    })
+
+    it('passes the pool address through unnormalised, leaving resolution to the chain reader', async () => {
+      // the op is a thin delegate: it must not checksum, resolve, or otherwise rewrite the address
+      const calls: Array<[string, bigint | undefined]> = []
+      const lowercase = POOL.toLowerCase()
+      await new GetTokenPoolRemotes().query(stubChain(calls), { poolAddress: lowercase })
+      assert.equal(calls[0]![0], lowercase)
+    })
+
+    it('accepts the uint64 selector bounds', async () => {
+      const calls: Array<[string, bigint | undefined]> = []
+      const chain = stubChain(calls)
+      for (const selector of [0n, 2n ** 64n - 1n]) {
+        await new GetTokenPoolRemotes().query(chain, {
+          poolAddress: POOL,
+          remoteChainSelector: selector,
+        })
+      }
+      assert.deepEqual(
+        calls.map(([, selector]) => selector),
+        [0n, 2n ** 64n - 1n],
+      )
+    })
+  })
+
+  describe('validation', () => {
+    it('rejects an invalid poolAddress before any RPC', async () => {
+      let called = false
+      const chain = {
+        getTokenPoolRemotes: () => {
+          called = true
+          return Promise.resolve(REMOTES)
+        },
+      } as unknown as EVMChain
+
+      await assert.rejects(
+        () => new GetTokenPoolRemotes().query(chain, { poolAddress: 'not-an-address' }),
+        (error: unknown) =>
+          error instanceof CCTParamsInvalidError &&
+          error.context.operation === 'getTokenPoolRemotes' &&
+          error.context.param === 'poolAddress',
+      )
+      assert.equal(called, false, 'validation fails before the chain read')
+    })
+
+    for (const [label, remoteChainSelector] of [
+      ['negative', -1n],
+      ['above uint64 max', 2n ** 64n],
+      ['a number, not a bigint', 1 as never],
+    ] as const) {
+      it(`rejects a remoteChainSelector that is ${label}, before any RPC`, async () => {
+        let called = false
+        const chain = {
+          getTokenPoolRemotes: () => {
+            called = true
+            return Promise.resolve(REMOTES)
+          },
+        } as unknown as EVMChain
+
+        await assert.rejects(
+          () => new GetTokenPoolRemotes().query(chain, { poolAddress: POOL, remoteChainSelector }),
+          (error: unknown) =>
+            error instanceof CCTParamsInvalidError &&
+            error.context.operation === 'getTokenPoolRemotes' &&
+            error.context.param === 'remoteChainSelector',
+        )
+        assert.equal(called, false, 'validation fails before the chain read')
+      })
+    }
+  })
+})

--- a/ccip-sdk/src/cct/evm/token-pool/operations/get-token-pool-remotes.ts
+++ b/ccip-sdk/src/cct/evm/token-pool/operations/get-token-pool-remotes.ts
@@ -1,0 +1,63 @@
+/**
+ * getTokenPoolRemotes — reads a token pool's per-lane remote configuration
+ * Delegates to {@link EVMChain.getTokenPoolRemotes}.
+ *
+ * @packageDocumentation
+ */
+
+import type { TokenPoolRemote } from '../../../../chain.ts'
+import type { EVMChain } from '../../../../evm/index.ts'
+import { EVMQuery } from '../../query.ts'
+import { validateAddress, validateUint64 } from '../../validate.ts'
+
+/** Parameters for {@link GetTokenPoolRemotes}. */
+export type GetTokenPoolRemotesParams = {
+  /**
+   * Token pool contract address to read.
+   * @remarks Spelled `poolAddress` for consistency with every other CCT pool op, even though
+   * {@link EVMChain.getTokenPoolRemotes} names the same argument `tokenPool`.
+   */
+  poolAddress: string
+  /**
+   * CCIP selector of a single remote chain to read (`uint64`). Omit to scan every lane the pool
+   * reports through `getSupportedChains()`.
+   */
+  remoteChainSelector?: bigint
+}
+
+/** Result of {@link GetTokenPoolRemotes}: remote-lane configurations keyed by network name. */
+export type GetTokenPoolRemotesResult = Record<string, TokenPoolRemote>
+
+/**
+ * Reads all, or one selected, remote-chain configurations of an EVM token pool.
+ *
+ * @remarks Delegates decoding wholesale to {@link EVMChain.getTokenPoolRemotes}; this class only
+ * validates params (no RPC) and forwards them.
+ */
+export class GetTokenPoolRemotes extends EVMQuery<
+  GetTokenPoolRemotesParams,
+  GetTokenPoolRemotesResult
+> {
+  readonly name = 'getTokenPoolRemotes'
+
+  /**
+   * Validates the pool address and, when given, the remote-chain selector; nothing to convert for
+   * {@link read}.
+   * @throws {@link CCTParamsInvalidError} if `poolAddress` is not a valid address, or
+   * `remoteChainSelector` is given and is not a `uint64`
+   */
+  protected prepare(params: GetTokenPoolRemotesParams): GetTokenPoolRemotesParams {
+    validateAddress(this.name, 'poolAddress', params.poolAddress)
+    if (params.remoteChainSelector !== undefined)
+      validateUint64(this.name, 'remoteChainSelector', params.remoteChainSelector)
+    return params
+  }
+
+  /** Delegates remote-lane decoding to the shared chain reader, which owns the version branches. */
+  protected read(
+    chain: EVMChain,
+    { poolAddress, remoteChainSelector }: GetTokenPoolRemotesParams,
+  ): Promise<GetTokenPoolRemotesResult> {
+    return chain.getTokenPoolRemotes(poolAddress, remoteChainSelector)
+  }
+}

--- a/ccip-sdk/src/cct/evm/validate.ts
+++ b/ccip-sdk/src/cct/evm/validate.ts
@@ -71,6 +71,28 @@ export function validateUint8(operation: string, param: string, value: unknown):
   )
 }
 
+const UINT64_MAX = BigInt(2) ** BigInt(64) - 1n
+
+/**
+ * Asserts `value` is a `bigint` in `[0, 2^64 − 1]` (a Solidity `uint64`), narrowing it to
+ * `bigint` for callers.
+ * @remarks The width of a CCIP chain selector, so this is the check every `remoteChainSelector`
+ * param goes through.
+ * @throws {@link CCTParamsInvalidError} if `value` is not such a bigint
+ */
+export function validateUint64(
+  operation: string,
+  param: string,
+  value: unknown,
+): asserts value is bigint {
+  if (typeof value === 'bigint' && value >= 0n && value <= UINT64_MAX) return
+  throw new CCTParamsInvalidError(
+    operation,
+    param,
+    `must be a bigint in [0, 2^64 − 1], got ${String(value)}`,
+  )
+}
+
 /** Largest value representable by a Solidity `uint256`. */
 const UINT256_MAX = BigInt(2) ** BigInt(256) - 1n
 


### PR DESCRIPTION
## What
- Add `getTokenPoolRemotes` query to `EVMTokenManager`. Reads a token pool's per-lane remote
configuration (for each configured remote chain, the `remoteToken`, the `remotePools`
authorized against it + the inbound/outbound rate-limiter intervals
- Takes an optional `remoteChainSelector` to read a single lane; omit it to scan every lane the
pool reports through `getSupportedChains()`

## Why
- Completes the read side of the token-pool work alongside `getTokenPoolState`

## Testing
- Unit tests cover the single-lane and full-scan paths and the param checks.

## Notes
- Decoding is delegated to `chain.getTokenPoolRemotes`, which already owns the version
branching; this op adds validation