### PR TITLE
feat: support local devnet and fork chains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- SDK/CLI: support chains missing from the bundled selector table (local devnets, chains newer than the installed release) — `registerChains` in the SDK, `--chain-selectors` / `CCIP_CHAIN_SELECTORS` in the CLI, taking `<chainId>=<selector>`, inline JSON, or a JSON/YAML file (including a `chain-selectors` `selectors:` document)
+- SDK/CLI: support forks served under a different chain id (Tenderly Virtual Environments, `anvil --fork --chain-id`) — `registerChains({ chainId, forkOf })` / `--chain-selectors <chainId>=fork:<chainId|selector|name>` re-keys the forked chain to the fork's chain id, keeping its selector, name and family; the forked chain id then stops resolving, since a selector identifies exactly one chain
+- EVM: `decodeMessage` no longer swallows `CCIPChainNotFoundError` while trying event fragments; an unresolvable chain selector surfaces as `CHAIN_NOT_FOUND` instead of a misleading `MESSAGE_INVALID` downstream
+
 ## [1.13.0] - 2026-08-25
 
 - Tests: networked suites (`*.integration.test.ts`, `*.e2e.test.ts`, `*.fork.test.ts`) take per-network OS locks via the new `useResource` test helper, so concurrent `node --test` file runs never share a live RPC endpoint (suites declare the networks they talk to and wait on each other instead of rate-limiting public gateways); `npm run test:unit` now runs only offline unit tests

--- a/ccip-api-ref/docs-cli/configuration.mdx
+++ b/ccip-api-ref/docs-cli/configuration.mdx
@@ -84,12 +84,13 @@ The CLI checks these environment variables in order: `PRIVATE_KEY`, `USER_KEY`, 
 
 ### Output Preferences
 
-| Variable       | Description                                                                                                                | Default                                 |
-| -------------- | -------------------------------------------------------------------------------------------------------------------------- | --------------------------------------- |
-| `CCIP_FORMAT`  | Output format (`pretty`, `log`, `json`)                                                                                    | `pretty`                                |
-| `CCIP_VERBOSE` | Enable debug logging (`true`/`false`)                                                                                      | `false`                                 |
-| `CCIP_PAGE`    | Pagination size for `getLogs` queries                                                                                      | -                                       |
-| `CCIP_API`     | CCIP API endpoint URL, or `false`/`no` to disable API calls (decentralized mode). `true`/`yes` to enable with default URL. | Enabled (`https://api.ccip.chain.link`) |
+| Variable               | Description                                                                                                                | Default                                 |
+| ---------------------- | -------------------------------------------------------------------------------------------------------------------------- | --------------------------------------- |
+| `CCIP_FORMAT`          | Output format (`pretty`, `log`, `json`)                                                                                    | `pretty`                                |
+| `CCIP_VERBOSE`         | Enable debug logging (`true`/`false`)                                                                                      | `false`                                 |
+| `CCIP_PAGE`            | Pagination size for `getLogs` queries                                                                                      | -                                       |
+| `CCIP_API`             | CCIP API endpoint URL, or `false`/`no` to disable API calls (decentralized mode). `true`/`yes` to enable with default URL. | Enabled (`https://api.ccip.chain.link`) |
+| `CCIP_CHAIN_SELECTORS` | Chains to register beyond the bundled selector table (same value as `--chain-selectors`)                                   | -                                       |
 
 **Example .env file:**
 
@@ -200,18 +201,19 @@ ccip-cli send ... --wallet ledger:1  # Uses m/44'/60'/1'/0/0 for EVM
 
 These options are available on all commands:
 
-| Option            | Alias   | Type     | Default                       | Description                                                                                                                          |
-| ----------------- | ------- | -------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| `--rpcs`          | `--rpc` | string[] | -                             | RPC endpoint URLs                                                                                                                    |
-| `--rpcs-file`     | -       | string   | `./.env`                      | File containing RPC endpoints                                                                                                        |
-| `--format`        | `-f`    | string   | `pretty`                      | Output format: `pretty`, `log`, or `json`                                                                                            |
-| `--verbose`       | `-v`    | boolean  | -                             | Enable debug logging                                                                                                                 |
-| `--page`          | -       | number   | -                             | Pagination size for `getLogs` queries                                                                                                |
-| `--api`           | -       | string   | `https://api.ccip.chain.link` | CCIP API endpoint URL. Enabled by default. Pass a URL for a custom endpoint. Use `--no-api` to disable (decentralized RPC-only mode) |
-| `--canton-config` | -       | string   | -                             | Path to Canton config JSON file (required for Canton operations)                                                                     |
-| `--indexer`       | -       | string[] | -                             | CCIP v2 indexer URLs for CCV verifications (used when lane involves Canton)                                                          |
-| `--help`          | `-h`    | boolean  | -                             | Show help                                                                                                                            |
-| `--version`       | `-V`    | boolean  | -                             | Show version                                                                                                                         |
+| Option              | Alias   | Type     | Default                       | Description                                                                                                                                                                                                      |
+| ------------------- | ------- | -------- | ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--rpcs`            | `--rpc` | string[] | -                             | RPC endpoint URLs                                                                                                                                                                                                |
+| `--rpcs-file`       | -       | string   | `./.env`                      | File containing RPC endpoints                                                                                                                                                                                    |
+| `--format`          | `-f`    | string   | `pretty`                      | Output format: `pretty`, `log`, or `json`                                                                                                                                                                        |
+| `--verbose`         | `-v`    | boolean  | -                             | Enable debug logging                                                                                                                                                                                             |
+| `--page`            | -       | number   | -                             | Pagination size for `getLogs` queries                                                                                                                                                                            |
+| `--api`             | -       | string   | `https://api.ccip.chain.link` | CCIP API endpoint URL. Enabled by default. Pass a URL for a custom endpoint. Use `--no-api` to disable (decentralized RPC-only mode)                                                                             |
+| `--canton-config`   | -       | string   | -                             | Path to Canton config JSON file (required for Canton operations)                                                                                                                                                 |
+| `--indexer`         | -       | string[] | -                             | CCIP v2 indexer URLs for CCV verifications (used when lane involves Canton)                                                                                                                                      |
+| `--chain-selectors` | -       | string[] | -                             | Register chains missing from the bundled selector table: `<chainId>=<selector>`, inline JSON, `<chainId>=fork:<chain>` for a fork, or a JSON/YAML file. See [Local Devnets and Forks](/cli/guides/local-testing) |
+| `--help`            | `-h`    | boolean  | -                             | Show help                                                                                                                                                                                                        |
+| `--version`         | `-V`    | boolean  | -                             | Show version                                                                                                                                                                                                     |
 
 **Output formats:**
 
@@ -234,6 +236,10 @@ Networks can be specified by name, chain ID, or CCIP chain selector. The CLI use
 | Aptos        | Prefixed chain ID   | `aptos:1` (mainnet), `aptos:2` (testnet)            |
 | Sui          | Prefixed chain ID   | `sui:1`                                             |
 | Canton       | Prefixed chain ID   | `canton:TestNet`, `canton:DevNet`, `canton:MainNet` |
+
+That table is bundled at build time. Chains missing from it — a local devnet, or a network added to
+the registry after your CLI release — are registered with `--chain-selectors`. See
+[Local Devnets and Forks](/cli/guides/local-testing).
 
 ## Canton Configuration {#canton-configuration}
 

--- a/ccip-api-ref/docs-cli/guides/local-testing.mdx
+++ b/ccip-api-ref/docs-cli/guides/local-testing.mdx
@@ -1,0 +1,236 @@
+---
+id: local-testing
+title: 'Local Devnets and Forks'
+description: 'Run the CLI against a local devnet or a fork whose chain id is not in the bundled table.'
+sidebar_label: Local Devnets and Forks
+sidebar_position: 6
+---
+
+# Local Devnets and Forks
+
+The CLI resolves chains from a selector table bundled at build time, generated from the public
+[chain-selectors](https://github.com/smartcontractkit/chain-selectors) registry. A chain that is not
+in that table cannot be resolved, and commands fail with `CHAIN_NOT_FOUND`:
+
+```console
+$ ccip-cli send -s 1337 -d 2337 -r 0x5FC8... --rpcs http://localhost:8545 --no-api
+error[CHAIN_NOT_FOUND]: Chain not found: 2337
+```
+
+This affects three cases:
+
+- a local devnet started with an arbitrary chain id (`anvil --chain-id 2337`)
+- a **fork** served under a chain id that differs from the network it forked (a Tenderly Virtual
+  Environment, `anvil --fork-url … --chain-id …`)
+- a public network added to the registry after your installed CLI was released
+
+The first needs a new chain; the second needs a **fork registration**, which is a different thing —
+see [Forks](#forks).
+
+Register those chains with `--chain-selectors`. Everything else — `send`, `show`, `manual-exec` —
+then works on the lane as it would on a bundled chain.
+
+Local networks are never indexed by the hosted CCIP API, so `--no-api` is required for any local
+lane. Pass an RPC for each side of the lane.
+
+## Register a Chain
+
+The shorthand is `<chainId>=<selector>`. It defaults to family `EVM` and network type `TESTNET`:
+
+```bash
+ccip-cli send -s 1337 -d 2337 \
+  -r 0x5FC8d32690cc91D4c39d9d3abcBD16989F875707 \
+  --to 0x2E2Ed0Cfd3AD2f1d34481277b3204d807Ca2F8c2 \
+  --data "hello" \
+  --chain-selectors 2337=12922642891491394802 \
+  --rpcs http://localhost:8545 \
+  --rpcs http://localhost:8555 \
+  --no-api
+```
+
+Track the message the same way, passing the source transaction hash:
+
+```bash
+ccip-cli show 0xc0ac87bc918dd987391814e9353ddc7551c0f3f51dbe41c0cc7acc609c1b3cda \
+  --chain-selectors 2337=12922642891491394802 \
+  --rpcs http://localhost:8545 \
+  --rpcs http://localhost:8555 \
+  --no-api
+```
+
+The flag is repeatable, and reads from `CCIP_CHAIN_SELECTORS` like every other option:
+
+```bash
+export CCIP_CHAIN_SELECTORS=2337=12922642891491394802
+```
+
+## Forks
+
+A fork is not a new chain. Its contracts hold the forked network's state and emit that network's
+chain selector on-chain, so it must keep that identity — giving it a fresh selector breaks message
+decoding, because a decoded message's selector then resolves to the real network rather than to your
+fork's RPC.
+
+Register it with `fork:` and the CLI re-keys the forked chain to the fork's chain id:
+
+```bash
+# a Sepolia fork served at chain id 735711155111
+ccip-cli show 0xSourceTxHash \
+  --chain-selectors 735711155111=fork:ethereum-testnet-sepolia \
+  --rpcs $TENDERLY_VIRTUAL_ENV_RPC \
+  --rpcs https://arb-sepolia.example.com \
+  --no-api
+```
+
+The forked chain can be named by chain id, selector, or name — `fork:11155111`,
+`fork:16015286601757825753`, and `fork:ethereum-testnet-sepolia` are equivalent. Add `name` to label
+the fork:
+
+```json
+[{ "chainId": 735711155111, "forkOf": "ethereum-testnet-sepolia", "name": "tenderly-sepolia" }]
+```
+
+The fork **takes over** the forked chain's identity: `11155111` stops resolving for the rest of the
+process, and the selector, name, and family now point at the fork. That is deliberate — a selector
+identifies exactly one chain, so you cannot address a network and its fork in the same invocation.
+
+A fork may also take over a chain id that is already bundled, as long as it is not a mainnet one.
+`hardhat node --fork` keeps chain id `31337` (bundled as `anvil-devnet`, with a selector that does
+not match the forked network), so a Hardhat fork of Sepolia needs:
+
+```bash
+--chain-selectors 31337=fork:ethereum-testnet-sepolia
+```
+
+Without it the RPC resolves to `anvil-devnet` and decoding later fails with `RPC_NOT_FOUND`, because
+the message carries Sepolia's selector. `anvil --fork-url` inherits the upstream chain id and needs
+nothing.
+
+### Tenderly Virtual Environments
+
+Tenderly does not default a Virtual Environment to its parent's chain id: the REST API **requires**
+`virtual_network_config.chain_config.chain_id`, the dashboard defaults to a custom id, and Tenderly's
+own docs recommend prefixing `7357` to the parent's id (a Sepolia fork becomes `735711155111`). So a
+Virtual Environment almost always needs `fork:`.
+
+Read the id from the environment itself rather than assuming one:
+
+```bash
+cast chain-id --rpc-url $TENDERLY_VIRTUAL_ENV_RPC
+```
+
+Fund a sender with Tenderly's faucet on the **Admin** RPC before sending:
+
+```bash
+cast rpc tenderly_setBalance '["0xYourSender"]' 0xDE0B6B3A7640000 --rpc-url $TENDERLY_ADMIN_RPC
+```
+
+A message sent on a fork is never picked up by CCIP's offchain network — the fork is private. `show`
+reconstructs and decodes it from the fork's RPC, and reports no commit or execution, which is
+expected. Use a fork to exercise sending, fee quoting, and decoding, not delivery.
+
+The Virtual Environment RPC URL embeds a UUID that acts as its credential; keep the Admin RPC secret.
+
+### Chainlink Local
+
+[Chainlink Local](https://docs.chain.link/chainlink-local)'s **non-fork** simulator is not reachable
+from the CLI: it runs inside `forge test` / `hardhat test` with no RPC endpoint, and its
+`MockCCIPRouter` emits `MessageExecuted`, not the real `CCIPSendRequested` / `CCIPMessageSent`, so
+there is nothing for `show` to decode. Its fork helpers are Foundry cheatcodes, equally out of reach.
+
+What does work is forking onto a **standalone node** — `anvil --fork-url …` or
+`hardhat node --fork …` — where the real CCIP contracts are present. `send` and `show`'s source side
+then behave normally. Run one node per lane side and pass both to `--rpcs`, or `show` will fail when
+it reaches the destination chain.
+
+A message sent on a fork is never committed or executed: no CCIP DON watches your fork, and
+`manual-exec` cannot substitute, because it builds a proof against a commit root that will never
+exist there. Chainlink Local sidesteps this by impersonating the OffRamp and calling
+`executeSingleMessage` directly.
+
+## What Works Locally
+
+Verified against a from-scratch devnet, `anvil --fork` (parent and custom chain ids), and a Tenderly
+Virtual Environment. All of it requires `--no-api`.
+
+| Command              | Local devnet | Fork | Notes                                                        |
+| -------------------- | ------------ | ---- | ------------------------------------------------------------ |
+| `show`               | ✅           | ✅   | On a fork, reports no commit/execution — nothing delivers it |
+| `send`               | ✅           | ✅   | Including `--only-get-fee`                                   |
+| `lane`               | ✅           | ✅   |                                                              |
+| `token`              | ✅           | ✅   | Native and ERC-20                                            |
+| `manual-exec`        | ✅           | ❌   | Needs a commit; a fork never gets one (`COMMIT_NOT_FOUND`)   |
+| `parse`              | ✅           | ✅   | Offline, no RPC                                              |
+| `getSupportedTokens` | ⚠️           | ⚠️   | Slow on forks; needs a registry the CLI can probe            |
+| `laneLatency`        | ❌           | ❌   | API-only (`API_CLIENT_NOT_AVAILABLE`)                        |
+| `search`             | ❌           | ❌   | API-only                                                     |
+
+`manual-exec` works on a devnet that runs its own verifier/committee stack, because a commit really
+is produced there. On a fork of a public network no CCIP DON is watching, so the message stays
+unexecuted and `manual-exec` fails with `COMMIT_NOT_FOUND` — that is correct behaviour, not a bug.
+
+## Register from a File
+
+For non-EVM families, mainnet chains, or more than a couple of entries, pass a JSON or YAML file.
+The `selectors:` shape of the `chain-selectors` registry is accepted as-is, so `test_selectors.yml`
+can be used unmodified:
+
+```yaml
+# local-selectors.yml
+selectors:
+  2337:
+    selector: 12922642891491394802
+    name: local-anvil-dst
+    network_type: testnet # family defaults to EVM
+```
+
+```bash
+ccip-cli show 0xc0ac87bc... --chain-selectors ./local-selectors.yml --rpcs ... --no-api
+```
+
+An array of entries and a `chainId -> entry` map both work, in JSON or YAML, inline or from a file:
+
+```json
+[
+  {
+    "chainId": 2337,
+    "chainSelector": "12922642891491394802",
+    "name": "local-anvil-dst",
+    "family": "EVM",
+    "networkType": "TESTNET"
+  }
+]
+```
+
+| Field           | Required | Default       | Notes                                         |
+| --------------- | -------- | ------------- | --------------------------------------------- |
+| `chainId`       | yes      | -             | Map keys are used as the chain id when given  |
+| `chainSelector` | yes      | -             | Also accepted as `selector`                   |
+| `name`          | no       | `custom-<id>` | Usable anywhere a chain name is               |
+| `family`        | no       | `EVM`         | `EVM`, `SVM`, `APTOS`, `SUI`, `TON`, `CANTON` |
+| `networkType`   | no       | `TESTNET`     | Also accepted as `network_type`               |
+
+Registering a chain id that is already bundled overrides it. Registering a selector that another
+chain already owns is rejected.
+
+## From the SDK
+
+The CLI flag is a wrapper around `registerChains`. Call it before any chain resolution:
+
+```typescript
+import { networkInfo, registerChains } from '@chainlink/ccip-sdk'
+
+// a new chain (from-scratch devnet)
+registerChains([{ chainId: 2337, chainSelector: 12922642891491394802n, name: 'local-anvil-dst' }])
+networkInfo(12922642891491394802n).chainId // 2337
+
+// a fork served under a different chain id
+registerChains([{ chainId: 735711155111, forkOf: 'ethereum-testnet-sepolia' }])
+networkInfo(735711155111n).chainSelector // 16015286601757825753n
+```
+
+## See Also
+
+- [Configuration](/cli/configuration) - RPCs, wallets, and global options
+- [send](/cli/send) - Send messages
+- [show](/cli/show) - Track messages

--- a/ccip-api-ref/docs-cli/index.mdx
+++ b/ccip-api-ref/docs-cli/index.mdx
@@ -157,4 +157,5 @@ See [Canton Configuration](/cli/configuration#canton-configuration) for setup de
 - [Configuration](/cli/configuration) — RPC endpoints, wallets, global options
 - [Debugging Failed Messages](/cli/guides/debugging-workflow) — Track, debug, and manually execute
 - [Token Transfer Workflow](/cli/guides/token-transfer-workflow) — Send tokens cross-chain
+- [Local Devnets and Forks](/cli/guides/local-testing) — Run against a devnet or fork whose chain id is not bundled
 - [Troubleshooting](/cli/troubleshooting) — Common errors and solutions

--- a/ccip-api-ref/docs-cli/troubleshooting.mdx
+++ b/ccip-api-ref/docs-cli/troubleshooting.mdx
@@ -78,6 +78,32 @@ Solutions:
    ```
 3. Use archive node for old transactions
 
+### Chain not found
+
+```
+error[CHAIN_NOT_FOUND]: Chain not found: 12922642891491394802
+```
+
+Cause: the chain id or selector is not in the bundled selector table. Typical for a local devnet, or
+for a network added to the [chain-selectors](https://github.com/smartcontractkit/chain-selectors)
+registry after your CLI release.
+
+Solutions:
+
+1. Update the CLI, if the chain is a public network
+2. Register the chain yourself:
+   ```bash
+   ccip-cli show 0x... --chain-selectors 2337=12922642891491394802 --rpc http://localhost:8545 --no-api
+   ```
+3. If the RPC is a **fork** served under a different chain id (Tenderly Virtual Environment,
+   `anvil --fork --chain-id`), register it as a fork instead, so it keeps the forked chain's
+   selector — otherwise decoding fails later with `RPC_NOT_FOUND`:
+   ```bash
+   ccip-cli show 0x... --chain-selectors 735711155111=fork:ethereum-testnet-sepolia --rpc $FORK_RPC --no-api
+   ```
+
+See [Local Devnets and Forks](/cli/guides/local-testing).
+
 ## Wallet
 
 ### Wallet not configured

--- a/ccip-api-ref/sidebars-cli.ts
+++ b/ccip-api-ref/sidebars-cli.ts
@@ -46,6 +46,11 @@ const sidebars: SidebarsConfig = {
           id: 'guides/reading-json-output',
           label: 'Reading JSON Output',
         },
+        {
+          type: 'doc',
+          id: 'guides/local-testing',
+          label: 'Local Devnets and Forks',
+        },
       ],
     },
     {

--- a/ccip-cli/README.md
+++ b/ccip-cli/README.md
@@ -115,6 +115,45 @@ ChainIDs depend on the chain family and must be passed using this pattern:
 - `Aptos`, `Sui`: numeric chain id, prefixed with chain family and colon: e.g `aptos:1` for `aptos-mainnet`
 - `Canton`: prefixed chain id: e.g. `canton:TestNet`, `canton:DevNet`, `canton:MainNet`
 
+### Local devnets and unbundled chains
+
+The selector table is bundled from the public
+[chain-selectors](https://github.com/smartcontractkit/chain-selectors) registry, so a chain that
+isn't in it — a local devnet with an arbitrary chain id, or a network newer than your installed CLI
+— can't be resolved, and `send` / `show` fail with `CHAIN_NOT_FOUND`. Register such chains at
+runtime with `--chain-selectors` (or `CCIP_CHAIN_SELECTORS`):
+
+```sh
+# shorthand: <chainId>=<selector>; defaults to family=EVM, networkType=TESTNET
+ccip-cli show <txHash> --rpcs http://localhost:8545 --rpcs http://localhost:8555 --no-api \
+  --chain-selectors 2337=12922642891491394802
+
+# or a JSON/YAML file — including a chain-selectors `selectors:` document, as-is
+ccip-cli send -s 1337 -d 2337 -r 0x5FC8... --chain-selectors ./local-selectors.yml
+```
+
+```yaml
+# local-selectors.yml
+selectors:
+  2337:
+    selector: 12922642891491394802
+    name: local-anvil-dst
+    network_type: testnet # family defaults to EVM
+```
+
+The same is available from the SDK as
+[`registerChains`](https://github.com/smartcontractkit/ccip-tools-ts):
+
+```typescript
+import { networkInfo, registerChains } from '@chainlink/ccip-sdk'
+
+registerChains([{ chainId: 2337, chainSelector: 12922642891491394802n, name: 'local-anvil-dst' }])
+networkInfo(12922642891491394802n).chainId // 2337
+```
+
+Note that the hosted CCIP API never indexes local networks, so `--no-api` is required for any local
+lane.
+
 ## Shell Completion
 
 The CLI supports shell tab-completion for commands and options. To enable it, add the completion script to your shell profile:
@@ -146,6 +185,8 @@ ccip-cli send --<TAB>  # lists all send options
   `@chainlink/ccip-sdk`, or see
   [Reading JSON Output](https://docs.chain.link/ccip/tools/cli/guides/reading-json-output).
 - `--no-api`: Disable CCIP API integration (fully decentralized mode, RPC-only)
+- `--chain-selectors`: Register chains missing from the bundled selector table (see
+  [Local devnets and unbundled chains](#local-devnets-and-unbundled-chains))
 - `--api=<url>`: Use a custom CCIP API URL instead of the default `api.ccip.chain.link`
 
 **Environment variable prefix:** All CLI options can be set via environment variables using the

--- a/ccip-cli/src/chain-selectors.test.ts
+++ b/ccip-cli/src/chain-selectors.test.ts
@@ -1,0 +1,107 @@
+import assert from 'node:assert/strict'
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, it } from 'node:test'
+
+import {
+  type NewChainRegistration,
+  CCIPArgumentInvalidError,
+} from '@chainlink/ccip-sdk/src/index.ts'
+
+import { parseChainSelectorsArg } from './chain-selectors.ts'
+
+const DST_SELECTOR = 12922642891491394802n
+
+function tmpFile(name: string, content: string): string {
+  const path = join(mkdtempSync(join(tmpdir(), 'ccip-selectors-')), name)
+  writeFileSync(path, content)
+  return path
+}
+
+describe('parseChainSelectorsArg', () => {
+  it('parses the <chainId>=<selector> shorthand', () => {
+    assert.deepEqual(parseChainSelectorsArg('2337=12922642891491394802'), [
+      { chainId: '2337', chainSelector: DST_SELECTOR },
+    ])
+  })
+
+  it('parses inline JSON, array or map form', () => {
+    // types are preserved as written; registerChains does the coercion and validation
+    assert.deepEqual(
+      parseChainSelectorsArg(
+        '[{"chainId": 2337, "chainSelector": "12922642891491394802", "name": "local-dst", "family": "evm"}]',
+      ),
+      [
+        {
+          // ints are parsed as bigints (precision), then normalized to a string chainId key
+          chainId: '2337',
+          chainSelector: '12922642891491394802',
+          name: 'local-dst',
+          family: 'EVM',
+        },
+      ],
+    )
+    assert.deepEqual(
+      parseChainSelectorsArg(
+        '{"2337": {"selector": "12922642891491394802", "name": "local-dst", "family": "evm"}}',
+      ),
+      [
+        {
+          chainId: '2337',
+          chainSelector: '12922642891491394802',
+          name: 'local-dst',
+          family: 'EVM',
+        },
+      ],
+    )
+  })
+
+  it('keeps selector precision for bare (unquoted) integers', () => {
+    // JSON.parse would round 12922642891491394802 to ...4804
+    const [entry] = parseChainSelectorsArg(
+      '[{"chainId": 2337, "chainSelector": 12922642891491394802}]',
+    ) as NewChainRegistration[]
+    assert.equal(BigInt(entry!.chainSelector as bigint), DST_SELECTOR)
+  })
+
+  it('parses the <chainId>=fork:<chain> shorthand', () => {
+    assert.deepEqual(parseChainSelectorsArg('73571=fork:11155111'), [
+      { chainId: '73571', forkOf: '11155111' },
+    ])
+    assert.deepEqual(parseChainSelectorsArg('73571=fork:ethereum-testnet-sepolia'), [
+      { chainId: '73571', forkOf: 'ethereum-testnet-sepolia' },
+    ])
+    assert.deepEqual(
+      parseChainSelectorsArg('[{"chainId": 73571, "forkOf": "ethereum-testnet-sepolia"}]'),
+      [{ chainId: '73571', forkOf: 'ethereum-testnet-sepolia' }],
+    )
+  })
+
+  it('reads a chain-selectors YAML document, selectors:-wrapped', () => {
+    const path = tmpFile(
+      'test_selectors.yml',
+      'selectors:\n  2337:\n    selector: 12922642891491394802\n    name: local-anvil-dst\n    network_type: testnet\n',
+    )
+    assert.deepEqual(parseChainSelectorsArg(path), [
+      {
+        chainId: '2337',
+        chainSelector: DST_SELECTOR,
+        name: 'local-anvil-dst',
+        networkType: 'TESTNET',
+      },
+    ])
+  })
+
+  it('reports a missing file and invalid content as argument errors', () => {
+    assert.throws(() => parseChainSelectorsArg('/no/such/file.json'), CCIPArgumentInvalidError)
+    assert.throws(
+      () => parseChainSelectorsArg(tmpFile('bad.json', '{{{not json')),
+      CCIPArgumentInvalidError,
+    )
+    assert.throws(
+      () => parseChainSelectorsArg(tmpFile('scalar.json', '42')),
+      CCIPArgumentInvalidError,
+    )
+  })
+})

--- a/ccip-cli/src/chain-selectors.ts
+++ b/ccip-cli/src/chain-selectors.ts
@@ -1,0 +1,123 @@
+import { readFileSync } from 'node:fs'
+
+import {
+  type ChainRegistration,
+  type NetworkInfo,
+  type NewChainRegistration,
+  CCIPArgumentInvalidError,
+  jsonParse,
+  registerChains,
+} from '@chainlink/ccip-sdk/src/index.ts'
+
+/** Shorthand form: `<chainId>=<selector>`, e.g. `2337=12922642891491394802`. */
+const SHORTHAND = /^([^=\s]+)=(\d+)$/
+/** Fork form: `<chainId>=fork:<chainId|selector|name>`, e.g. `73571=fork:11155111`. */
+const FORK_SHORTHAND = /^([^=\s]+)=fork:(.+)$/
+
+type RawEntry = {
+  chainId?: unknown
+  chain_id?: unknown
+  forkOf?: unknown
+  fork_of?: unknown
+  chainSelector?: unknown
+  selector?: unknown
+  name?: unknown
+  family?: unknown
+  networkType?: unknown
+  network_type?: unknown
+}
+
+function asString(field: string, value: unknown): string {
+  if (typeof value === 'string') return value
+  if (typeof value === 'number' || typeof value === 'bigint') return value.toString()
+  throw new CCIPArgumentInvalidError('chain-selectors', `${field} must be a string or number`)
+}
+
+function toRegistration(chainId: unknown, raw: RawEntry): ChainRegistration {
+  const id = chainId ?? raw.chainId ?? raw.chain_id
+  const forkOf = raw.forkOf ?? raw.fork_of
+  if (forkOf != null) {
+    const fork: { chainId: ChainRegistration['chainId']; forkOf: string; name?: string } = {
+      chainId: (typeof id === 'number'
+        ? id
+        : asString('chainId', id)) as ChainRegistration['chainId'],
+      forkOf: asString('forkOf', forkOf),
+    }
+    if (raw.name != null) fork.name = asString('name', raw.name)
+    return fork
+  }
+  const family = raw.family
+  const networkType = raw.networkType ?? raw.network_type
+  const registration: {
+    -readonly [K in keyof NewChainRegistration]: NewChainRegistration[K]
+  } = {
+    chainId: (typeof id === 'number'
+      ? id
+      : asString('chainId', id)) as NewChainRegistration['chainId'],
+    chainSelector: (raw.chainSelector ?? raw.selector) as NewChainRegistration['chainSelector'],
+  }
+  if (raw.name != null) registration.name = asString('name', raw.name)
+  if (family != null)
+    registration.family = asString('family', family).toUpperCase() as NetworkInfo['family']
+  if (networkType != null)
+    registration.networkType = asString(
+      'networkType',
+      networkType,
+    ).toUpperCase() as NetworkInfo['networkType']
+  return registration
+}
+
+/**
+ * Parses one `--chain-selectors` argument into chain registrations.
+ *
+ * Accepts, in order: the `<chainId>=<selector>` shorthand, inline JSON, or a path to a JSON/YAML
+ * file. Documents may be an array of entries, a `chainId -> entry` map, or the
+ * `smartcontractkit/chain-selectors` `selectors:`-wrapped shape (so `test_selectors.yml` loads
+ * as-is).
+ */
+export function parseChainSelectorsArg(arg: string): ChainRegistration[] {
+  const value = arg.trim()
+  const fork = FORK_SHORTHAND.exec(value)
+  if (fork) return [{ chainId: fork[1]!, forkOf: fork[2]!.trim() }]
+  const shorthand = SHORTHAND.exec(value)
+  if (shorthand) return [{ chainId: shorthand[1]!, chainSelector: BigInt(shorthand[2]!) }]
+
+  const inline = value.startsWith('{') || value.startsWith('[')
+  let text
+  try {
+    text = inline ? value : readFileSync(value, 'utf8')
+  } catch (err) {
+    throw new CCIPArgumentInvalidError('chain-selectors', `cannot read file "${value}"`, {
+      cause: err instanceof Error ? err : undefined,
+    })
+  }
+  let doc
+  try {
+    doc = jsonParse<unknown>(text)
+  } catch (err) {
+    throw new CCIPArgumentInvalidError(
+      'chain-selectors',
+      `${inline ? 'inline value' : `file "${value}"`} is not valid JSON/YAML`,
+      { cause: err instanceof Error ? err : undefined },
+    )
+  }
+  if (doc && typeof doc === 'object' && 'selectors' in doc) doc = doc.selectors
+  if (Array.isArray(doc)) return doc.map((entry) => toRegistration(undefined, entry as RawEntry))
+  if (doc && typeof doc === 'object')
+    return Object.entries(doc as Record<string, RawEntry | null>).map(([id, entry]) =>
+      toRegistration(id, entry ?? {}),
+    )
+  throw new CCIPArgumentInvalidError(
+    'chain-selectors',
+    `expected an array or a chainId->entry object, got: ${String(doc)}`,
+  )
+}
+
+/**
+ * Registers every chain declared through `--chain-selectors` (or `CCIP_CHAIN_SELECTORS`), so local
+ * devnets and chains missing from the bundled selector table resolve like any bundled chain.
+ */
+export function registerChainsFromArgs(args: readonly string[] | undefined): NetworkInfo[] {
+  if (!args?.length) return []
+  return registerChains(args.flatMap((arg) => parseChainSelectorsArg(arg)))
+}

--- a/ccip-cli/src/index.ts
+++ b/ccip-cli/src/index.ts
@@ -24,7 +24,9 @@ import updateNotifier from 'update-notifier'
 import yargs, { type ArgumentsCamelCase, type InferredOptionTypes } from 'yargs'
 import { hideBin } from 'yargs/helpers'
 
+import { registerChainsFromArgs } from './chain-selectors.ts'
 import { Format } from './commands/index.ts'
+import { formatCCIPError } from './commands/utils.ts'
 
 util.inspect.defaultOptions.depth = 6 // print down to tokenAmounts in requests
 Error.stackTraceLimit = 50 // show more stack frames for better debugging
@@ -119,6 +121,16 @@ const globalOpts = {
     describe:
       'Additional CCIP v2 indexer base URLs to query for CCV verifications (e.g. https://indexer-1.ccip.chain.link)',
   },
+  'chain-selectors': {
+    type: 'array',
+    string: true,
+    describe:
+      'Register chains missing from the bundled selector table: "<chainId>=<selector>" for a new ' +
+      'chain (local devnet; defaults to family=EVM, networkType=TESTNET), or ' +
+      '"<chainId>=fork:<chainId|selector|name>" for a fork of a known chain served under a ' +
+      'different chain id (Tenderly Virtual Environment, anvil --fork --chain-id). ' +
+      'Also accepts inline JSON or a path to a JSON/YAML file',
+  },
 } as const
 
 /** Type for global CLI options. */
@@ -140,6 +152,10 @@ async function main() {
     .scriptName(process.env.CLI_NAME || 'ccip-cli')
     .env('CCIP')
     .options(globalOpts)
+    .middleware((argv) => {
+      // must run before any command resolves a chain
+      registerChainsFromArgs(argv.chainSelectors)
+    }, true)
     .check((_argv) => {
       const raw = process.argv
       const hasJson = raw.includes('--json')
@@ -170,7 +186,10 @@ if (import.meta.main || wasCalledAsScript()) {
   const later = setTimeout(() => {}, 2 ** 31 - 1) // keep event-loop alive
   await main()
     .catch((err) => {
-      console.error(err)
+      // errors thrown before a command handler runs (e.g. --chain-selectors parsing, in middleware)
+      // never reach the per-command Ctx logger, so format them here too
+      const verbose = process.argv.includes('-v') || process.argv.includes('--verbose')
+      console.error(formatCCIPError(err, verbose) ?? err)
       throw err
     })
     .finally(() => {

--- a/ccip-sdk/src/errors/index.ts
+++ b/ccip-sdk/src/errors/index.ts
@@ -5,7 +5,7 @@ export { type CCIPErrorOptions, CCIPError } from './CCIPError.ts'
 export { CCIPErrorCode, TRANSIENT_ERROR_CODES, isTransientError } from './codes.ts'
 
 // Specialized errors - Chain/Network
-export { CCIPChainNotFoundError } from './pure.ts'
+export { CCIPChainNotFoundError, CCIPChainRegistrationError } from './pure.ts'
 export {
   CCIPChainFamilyMismatchError,
   CCIPChainFamilyUnsupportedError,

--- a/ccip-sdk/src/errors/pure.ts
+++ b/ccip-sdk/src/errors/pure.ts
@@ -33,3 +33,36 @@ export class CCIPChainNotFoundError extends CCIPError {
     })
   }
 }
+
+/**
+ * Thrown when a runtime chain registration is invalid (bad selector, family, or a selector
+ * already taken by another chain).
+ *
+ * @example
+ * ```typescript
+ * import { registerChains } from '@chainlink/ccip-sdk'
+ *
+ * try {
+ *   registerChains([{ chainId: 2337, chainSelector: 'not-a-number' }])
+ * } catch (error) {
+ *   if (error instanceof CCIPChainRegistrationError) {
+ *     console.log(error.context.reason)
+ *   }
+ * }
+ * ```
+ */
+export class CCIPChainRegistrationError extends CCIPError {
+  override readonly name = 'CCIPChainRegistrationError'
+  /** Creates a chain registration error. */
+  constructor(chainId: unknown, reason: string, options?: CCIPErrorOptions) {
+    super(
+      CCIPErrorCode.ARGUMENT_INVALID,
+      `Invalid chain registration for "${String(chainId)}": ${reason}`,
+      {
+        ...options,
+        isTransient: false,
+        context: { ...options?.context, argument: 'chains', chainId: String(chainId), reason },
+      },
+    )
+  }
+}

--- a/ccip-sdk/src/evm/index.ts
+++ b/ccip-sdk/src/evm/index.ts
@@ -51,6 +51,7 @@ import { fetchVerifications } from '../commits.ts'
 import {
   CCIPAddressInvalidError,
   CCIPBlockNotFoundError,
+  CCIPChainNotFoundError,
   CCIPContractNotRouterError,
   CCIPContractTypeInvalidError,
   CCIPDataFormatUnsupportedError,
@@ -713,6 +714,8 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
    * @returns Decoded CCIPMessage or undefined if not a valid CCIP message.
    * @throws {@link CCIPLogDataInvalidError} if log data is not valid bytes
    * @throws {@link CCIPMessageDecodeError} if message cannot be decoded
+   * @throws {@link CCIPChainNotFoundError} if the message's chain selectors can't be resolved;
+   *   register unbundled chains (e.g. a local devnet) with `registerChains`
    */
   static decodeMessage(log: {
     topics?: readonly string[]
@@ -740,7 +743,11 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
           Object.assign(message, decodeMessageV1(message.encodedMessage as BytesLike))
         }
         if (message) break
-      } catch {
+      } catch (err) {
+        // a selector we can't resolve is a real failure, not a wrong-fragment signal: surfacing it
+        // as-is avoids it resurfacing downstream as a misleading MESSAGE_INVALID
+        if (err instanceof CCIPChainNotFoundError) throw err
+        message = undefined // discard a partial decode from a non-matching fragment
         // try next fragment
       }
     }

--- a/ccip-sdk/src/evm/unknown-chain.test.ts
+++ b/ccip-sdk/src/evm/unknown-chain.test.ts
@@ -1,0 +1,78 @@
+import assert from 'node:assert/strict'
+import { afterEach, describe, it } from 'node:test'
+
+import { ZeroAddress, ZeroHash } from 'ethers'
+
+import { CCIPChainNotFoundError } from '../errors/pure.ts'
+import { clearNetworkInfoCaches, registerChains } from '../networks.ts'
+import SELECTORS from '../selectors.ts'
+import { interfaces } from './const.ts'
+import { encodeMessageV1 } from './messageCodec.ts'
+import { EVMChain } from './index.ts'
+
+import '../index.ts'
+
+// the scratch-mode local devnet: source 1337 is bundled (geth-testnet), dest 2337 is not
+const SRC_SELECTOR = 3379446385462418246n
+const DST_CHAIN_ID = 2337
+const DST_SELECTOR = 12922642891491394802n
+
+function v2MessageSentLog(destChainSelector: bigint) {
+  const encodedMessage = encodeMessageV1({
+    sourceChainSelector: SRC_SELECTOR,
+    destChainSelector,
+    messageNumber: 7n,
+    executionGasLimit: 0,
+    ccipReceiveGasLimit: 200_000,
+    finality: '0x00000000',
+    ccvAndExecutorHash: ZeroHash,
+    onRampAddress: ZeroHash,
+    offRampAddress: '0xe60c1d654283252623e448f53f648663a701cd7b',
+    sender: ZeroHash,
+    receiver: '0x161d23c30b5ae2899c3d4d969ba2b82026f3954a',
+    data: '0xabcd',
+  })
+  const fragment = interfaces.OnRamp_v2_0.getEvent('CCIPMessageSent')!
+  return interfaces.OnRamp_v2_0.encodeEventLog(fragment, [
+    destChainSelector,
+    ZeroAddress, // sender
+    ZeroHash, // messageId
+    ZeroAddress, // feeToken
+    0n, // tokenAmountBeforeTokenPoolFees
+    encodedMessage,
+    [], // receipts
+    [], // verifierBlobs
+  ])
+}
+
+describe('EVMChain.decodeMessage on an unbundled chain', () => {
+  afterEach(() => {
+    delete SELECTORS[String(DST_CHAIN_ID)]
+    clearNetworkInfoCaches()
+  })
+
+  it('surfaces the real CHAIN_NOT_FOUND instead of masking it as MESSAGE_INVALID', () => {
+    const log = v2MessageSentLog(DST_SELECTOR)
+    assert.throws(
+      () => EVMChain.decodeMessage(log),
+      (err: unknown) => {
+        assert.ok(
+          err instanceof CCIPChainNotFoundError,
+          `expected CHAIN_NOT_FOUND, got ${String(err)}`,
+        )
+        assert.equal(err.context.chainIdOrSelector, DST_SELECTOR)
+        return true
+      },
+    )
+  })
+
+  it('decodes the same log once the chain is registered', () => {
+    registerChains([
+      { chainId: DST_CHAIN_ID, chainSelector: DST_SELECTOR, name: 'local-anvil-dst' },
+    ])
+    const message = EVMChain.decodeMessage(v2MessageSentLog(DST_SELECTOR))
+    assert.ok(message)
+    assert.equal(message.sourceChainSelector, SRC_SELECTOR)
+    assert.equal((message as { destChainSelector: bigint }).destChainSelector, DST_SELECTOR)
+  })
+})

--- a/ccip-sdk/src/index.ts
+++ b/ccip-sdk/src/index.ts
@@ -128,7 +128,16 @@ import { AptosChain } from './aptos/index.ts'
 export type { UnsignedAptosTx } from './aptos/index.ts'
 import { CantonChain } from './canton/index.ts'
 import { EVMChain } from './evm/index.ts'
-export { type NetworkInfo, ChainFamily, NetworkType, networkInfo } from './networks.ts'
+export {
+  type ChainRegistration,
+  type ForkChainRegistration,
+  type NetworkInfo,
+  type NewChainRegistration,
+  ChainFamily,
+  NetworkType,
+  networkInfo,
+  registerChains,
+} from './networks.ts'
 import SELECTORS from './selectors.ts'
 export { SELECTORS }
 export type { UnsignedEVMTx } from './evm/index.ts'

--- a/ccip-sdk/src/networks.test.ts
+++ b/ccip-sdk/src/networks.test.ts
@@ -1,0 +1,182 @@
+import assert from 'node:assert/strict'
+import { afterEach, describe, it } from 'node:test'
+
+import { CCIPChainNotFoundError, CCIPChainRegistrationError } from './errors/pure.ts'
+import {
+  type ChainRegistration,
+  ChainFamily,
+  NetworkType,
+  clearNetworkInfoCaches,
+  networkInfo,
+  registerChains,
+} from './networks.ts'
+import SELECTORS from './selectors.ts'
+
+// the local-anvil devnet from the scratch-mode harness: chainId 2337 is not in the bundled table
+const LOCAL_CHAIN_ID = 2337
+const LOCAL_SELECTOR = 12922642891491394802n
+
+function unregister(...chainIds: (string | number)[]) {
+  for (const id of chainIds) delete SELECTORS[String(id)]
+  // a fork re-keys the bundled entry away; put it back so suites stay independent
+  SELECTORS['11155111'] = {
+    selector: SEPOLIA_SELECTOR,
+    name: 'ethereum-testnet-sepolia',
+    network_type: NetworkType.Testnet,
+    family: ChainFamily.EVM,
+  }
+  clearNetworkInfoCaches()
+}
+
+const SEPOLIA_SELECTOR = 16015286601757825753n
+
+describe('registerChains', () => {
+  afterEach(() => unregister(LOCAL_CHAIN_ID, 4242, 'aptos:99', 73571))
+
+  it('resolves a chain that is not in the bundled table, by id, selector and name', () => {
+    assert.throws(() => networkInfo(LOCAL_CHAIN_ID), CCIPChainNotFoundError)
+    assert.throws(() => networkInfo(LOCAL_SELECTOR), CCIPChainNotFoundError)
+
+    const [info] = registerChains([
+      { chainId: LOCAL_CHAIN_ID, chainSelector: LOCAL_SELECTOR, name: 'local-anvil-dst' },
+    ])
+
+    assert.deepEqual(info, {
+      chainId: LOCAL_CHAIN_ID,
+      chainSelector: LOCAL_SELECTOR,
+      name: 'local-anvil-dst',
+      family: ChainFamily.EVM,
+      networkType: NetworkType.Testnet,
+    })
+    // every resolution form must see it, including the reverse selector -> chainId scan
+    assert.equal(networkInfo(LOCAL_CHAIN_ID).chainSelector, LOCAL_SELECTOR)
+    assert.equal(networkInfo(LOCAL_SELECTOR).chainId, LOCAL_CHAIN_ID)
+    assert.equal(networkInfo(String(LOCAL_SELECTOR)).chainId, LOCAL_CHAIN_ID)
+    assert.equal(networkInfo('local-anvil-dst').chainId, LOCAL_CHAIN_ID)
+  })
+
+  it('busts the memoized miss recorded before registration', () => {
+    assert.throws(() => networkInfo(LOCAL_SELECTOR), CCIPChainNotFoundError)
+    registerChains([{ chainId: LOCAL_CHAIN_ID, chainSelector: LOCAL_SELECTOR }])
+    assert.equal(networkInfo(LOCAL_SELECTOR).chainId, LOCAL_CHAIN_ID)
+  })
+
+  it('defaults name/family/networkType, and accepts non-EVM families', () => {
+    const [evm, aptos] = registerChains([
+      { chainId: 4242, chainSelector: '4242424242424242424' },
+      {
+        chainId: 'aptos:99',
+        chainSelector: 4242424242424242425n,
+        family: ChainFamily.Aptos,
+        networkType: NetworkType.Mainnet,
+      },
+    ])
+    assert.equal(evm!.name, 'custom-4242')
+    assert.equal(evm!.family, ChainFamily.EVM)
+    assert.equal(evm!.networkType, NetworkType.Testnet)
+    assert.equal(aptos!.family, ChainFamily.Aptos)
+    assert.equal(aptos!.networkType, NetworkType.Mainnet)
+    assert.equal(aptos!.chainId, 'aptos:99')
+  })
+
+  it('does not perturb bundled chains', () => {
+    const sepolia = networkInfo(11155111)
+    registerChains([{ chainId: LOCAL_CHAIN_ID, chainSelector: LOCAL_SELECTOR }])
+    assert.deepEqual(networkInfo(11155111), sepolia)
+    assert.equal(networkInfo(16015286601757825753n).name, 'ethereum-testnet-sepolia')
+  })
+
+  it('rejects a selector already owned by another chain', () => {
+    assert.throws(
+      () => registerChains([{ chainId: LOCAL_CHAIN_ID, chainSelector: 16015286601757825753n }]),
+      CCIPChainRegistrationError,
+    )
+    assert.throws(() => networkInfo(LOCAL_CHAIN_ID), CCIPChainNotFoundError)
+  })
+
+  it('rejects a selector already owned by another chain, unless it is an explicit fork', () => {
+    assert.throws(
+      () => registerChains([{ chainId: 73571, chainSelector: SEPOLIA_SELECTOR }]),
+      CCIPChainRegistrationError,
+    )
+    assert.equal(
+      registerChains([{ chainId: 73571, forkOf: 11155111 }])[0]!.chainSelector,
+      SEPOLIA_SELECTOR,
+    )
+  })
+
+  it('rejects invalid entries', () => {
+    for (const entry of [
+      { chainId: LOCAL_CHAIN_ID, chainSelector: 'not-a-number' },
+      { chainId: LOCAL_CHAIN_ID, chainSelector: 0n },
+      { chainId: '', chainSelector: LOCAL_SELECTOR },
+      { chainId: LOCAL_CHAIN_ID, chainSelector: LOCAL_SELECTOR, family: 'BITCOIN' },
+      { chainId: LOCAL_CHAIN_ID, chainSelector: LOCAL_SELECTOR, networkType: 'STAGING' },
+    ] as ChainRegistration[]) {
+      assert.throws(() => registerChains([entry]), CCIPChainRegistrationError)
+    }
+  })
+})
+
+describe('registerChains — forks', () => {
+  afterEach(() => unregister(73571))
+
+  it('re-keys a known chain to the fork chain id, keeping its selector, name and family', () => {
+    const [fork] = registerChains([{ chainId: 73571, forkOf: 'ethereum-testnet-sepolia' }])
+    assert.deepEqual(fork, {
+      chainId: 73571,
+      chainSelector: SEPOLIA_SELECTOR,
+      name: 'ethereum-testnet-sepolia',
+      family: ChainFamily.EVM,
+      networkType: NetworkType.Testnet,
+    })
+    // all three resolution forms agree on the fork — a message decoded from the fork carries the
+    // ORIGINAL selector, so this is what makes it resolve back to the fork's RPC
+    assert.equal(networkInfo(73571).chainSelector, SEPOLIA_SELECTOR)
+    assert.equal(networkInfo(SEPOLIA_SELECTOR).chainId, 73571)
+    assert.equal(networkInfo('ethereum-testnet-sepolia').chainId, 73571)
+    // the forked chain id no longer resolves: a selector identifies exactly one chain
+    assert.throws(() => networkInfo(11155111), CCIPChainNotFoundError)
+  })
+
+  it('accepts the forked chain by id, selector or name, and an optional name override', () => {
+    for (const forkOf of [11155111, SEPOLIA_SELECTOR, 'ethereum-testnet-sepolia'] as const) {
+      const [fork] = registerChains([{ chainId: 73571, forkOf }])
+      assert.equal(fork!.chainSelector, SEPOLIA_SELECTOR)
+      unregister(73571)
+    }
+    const [named] = registerChains([{ chainId: 73571, forkOf: 11155111, name: 'tenderly-sepolia' }])
+    assert.equal(named!.name, 'tenderly-sepolia')
+    assert.equal(networkInfo('tenderly-sepolia').chainSelector, SEPOLIA_SELECTOR)
+  })
+
+  it('rejects an unknown forked chain', () => {
+    assert.throws(
+      () => registerChains([{ chainId: 73571, forkOf: 'no-such-chain' }]),
+      CCIPChainRegistrationError,
+    )
+  })
+
+  it('refuses to give a fork a mainnet chain id', () => {
+    assert.throws(
+      () => registerChains([{ chainId: 1, forkOf: 'ethereum-testnet-sepolia' }]),
+      CCIPChainRegistrationError,
+    )
+    assert.equal(networkInfo(1).name, 'ethereum-mainnet')
+  })
+
+  it('takes over a bundled local chain id (hardhat node --fork keeps 31337)', () => {
+    assert.equal(networkInfo(31337).name, 'anvil-devnet') // bundled, wrong selector for a fork
+    const [fork] = registerChains([{ chainId: 31337, forkOf: 'ethereum-testnet-sepolia' }])
+    assert.equal(fork!.chainSelector, SEPOLIA_SELECTOR)
+    assert.equal(networkInfo(SEPOLIA_SELECTOR).chainId, 31337)
+    // restore the displaced bundled entry
+    SELECTORS['31337'] = {
+      selector: 7759470850252068959n,
+      name: 'anvil-devnet',
+      network_type: NetworkType.Testnet,
+      family: ChainFamily.EVM,
+    }
+    unregister()
+  })
+})

--- a/ccip-sdk/src/networks.ts
+++ b/ccip-sdk/src/networks.ts
@@ -1,6 +1,7 @@
 import { memoize } from 'micro-memoize'
 
-import { CCIPChainNotFoundError } from './errors/pure.ts'
+import { CCIPError } from './errors/CCIPError.ts'
+import { CCIPChainNotFoundError, CCIPChainRegistrationError } from './errors/pure.ts'
 import SELECTORS from './selectors.ts'
 
 /**
@@ -143,3 +144,185 @@ export const networkInfo = memoize(function networkInfo_(
   }
   return networkInfoFromChainId(chainId as string | number)
 })
+
+/**
+ * A chain to register at runtime, for networks missing from the bundled selector table —
+ * e.g. a local devnet started with an arbitrary chain id.
+ *
+ * @see {@link registerChains}
+ */
+export type ChainRegistration = NewChainRegistration | ForkChainRegistration
+
+/**
+ * A chain that does not exist in the bundled table — a from-scratch devnet, or a network newer than
+ * the installed SDK. It gets its own selector.
+ */
+export type NewChainRegistration = {
+  /** Chain id, in the format of its family (EVM: `2337`, Aptos: `"aptos:1"`, Solana: genesisHash). */
+  readonly chainId: NetworkInfo['chainId']
+  /** CCIP chain selector; bigint, or a decimal number/string. */
+  readonly chainSelector: bigint | number | string
+  /** Human-readable name; defaults to `custom-<chainId>`. */
+  readonly name?: string
+  /** Chain family; defaults to {@link ChainFamily.EVM}. */
+  readonly family?: ChainFamily
+  /** Network type; defaults to {@link NetworkType.Testnet}. */
+  readonly networkType?: NetworkType
+}
+
+/**
+ * A fork of a known chain, served under a different chain id (e.g. a Tenderly Virtual Environment,
+ * or `anvil --fork --chain-id`). The fork is not a new chain: its contracts hold the original
+ * chain's state and emit the original chain's selector, so it inherits that identity and is
+ * re-keyed to the fork's chain id. The original chain id stops resolving — a fork and the chain it
+ * forked cannot both be addressed in one process.
+ */
+export type ForkChainRegistration = {
+  /** Chain id the fork's RPC reports from `eth_chainId`. */
+  readonly chainId: NetworkInfo['chainId']
+  /** The forked chain, by chain id, selector or name. */
+  readonly forkOf: bigint | number | string
+  /** Human-readable name; defaults to the forked chain's own name. */
+  readonly name?: string
+}
+
+const FAMILIES = new Set<string>(Object.values(ChainFamily))
+const NETWORK_TYPES = new Set<string>(Object.values(NetworkType))
+
+/**
+ * Re-keys a known chain to the chain id its fork serves. The fork keeps the original chain's
+ * selector, name and family — the forked contracts emit that selector on-chain — so this MOVES the
+ * entry rather than adding one: a selector identifies exactly one chain.
+ */
+function registerFork(chain: ForkChainRegistration): string {
+  const { chainId, forkOf, name } = chain
+  if (typeof chainId !== 'string' && typeof chainId !== 'number')
+    throw new CCIPChainRegistrationError(chainId, 'chainId must be a string or number')
+  const id = String(chainId)
+  if (!id.trim()) throw new CCIPChainRegistrationError(chainId, 'chainId must not be empty')
+  if (name != null && (typeof name !== 'string' || !name.trim()))
+    throw new CCIPChainRegistrationError(id, 'name must be a non-empty string')
+
+  let original
+  try {
+    original = networkInfo(forkOf as bigint | number | string)
+  } catch (cause) {
+    throw new CCIPChainRegistrationError(id, `forkOf: unknown chain ${String(forkOf)}`, {
+      cause: cause instanceof CCIPError ? cause : undefined,
+    })
+  }
+  const originalId = String(original.chainId)
+  // a fork legitimately takes over a local/dev chain id that is already bundled (Hardhat's
+  // `hardhat node --fork` keeps 31337 = anvil-devnet), but must never assume a mainnet identity:
+  // that would point mainnet RPCs and wallets at the forked chain's lanes
+  const existing = SELECTORS[id]
+  if (
+    existing &&
+    id !== originalId &&
+    existing.selector !== original.chainSelector &&
+    existing.network_type === NetworkType.Mainnet
+  )
+    throw new CCIPChainRegistrationError(
+      id,
+      `chainId is already registered to the mainnet chain "${existing.name ?? 'unknown'}" ` +
+        `(selector ${existing.selector}); refusing to overwrite it with a fork of "${original.name}"`,
+    )
+
+  delete SELECTORS[originalId] // a selector identifies one chain: the fork replaces it
+  SELECTORS[id] = {
+    selector: original.chainSelector,
+    name: name ?? original.name,
+    family: original.family,
+    network_type: original.networkType,
+  }
+  return id
+}
+
+/**
+ * Registers additional chains for selector/chainId/name resolution, at runtime.
+ *
+ * The bundled {@link SELECTORS} table is generated from the public `chain-selectors` registry, so
+ * local devnets (and chains newer than the installed SDK) can't be resolved by {@link networkInfo}.
+ * Registering them makes every SDK and CLI path that resolves chains — `send`, message decoding,
+ * `show`, manual-exec — work on those lanes.
+ *
+ * Registrations take effect immediately: they are added to the shared selector table and the
+ * memoized resolution caches are invalidated. Registering a `chainId` that is already known
+ * overrides it; registering a selector that another chain already owns is rejected — a selector
+ * identifies exactly one chain.
+ *
+ * A fork of a known chain is registered with `forkOf` instead of `chainSelector`: it inherits the
+ * forked chain's selector (its contracts emit that selector on-chain) and is re-keyed to the fork's
+ * chain id, so the original chain id stops resolving.
+ *
+ * @param chains - Chains to register
+ * @returns The resolved {@link NetworkInfo} of each registered chain
+ * @throws {@link CCIPChainRegistrationError} if an entry is invalid or conflicts
+ *
+ * @example
+ * ```typescript
+ * import { networkInfo, registerChains } from '@chainlink/ccip-sdk'
+ *
+ * registerChains([{ chainId: 2337, chainSelector: 12922642891491394802n, name: 'local-anvil-dst' }])
+ * networkInfo(12922642891491394802n).chainId // 2337
+ *
+ * // a Sepolia fork served under a custom chain id (Tenderly Virtual Environment, anvil --fork)
+ * registerChains([{ chainId: 73571, forkOf: 'ethereum-testnet-sepolia' }])
+ * networkInfo(73571).chainSelector // 16015286601757825753n
+ * ```
+ */
+/**
+ * Invalidates the memoized chain-resolution caches. Called by {@link registerChains}; exported for
+ * callers that mutate the shared {@link SELECTORS} table directly (tests).
+ * @internal
+ */
+export function clearNetworkInfoCaches(): void {
+  networkInfo.cache.clear()
+  networkInfoFromChainId.cache.clear()
+}
+
+export function registerChains(chains: Iterable<ChainRegistration>): NetworkInfo[] {
+  const ids: string[] = []
+  for (const chain of chains) {
+    if ('forkOf' in chain) {
+      ids.push(registerFork(chain))
+      continue
+    }
+    const { chainId, chainSelector, name, family = ChainFamily.EVM, networkType } = chain
+    if (typeof chainId !== 'string' && typeof chainId !== 'number')
+      throw new CCIPChainRegistrationError(chainId, 'chainId must be a string or number')
+    const id = String(chainId)
+    if (!id.trim()) throw new CCIPChainRegistrationError(chainId, 'chainId must not be empty')
+    let selector
+    try {
+      selector = BigInt(chainSelector as string)
+    } catch {
+      throw new CCIPChainRegistrationError(
+        id,
+        `chainSelector is not an integer: ${String(chainSelector)}`,
+      )
+    }
+    if (selector <= 0n)
+      throw new CCIPChainRegistrationError(id, `chainSelector must be positive: ${selector}`)
+    if (name != null && (typeof name !== 'string' || !name.trim()))
+      throw new CCIPChainRegistrationError(id, 'name must be a non-empty string')
+    if (!FAMILIES.has(family))
+      throw new CCIPChainRegistrationError(id, `unknown family: ${String(family)}`)
+    const network_type = networkType ?? NetworkType.Testnet
+    if (!NETWORK_TYPES.has(network_type))
+      throw new CCIPChainRegistrationError(id, `unknown networkType: ${String(networkType)}`)
+    // a selector uniquely identifies a chain: refuse to shadow a different chainId's selector
+    for (const other in SELECTORS) {
+      if (other !== id && SELECTORS[other]!.selector === selector)
+        throw new CCIPChainRegistrationError(
+          id,
+          `chainSelector ${selector} is already registered for chain "${other}"`,
+        )
+    }
+    SELECTORS[id] = { selector, name: name ?? `custom-${id}`, family, network_type }
+    ids.push(id)
+  }
+  // both resolvers are memoized: a lookup that missed before registration would stay a miss
+  if (ids.length) clearNetworkInfoCaches()
+  return ids.map((id) => networkInfoFromChainId(id))
+}


### PR DESCRIPTION
This pull request adds support for using the CLI and SDK with local devnets, forks, and chains not present in the bundled selector table. It introduces the `--chain-selectors` CLI flag and `CCIP_CHAIN_SELECTORS` environment variable, allowing users to register custom chains at runtime. The documentation is updated with a new guide and troubleshooting section, and relevant references are added throughout the docs and README.

**New Features:**

* CLI/SDK now support registering chains missing from the bundled selector table (e.g., local devnets, new public networks) via the `--chain-selectors` flag, `CCIP_CHAIN_SELECTORS` environment variable, or `registerChains` in the SDK. Supports shorthand, inline JSON, or JSON/YAML files. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R13) [[2]](diffhunk://#diff-d509fd26ff682f49f0c054dcca5422c10bed45e76de696409168b0c5f5e2240bR214) [[3]](diffhunk://#diff-d509fd26ff682f49f0c054dcca5422c10bed45e76de696409168b0c5f5e2240bL88-R93) [[4]](diffhunk://#diff-efcba0717403789536cb897c8f810202b890a98c20d3ab420e0f9c82e1eb18a1R118-R156) [[5]](diffhunk://#diff-efcba0717403789536cb897c8f810202b890a98c20d3ab420e0f9c82e1eb18a1R188-R189)
* Forks served under a different chain id (e.g., Tenderly Virtual Environments, `anvil --fork --chain-id`) can be registered as forks, preserving selector and identity for correct message decoding. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R13) [[2]](diffhunk://#diff-c6a7dc3bce6e58842601cfbf87c2d8ee1c55c628a2d0ef96e34cc9c047d84d8cR1-R236)

**Documentation Additions and Updates:**

* New guide: "Local Devnets and Forks" explains how to use the new chain registration features for local testing, including detailed examples and caveats. [[1]](diffhunk://#diff-c6a7dc3bce6e58842601cfbf87c2d8ee1c55c628a2d0ef96e34cc9c047d84d8cR1-R236) [[2]](diffhunk://#diff-e78fa71ed0989f5b34a335bfbad3cb0eef99e7ff67dc11cba1f98be986522f28R49-R53)
* CLI configuration docs updated to include `--chain-selectors` and `CCIP_CHAIN_SELECTORS`, with explanations and examples. [[1]](diffhunk://#diff-d509fd26ff682f49f0c054dcca5422c10bed45e76de696409168b0c5f5e2240bL88-R93) [[2]](diffhunk://#diff-d509fd26ff682f49f0c054dcca5422c10bed45e76de696409168b0c5f5e2240bR214) [[3]](diffhunk://#diff-d509fd26ff682f49f0c054dcca5422c10bed45e76de696409168b0c5f5e2240bR240-R243)
* Troubleshooting docs now include solutions for `CHAIN_NOT_FOUND` errors, guiding users to register missing chains or forks.
* References to the new guide are added to the main doc index and sidebar. [[1]](diffhunk://#diff-b5d853a65f58568562d1d3435dc4c62859711b033c4ca99977feb02a4e3549b4R160) [[2]](diffhunk://#diff-e78fa71ed0989f5b34a335bfbad3cb0eef99e7ff67dc11cba1f98be986522f28R49-R53)

**SDK/CLI Behavior Changes:**

* EVM: `decodeMessage` now surfaces `CHAIN_NOT_FOUND` for unresolvable selectors, instead of a misleading `MESSAGE_INVALID` error.

These changes make it much easier to use the CLI and SDK in local development environments and with new or custom chains, improving the developer experience and error transparency.