### PR TITLE
feat(cli): fetch CCV attestations directly from a verifier's aggregator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `getMessageById` and `getExecutionReceipts` accept `since` too
 - Aptos: fix `getLogs` never emitting the event exactly at a full page boundary, and no longer split a ledger version's events across rounds on multi-topic streams
 - TON: remove the per-address `getTransactions` window cache (made redundant by `since`); long-lived watch streams no longer retain parsed account history in memory
+- CLI: `manual-exec --verifier [<ccv>=]<scheme>://<host>[:port]` fetches CCV attestations straight from a verifier's aggregator over gRPC, so a message whose CCV is not onboarded in the indexer can still be executed; repeat the flag for one CCV to give it failover endpoints
+- CLI: `manual-exec --ccv-data <ccv>=<0x-hex>` supplies an attestation obtained out of band; either way the collected set is checked against the destination's CCV policy before signing, so a missing verifier fails locally instead of reverting onchain
 
 ## [1.12.0] - 2026-08-19
 

--- a/ccip-api-ref/docs-cli/configuration.mdx
+++ b/ccip-api-ref/docs-cli/configuration.mdx
@@ -209,7 +209,7 @@ These options are available on all commands:
 | `--page`          | -       | number   | -                             | Pagination size for `getLogs` queries                                                                                                |
 | `--api`           | -       | string   | `https://api.ccip.chain.link` | CCIP API endpoint URL. Enabled by default. Pass a URL for a custom endpoint. Use `--no-api` to disable (decentralized RPC-only mode) |
 | `--canton-config` | -       | string   | -                             | Path to Canton config JSON file (required for Canton operations)                                                                     |
-| `--indexer`       | -       | string[] | -                             | CCIP v2 indexer URLs for CCV verifications (used when lane involves Canton)                                                          |
+| `--indexer`       | -       | string[] | -                             | CCIP v2 indexer base URLs for CCV verifications; replaces the built-in defaults. Required for Canton manual execution                |
 | `--help`          | `-h`    | boolean  | -                             | Show help                                                                                                                            |
 | `--version`       | `-V`    | boolean  | -                             | Show version                                                                                                                         |
 

--- a/ccip-api-ref/docs-cli/manual-exec.mdx
+++ b/ccip-api-ref/docs-cli/manual-exec.mdx
@@ -35,6 +35,54 @@ The `manual-exec` command allows you to manually trigger the execution of a CCIP
 
 ## Options
 
+### Verification Sources
+
+| Option                              | Type  | Default | Description                                                                                                             |
+| ----------------------------------- | ----- | ------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `--verifier`, `--verifier-endpoint` | array | -       | Fetch CCV attestations from a verifier's own aggregator when the CCIP API and indexer cannot cover the required CCV set |
+| `--ccv-data`                        | array | -       | Supply an attestation directly as `<ccv-address>=<0x-hex>`, when no fetch source is reachable                           |
+
+A CCV that no indexer has onboarded cannot be executed from the managed sources: the indexer returns
+404 for its messages and the CCIP API reports no verification, even though the attestation is
+available on the verifier's own public endpoint. `--verifier` reads it from there.
+
+**Endpoint format:** `[<ccv-address>=]<scheme>://<host>[:port]`, repeatable, also comma-separated.
+Schemes are `grpc://` (aggregator over TLS, with `grpcs://` as an alias) and `grpc+plaintext://`
+(aggregator, no TLS). The scheme selects the transport explicitly, because a bare `host:port` cannot
+express whether the listener speaks TLS.
+
+Several endpoints for one CCV are redundant replicas of a single committee. Repeat the same address;
+they are tried in the order given, stopping at the first that serves an attestation:
+
+```bash
+ccip-cli manual-exec <src-tx> \
+  --verifier 0xAAA...=grpc://aggregator-primary:443 \
+  --verifier 0xAAA...=grpc://aggregator-backup:443
+```
+
+Several CCVs each get their own endpoints. All required CCVs are fetched, and coverage against the
+destination's required and optional policy is checked before anything is signed, so a missing
+attestation is a local error naming the CCV rather than an onchain `RequiredCCVMissing` revert:
+
+```bash
+ccip-cli manual-exec <src-tx> \
+  --verifier 0xAAA...=grpc://a-primary:443 --verifier 0xAAA...=grpc://a-backup:443 \
+  --verifier 0xBBB...=grpc://b-primary:443
+```
+
+Omit the address to apply one endpoint to every required CCV. The CCIP API and indexer are always
+tried first; `--verifier` endpoints are used only if those come up short. For a CCV no indexer has
+onboarded they never cover it, so the verifier is always used.
+
+When no source is reachable, supply the bytes yourself. This is the bottom of the ladder:
+
+```bash
+ccip-cli manual-exec <src-tx> --no-api --ccv-data 0xAAA...=0x0001000100407602...
+```
+
+Validity is decided onchain by the CCV's `verifyMessage`, so bytes obtained out of band are as safe
+as fetched ones: wrong bytes can only waste the sender's gas, never make a bad message execute.
+
 ### Message Selection
 
 | Option        | Type   | Default | Description                                                                            |

--- a/ccip-api-ref/src/components/cli-builder/components/CLIBuilder.tsx
+++ b/ccip-api-ref/src/components/cli-builder/components/CLIBuilder.tsx
@@ -20,6 +20,7 @@ import type {
   StringOption,
 } from '../types/index.ts'
 import { CommandPreview } from './CommandPreview.tsx'
+import { GROUP_ORDER } from './groups.ts'
 import { ArrayInput, BooleanInput, ChainSelect, SelectInput, StringInput } from './inputs/index.ts'
 import { GROUP_LABELS, OptionGroup } from './OptionGroup.tsx'
 
@@ -135,10 +136,7 @@ function CLIBuilderForm({
     return groups
   }, [schema.options])
 
-  // Get ordered group names
-  const groupOrder = ['message', 'gas', 'solana', 'wallet', 'output', 'rpc', 'other']
-
-  const orderedGroups = groupOrder.filter((g) => groupedOptions[g]?.length > 0)
+  const orderedGroups = GROUP_ORDER.filter((g) => groupedOptions[g]?.length > 0)
 
   return (
     <div className={`${styles.cliBuilder} ${className ?? ''}`}>

--- a/ccip-api-ref/src/components/cli-builder/components/OptionGroup.tsx
+++ b/ccip-api-ref/src/components/cli-builder/components/OptionGroup.tsx
@@ -51,6 +51,10 @@ export const GROUP_LABELS: Record<string, { label: string; description?: string 
     label: 'Required Arguments',
     description: 'These values are required to build the command',
   },
+  verification: {
+    label: 'Verification Sources',
+    description: 'Choose where the CCV attestations are fetched from',
+  },
   message: {
     label: 'Message Options',
     description: 'Configure the CCIP message payload',

--- a/ccip-api-ref/src/components/cli-builder/components/groups.test.ts
+++ b/ccip-api-ref/src/components/cli-builder/components/groups.test.ts
@@ -1,0 +1,15 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import { manualExecSchema } from '../schemas/manual-exec.schema.ts'
+import { GROUP_ORDER } from './groups.ts'
+
+describe('CLI Builder option groups', () => {
+  it('should render the group holding the verification flags', () => {
+    // The builder renders only the groups in GROUP_ORDER and drops the rest with no error, so a
+    // flag in an unregistered group is invisible on the page.
+    const verification = manualExecSchema.options.filter((opt) => opt.group === 'verification')
+    assert.deepEqual(verification.map((opt) => opt.name).sort(), ['ccv-data', 'verifier'])
+    assert.ok(GROUP_ORDER.includes('verification'))
+  })
+})

--- a/ccip-api-ref/src/components/cli-builder/components/groups.ts
+++ b/ccip-api-ref/src/components/cli-builder/components/groups.ts
@@ -1,0 +1,16 @@
+/**
+ * Render order for CLI option groups.
+ *
+ * The CLI Builder renders only the groups listed here, so a schema option whose `group` is absent
+ * is silently dropped from the page. `groups.test.ts` asserts the verification group appears.
+ */
+export const GROUP_ORDER = [
+  'verification',
+  'message',
+  'gas',
+  'solana',
+  'wallet',
+  'output',
+  'rpc',
+  'other',
+] as const

--- a/ccip-api-ref/src/components/cli-builder/schemas/manual-exec.schema.ts
+++ b/ccip-api-ref/src/components/cli-builder/schemas/manual-exec.schema.ts
@@ -25,6 +25,35 @@ export const manualExecSchema: CommandSchema<'manual-exec'> = {
   ],
 
   options: [
+    // Verification Sources
+    {
+      type: 'array',
+      name: 'verifier',
+      alias: 'verifier-endpoint',
+      label: 'Verifier Endpoints',
+      description:
+        'Fetch CCV attestations from a verifier when the CCIP API and indexer cannot cover the ' +
+        'required CCV set. Format: [<ccv-address>=]<scheme>://<host>[:port]. Schemes: grpc:// ' +
+        '(aggregator over TLS), grpc+plaintext:// (no TLS). Repeat the same address to give it ' +
+        'failover endpoints, tried in order. Use different addresses for different CCVs, or omit ' +
+        'the address to apply one endpoint to every required CCV.',
+      group: 'verification',
+      itemType: 'string',
+      placeholder: '0x345AEDB0...=grpc://aggregator.example:443',
+    },
+    {
+      type: 'array',
+      name: 'ccv-data',
+      label: 'Supplied CCV Attestations',
+      description:
+        'Supply a CCV attestation directly as <ccv-address>=<0x-hex>. The bottom of the source ' +
+        'ladder: use it when the CCIP API, the indexer and the verifier endpoint are all ' +
+        'unavailable, or to execute bytes obtained out of band. The CCV verifyMessage decides ' +
+        'validity onchain, so wrong bytes can only waste gas.',
+      group: 'verification',
+      itemType: 'string',
+      placeholder: '0x345AEDB0...=0x00010001...',
+    },
     // Message Selection
     {
       type: 'number',

--- a/ccip-cli/package.json
+++ b/ccip-cli/package.json
@@ -28,11 +28,12 @@
     "lint:fix": "oxfmt ./src && oxlint --fix ./src",
     "typecheck": "tsc --noEmit",
     "check": "npm run lint && npm run typecheck",
-    "build": "npm run clean && tsc -p ./tsconfig.build.json && npm run patch-dist",
+    "build": "npm run clean && tsc -p ./tsconfig.build.json && npm run copy-assets && npm run patch-dist",
     "patch-dist": "chmod +x ./dist/index.js && find ./dist -type f -name \"*.js\" -exec sed -i.bkp 's|@chainlink/ccip-sdk/src/.*\\.ts|@chainlink/ccip-sdk|g' {} + && find ./dist -type f -name \"*.bkp\" -delete",
     "start": "./ccip-cli",
     "clean": "rm -rfv ./dist",
-    "prepare": "npm run build"
+    "prepare": "npm run build",
+    "copy-assets": "mkdir -p ./dist/verifiers/proto/google/rpc && cp ./src/verifiers/proto/verifier.proto ./dist/verifiers/proto/ && cp ./src/verifiers/proto/google/rpc/status.proto ./dist/verifiers/proto/google/rpc/ && test -f ./dist/verifiers/proto/verifier.proto"
   },
   "files": [
     "dist",
@@ -54,6 +55,8 @@
     "@chainlink/ccip-sdk": "^1.13.0",
     "@coral-xyz/anchor": "^0.29.0",
     "@ethers-ext/signer-ledger": "^6.0.0-beta.1",
+    "@grpc/grpc-js": "^1.14.4",
+    "@grpc/proto-loader": "^0.8.1",
     "@inquirer/prompts": "8.5.2",
     "@ledgerhq/hw-app-aptos": "6.37.0",
     "@ledgerhq/hw-app-solana": "7.9.0",

--- a/ccip-cli/src/commands/manual-exec.ts
+++ b/ccip-cli/src/commands/manual-exec.ts
@@ -23,6 +23,7 @@ import {
   type CCIPRequest,
   type Chain,
   CCIPAPIClient,
+  CCIPArgumentInvalidError,
   CCIPDestSimulationUnavailableError,
   CCIPInteractiveRequiredError,
   CCIPMessageIdNotFoundError,
@@ -37,6 +38,7 @@ import type { Argv } from 'yargs'
 
 import type { GlobalOpts } from '../index.ts'
 import { fetchChainsFromRpcs, loadChainWallet, resolveIndexer } from '../providers/index.ts'
+import { assertCoverage, collectDirectVerifications } from '../verifiers/direct.ts'
 import { type Ctx, Format } from './types.ts'
 import {
   getCtx,
@@ -217,16 +219,79 @@ async function manualExec(
   if (argv.estimateGasLimit != null && !source)
     source = await getChain(request.lane.sourceChainSelector)
 
+  // The verification block below lives under `if (source)`, and a bare messageId positional never
+  // sets `source`. Without this, --verifier/--ccv-data were silently ignored and execution fell
+  // through to `dest.execute({ messageId })` with NO verifications, broadcasting an unverified
+  // execute that reverts RequiredCCVMissing and costs gas. Resolve the source chain so the
+  // verifier fetch and the coverage assert actually run.
+  const verifierEntries = (argv as { verifier?: readonly string[] }).verifier ?? []
+  const ccvDataEntries = (argv as { ccvData?: readonly string[] }).ccvData ?? []
+
+  // A messageId positional does not set `source`, so resolve it here to reach the verifier fetch
+  // and the coverage assert. It is optional: a v2 execution needs only the encoded message and the
+  // OffRamp, both of which the CCIP API returns, so a missing source RPC falls through to the
+  // API-only branch below rather than failing.
+  if (!source && (verifierEntries.length > 0 || ccvDataEntries.length > 0))
+    source = await getChain(request.lane.sourceChainSelector).catch(() => undefined)
+
   let inputs
   if (source) {
     offRamp ??= await discoverOffRamp(source, dest, request.lane.onRamp, source)
     const indexer = resolveIndexer(argv, dest, logger, source)
-    const verifications = await dest.getVerifications({
-      ...argv,
-      indexer,
-      offRamp,
-      request,
-    })
+
+    // Source order: the managed sources first, then the verifiers themselves. `--verifier` /
+    // `--ccv-data` are a FALLBACK used only when the API/indexer could not cover the required set.
+    // That keeps routine calls off partner infrastructure and only discloses the messageId to a
+    // verifier operator when there is no alternative. For a CCV no indexer has onboarded the
+    // managed sources never cover it, so the fallback always fires.
+    let verifications
+    if (verifierEntries.length > 0 || ccvDataEntries.length > 0) {
+      verifications = await dest
+        .getVerifications({ ...argv, indexer, offRamp, request })
+        .catch(() => undefined)
+      // Only families whose policy is keyed by DEST address can be coverage-checked here.
+      // Canton derives `requiredCCVs` from the source-side `message_ccv_addresses` while its
+      // results carry dest addresses, so comparing them would reject a complete attestation set.
+      const destKeyedPolicy =
+        verifications &&
+        'verificationPolicy' in verifications &&
+        typeof dest.getCCVsForEncodedMessage === 'function'
+      if (verifications && 'verificationPolicy' in verifications && destKeyedPolicy) {
+        try {
+          assertCoverage(verifications.verifications, verifications.verificationPolicy)
+          logger.info('managed sources covered the required CCV set; not contacting verifiers')
+        } catch {
+          logger.info(
+            'managed sources did not cover the required CCV set; falling back to --verifier',
+          )
+          verifications = undefined
+        }
+      } else if (verifications) {
+        // pre-v2 shape carries no policy to check; keep it
+        logger.debug('non-v2 verifications; --verifier not applicable')
+      }
+    }
+
+    if (verifications === undefined && (verifierEntries.length > 0 || ccvDataEntries.length > 0)) {
+      // Direct verifier fetch: read attestations from the verifiers themselves rather than the
+      // indexer. This is the only path available for a CCV that no indexer has onboarded.
+      verifications = await collectDirectVerifications({
+        dest,
+        offRamp,
+        encodedMessage: (request.message as { encodedMessage?: unknown }).encodedMessage,
+        messageId: request.message.messageId,
+        verifierEntries,
+        ccvDataEntries,
+        logger,
+      })
+    } else if (verifications === undefined) {
+      verifications = await dest.getVerifications({
+        ...argv,
+        indexer,
+        offRamp,
+        request,
+      })
+    }
 
     let estimated: number | undefined
     if (argv.estimateGasLimit != null) {
@@ -301,8 +366,55 @@ async function manualExec(
       }
     }
 
+    // Refuse to broadcast `execute(msg, [], [])`: with no attestation for any required CCV the
+    // OffRamp reverts RequiredCCVMissing, costing gas and moving the message to FAILURE. Placed
+    // after the estimate/`--only-estimate` block so a read-only diagnostic is never blocked by a
+    // broadcast-safety check.
+    if (
+      'verificationPolicy' in verifications &&
+      verifications.verificationPolicy.requiredCCVs.length > 0 &&
+      verifications.verifications.length === 0
+    ) {
+      throw new Error(
+        `no attestation was found for any of the ${verifications.verificationPolicy.requiredCCVs.length} ` +
+          `required CCV(s); OffRamp.execute would revert RequiredCCVMissing. Supply them with ` +
+          `--verifier <ccv>=<scheme>://<host>[:port] or --ccv-data <ccv>=<0x-hex>`,
+      )
+    }
+
     const input = await source.getExecutionInput({ ...argv, request, verifications })
     inputs = { input, offRamp }
+  } else if (verifierEntries.length > 0 || ccvDataEntries.length > 0) {
+    // No source chain, but attestations were supplied or can be fetched. A v2 execution needs only
+    // the encoded message and the OffRamp, both of which the CCIP API returns, so the source chain
+    // is not required: `getExecutionInput` on v2 merges the verifications and reads no chain.
+    if (!apiClient) {
+      throw new CCIPArgumentInvalidError(
+        'rpcs',
+        'reading attestations without a source-chain RPC needs the CCIP API; pass --rpcs for the ' +
+          'source chain, or drop --no-api',
+      )
+    }
+    const messageId = request.message.messageId
+    const execInput = await apiClient.getExecutionInput(messageId)
+    offRamp ??= execInput.offRamp
+    if (!('encodedMessage' in execInput)) {
+      throw new CCIPArgumentInvalidError(
+        'txHashOrId',
+        'this message predates CCIP v2.0; manual execution needs a source-chain RPC to build its ' +
+          'merkle proof. Pass --rpcs for the source chain.',
+      )
+    }
+    const collected = await collectDirectVerifications({
+      dest,
+      offRamp,
+      encodedMessage: execInput.encodedMessage,
+      messageId,
+      verifierEntries,
+      ccvDataEntries,
+      logger,
+    })
+    inputs = { input: { encodedMessage: execInput.encodedMessage, ...collected }, offRamp }
   }
 
   const [walletAddr, wallet] = await loadChainWallet(dest, argv, logger)

--- a/ccip-cli/src/index.ts
+++ b/ccip-cli/src/index.ts
@@ -113,11 +113,55 @@ const globalOpts = {
     describe:
       'Path to Canton config JSON file (party, ccipParty, jwt, edsUrl, transferInstructionUrl, etc.)',
   },
+  verifier: {
+    type: 'array',
+    string: true,
+    alias: 'verifier-endpoint',
+    describe:
+      'Fetch CCV attestations from a verifier when the CCIP API and indexer cannot cover the ' +
+      'required CCV set (e.g. a CCV no indexer has onboarded): ' +
+      '[<ccv-address>=]<scheme>://<host>[:port], repeatable. Schemes: grpc (aggregator over TLS), ' +
+      'grpc+plaintext (aggregator, no TLS). Repeat an address to give it failover endpoints, tried ' +
+      'in order. Omit the address to apply one endpoint to every required CCV.',
+    coerce: (entries: unknown[]): string[] =>
+      entries.flatMap((e) => {
+        if (typeof e !== 'string') {
+          throw new Error(`--verifier expects strings, got ${typeof e}`)
+        }
+        return e.split(',').map((s) => s.trim())
+      }),
+  },
+  'ccv-data': {
+    type: 'array',
+    string: true,
+    describe:
+      'Supply a CCV attestation directly as <ccv-address>=<0x-hex>, repeatable. The bottom of the ' +
+      'source ladder: use it when the CCIP API, the indexer and the verifier endpoint are all ' +
+      'unavailable, or to execute bytes obtained out of band. Validity is decided onchain by the ' +
+      "CCV's verifyMessage, so wrong bytes can only waste gas.",
+    coerce: (entries: unknown[]): string[] =>
+      entries.flatMap((e) => {
+        if (typeof e !== 'string') throw new Error(`--ccv-data expects strings, got ${typeof e}`)
+        return e.split(',').map((x) => x.trim())
+      }),
+  },
   indexer: {
     type: 'array',
     string: true,
     describe:
-      'Additional CCIP v2 indexer base URLs to query for CCV verifications (e.g. https://indexer-1.ccip.chain.link)',
+      'CCIP v2 indexer base URLs for CCV verifications; replaces the built-in defaults. Required for Canton manual execution (e.g. https://indexer-1.ccip.chain.link)',
+    // yargs applies boolean negation regardless of the declared type, so `--no-indexer` yields
+    // `[false]` and passes `.strict()`. Reject it here with a readable message instead of letting a
+    // non-string reach the SDK.
+    coerce: (urls: unknown[]): string[] =>
+      urls.map((url) => {
+        if (typeof url !== 'string') {
+          throw new Error(
+            `--indexer expects base URL strings, got ${typeof url}. To skip indexers, pass --indexer with no values.`,
+          )
+        }
+        return url
+      }),
   },
 } as const
 

--- a/ccip-cli/src/verifiers/aggregator.ts
+++ b/ccip-cli/src/verifiers/aggregator.ts
@@ -1,0 +1,201 @@
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import type { VerifierResult } from '@chainlink/ccip-sdk/src/index.ts'
+import { type ServiceError, credentials, loadPackageDefinition } from '@grpc/grpc-js'
+import { loadSync } from '@grpc/proto-loader'
+
+/** A parsed `--verifier` endpoint: where to read one CCV's attestations from. */
+export type VerifierEndpoint = {
+  /** Transport the endpoint speaks. Only `aggregator` (gRPC) is supported today. */
+  type: 'aggregator'
+  /** `host:port` of the aggregator's gRPC listener. */
+  target: string
+  /** Whether to use TLS. Selected by the URL scheme, never sniffed from the port. */
+  tls: boolean
+  /** The endpoint as the user wrote it, for diagnostics. */
+  raw: string
+}
+
+/** Why a single endpoint failed, kept per-endpoint so diagnostics can name each one. */
+export type EndpointFailure = { endpoint: string; reason: string }
+
+/** Outcome of reading one CCV's attestations across its endpoints, in order. */
+export type AggregatorReadResult = {
+  /** Results from the first endpoint that answered with at least one attestation. */
+  results: VerifierResult[]
+  /** The endpoint that served them, or `null` when every endpoint failed. */
+  servedBy: string | null
+  /** Every endpoint tried before success, with the reason each failed. */
+  failures: EndpointFailure[]
+}
+
+type RawVerifierResult = {
+  ccv_data?: Buffer | Uint8Array
+  message_ccv_addresses?: (Buffer | Uint8Array)[]
+  metadata?: {
+    verifier_source_address?: Buffer | Uint8Array
+    verifier_dest_address?: Buffer | Uint8Array
+    timestamp?: string | number
+  }
+}
+
+type RawResponse = { results?: RawVerifierResult[] }
+
+type VerifierClient = {
+  GetVerifierResultsForMessage(
+    req: { message_ids: Buffer[] },
+    cb: (err: ServiceError | null, res: RawResponse) => void,
+  ): void
+  close(): void
+}
+
+type VerifierClientCtor = new (
+  address: string,
+  creds: ReturnType<typeof credentials.createInsecure>,
+) => VerifierClient
+
+const PROTO_PATH = join(dirname(fileURLToPath(import.meta.url)), 'proto', 'verifier.proto')
+
+let cachedCtor: VerifierClientCtor | undefined
+
+/**
+ * Load the generated `chainlink_ccv.verifier.v1.Verifier` client constructor.
+ *
+ * `keepCase` preserves the proto's snake_case field names, and `longs: String` keeps uint64 fields
+ * as strings so no CCIP integer is ever narrowed through a JS number.
+ *
+ * @returns The gRPC client constructor for the Verifier service
+ */
+function loadClientCtor(): VerifierClientCtor {
+  if (cachedCtor) return cachedCtor
+  const def = loadSync(PROTO_PATH, {
+    keepCase: true,
+    longs: String,
+    enums: String,
+    defaults: true,
+    oneofs: true,
+    includeDirs: [dirname(PROTO_PATH)],
+  })
+  const pkg = loadPackageDefinition(def) as unknown as {
+    chainlink_ccv: { verifier: { v1: { Verifier: VerifierClientCtor } } }
+  }
+  cachedCtor = pkg.chainlink_ccv.verifier.v1.Verifier
+  return cachedCtor
+}
+
+/**
+ * Convert a protobuf `bytes` field to a 0x-prefixed hex string.
+ *
+ * @param b - Raw bytes from the decoded response
+ * @returns Hex string, or undefined when the field is absent or empty
+ */
+function toHex(b: Buffer | Uint8Array | undefined): string | undefined {
+  if (!b || b.length === 0) return undefined
+  return `0x${Buffer.from(b).toString('hex')}`
+}
+
+/**
+ * Convert a protobuf `bytes` field to a 20-byte EVM address.
+ *
+ * @param b - Raw bytes from the decoded response
+ * @returns 0x-prefixed lowercase hex address, or undefined when not exactly 20 bytes
+ */
+function toAddress(b: Buffer | Uint8Array | undefined): string | undefined {
+  if (!b || b.length !== 20) return undefined
+  return `0x${Buffer.from(b).toString('hex')}`
+}
+
+/**
+ * Call `GetVerifierResultsForMessage` on one aggregator.
+ *
+ * The read is anonymous: no HMAC, api-key or metadata is attached. The aggregator rejects partial
+ * HMAC headers, so the public read sends none at all.
+ *
+ * @param endpoint - The endpoint to query
+ * @param messageId - 0x-prefixed 32-byte message id
+ * @param timeoutMs - Deadline for the call
+ * @returns The attestations the aggregator holds, possibly empty before quorum
+ */
+async function readOne(
+  endpoint: VerifierEndpoint,
+  messageId: string,
+  timeoutMs: number,
+): Promise<VerifierResult[]> {
+  const Ctor = loadClientCtor()
+  const creds = endpoint.tls ? credentials.createSsl() : credentials.createInsecure()
+  const client = new Ctor(endpoint.target, creds)
+  try {
+    const res = await new Promise<RawResponse>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error(`timed out after ${timeoutMs}ms`)), timeoutMs)
+      client.GetVerifierResultsForMessage(
+        { message_ids: [Buffer.from(messageId.replace(/^0x/, ''), 'hex')] },
+        (err, r) => {
+          clearTimeout(timer)
+          if (err) reject(err)
+          else resolve(r)
+        },
+      )
+    })
+    const out: VerifierResult[] = []
+    for (const r of res.results ?? []) {
+      const ccvData = toHex(r.ccv_data)
+      // Key on the metadata dest-address hint, which is what the executor matches against the
+      // destination's required set. `message_ccv_addresses` is the whole SOURCE-side CCV list, so
+      // indexing into it is only correct when the message has exactly one CCV.
+      const destAddress =
+        toAddress(r.metadata?.verifier_dest_address) ?? toAddress(r.message_ccv_addresses?.[0])
+      const sourceAddress = toAddress(r.metadata?.verifier_source_address)
+      if (ccvData === undefined || destAddress === undefined) continue
+      const ts = r.metadata?.timestamp
+      out.push({
+        ccvData,
+        destAddress,
+        sourceAddress: sourceAddress ?? destAddress,
+        // proto timestamp is milliseconds; VerifierResult.timestamp is seconds
+        ...(ts != null ? { timestamp: Math.floor(Number(ts) / 1000) } : {}),
+      })
+    }
+    return out
+  } finally {
+    client.close()
+  }
+}
+
+/**
+ * Read one CCV's attestations, trying its endpoints in the order supplied.
+ *
+ * Endpoints are tried sequentially, stopping at the first that serves an attestation. They are
+ * redundant replicas of one committee, so their order encodes primary/backup intent. Racing them
+ * would defeat that ordering, tell every operator in the list which message is about to be
+ * executed, and load partner infrastructure for a result only one of them needs to supply.
+ *
+ * @param endpoints - Endpoints for a single CCV, in preference order
+ * @param messageId - 0x-prefixed 32-byte message id
+ * @param opts - Optional per-call deadline
+ * @returns The first successful read, plus every failure that preceded it
+ */
+export async function readAggregator(
+  endpoints: readonly VerifierEndpoint[],
+  messageId: string,
+  opts?: { timeoutMs?: number },
+): Promise<AggregatorReadResult> {
+  const timeoutMs = opts?.timeoutMs ?? 30_000
+  const failures: EndpointFailure[] = []
+  for (const endpoint of endpoints) {
+    try {
+      const results = await readOne(endpoint, messageId, timeoutMs)
+      if (results.length > 0) return { results, servedBy: endpoint.raw, failures }
+      failures.push({
+        endpoint: endpoint.raw,
+        reason: 'reachable, but holds no attestation for this message yet',
+      })
+    } catch (err) {
+      // grpc-js appends a trailing "Resolution note: " that is usually empty; drop it so the
+      // per-endpoint diagnostic ends on the actual cause.
+      const reason = (err as Error).message.replace(/\s*Resolution note:\s*$/, '')
+      failures.push({ endpoint: endpoint.raw, reason })
+    }
+  }
+  return { results: [], servedBy: null, failures }
+}

--- a/ccip-cli/src/verifiers/direct.test.ts
+++ b/ccip-cli/src/verifiers/direct.test.ts
@@ -1,0 +1,128 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import type { VerifierResult } from '@chainlink/ccip-sdk/src/index.ts'
+
+import { type VerificationPolicy, assertCoverage, formatCoverageFailure } from './direct.ts'
+
+const CCV_A = '0x345AEDB0988Ff1e897c26f9ad3AE84603Ed517E2'
+const CCV_B = '0xD5C448Fc5B81EFd3108656Ce5FF9bacF2b582bdB'
+
+function result(destAddress: string): VerifierResult {
+  return { ccvData: '0xabcd', destAddress, sourceAddress: destAddress }
+}
+
+describe('assertCoverage', () => {
+  it('should block the empty set that would broadcast a reverting execute', () => {
+    // An empty verification set reverts RequiredCCVMissing onchain and moves the message to
+    // FAILURE. Failing here costs nothing.
+    const policy: VerificationPolicy = {
+      requiredCCVs: [CCV_A],
+      optionalCCVs: [],
+      optionalThreshold: 0,
+    }
+    assert.throws(() => assertCoverage([], policy), /RequiredCCVMissing/)
+  })
+
+  it('should name every uncovered required CCV', () => {
+    const policy: VerificationPolicy = {
+      requiredCCVs: [CCV_A, CCV_B],
+      optionalCCVs: [],
+      optionalThreshold: 0,
+    }
+    assert.throws(
+      () => assertCoverage([result(CCV_A)], policy),
+      (err: Error) => {
+        assert.match(err.message, new RegExp(CCV_B))
+        assert.doesNotMatch(err.message, new RegExp(CCV_A))
+        return true
+      },
+    )
+  })
+
+  it('should match CCV addresses case-insensitively', () => {
+    const policy: VerificationPolicy = {
+      requiredCCVs: [CCV_A],
+      optionalCCVs: [],
+      optionalThreshold: 0,
+    }
+    assert.doesNotThrow(() => assertCoverage([result(CCV_A.toLowerCase())], policy))
+  })
+
+  it('should enforce the optional quorum, not just the required set', () => {
+    const policy: VerificationPolicy = {
+      requiredCCVs: [],
+      optionalCCVs: [CCV_A, CCV_B],
+      optionalThreshold: 2,
+    }
+    assert.throws(() => assertCoverage([result(CCV_A)], policy), /OptionalCCVQuorumNotReached/)
+    assert.doesNotThrow(() => assertCoverage([result(CCV_A), result(CCV_B)], policy))
+  })
+
+  it('should pass a fully satisfied policy through untouched', () => {
+    const policy: VerificationPolicy = {
+      requiredCCVs: [CCV_A],
+      optionalCCVs: [CCV_B],
+      optionalThreshold: 1,
+    }
+    assert.doesNotThrow(() => assertCoverage([result(CCV_A), result(CCV_B)], policy))
+  })
+})
+
+describe('formatCoverageFailure', () => {
+  it('should tell the user which flag to add when no endpoint was supplied', () => {
+    const msg = formatCoverageFailure(
+      [
+        {
+          ccvAddress: CCV_A,
+          role: 'required',
+          status: 'unmapped',
+          servedBy: null,
+          endpointsTried: [],
+          ccvDataLength: 0,
+          failures: [],
+        },
+      ],
+      { requiredCCVs: [CCV_A], optionalCCVs: [], optionalThreshold: 0 },
+    )
+    assert.match(msg, /no endpoint supplied/)
+    assert.match(msg, new RegExp(`--verifier ${CCV_A}=`))
+  })
+
+  it('should distinguish reachable-but-not-attested-yet from unreachable', () => {
+    const pending = formatCoverageFailure(
+      [
+        {
+          ccvAddress: CCV_A,
+          role: 'required',
+          status: 'pending',
+          servedBy: null,
+          endpointsTried: ['grpc://h:443'],
+          ccvDataLength: 0,
+          failures: [],
+        },
+      ],
+      { requiredCCVs: [CCV_A], optionalCCVs: [], optionalThreshold: 0 },
+    )
+    assert.match(pending, /has not attested this message yet/)
+    assert.match(pending, /not an execution failure/)
+
+    const unreachable = formatCoverageFailure(
+      [
+        {
+          ccvAddress: CCV_A,
+          role: 'required',
+          status: 'unreachable',
+          servedBy: null,
+          endpointsTried: ['grpc://h:443'],
+          ccvDataLength: 0,
+          failures: [{ endpoint: 'grpc://h:443', reason: 'ECONNREFUSED' }],
+        },
+      ],
+      { requiredCCVs: [CCV_A], optionalCCVs: [], optionalThreshold: 0 },
+    )
+    assert.match(unreachable, /no endpoint served an attestation/)
+    assert.match(unreachable, /ECONNREFUSED/)
+    assert.doesNotMatch(unreachable, /has not attested this message yet/)
+  })
+})

--- a/ccip-cli/src/verifiers/direct.ts
+++ b/ccip-cli/src/verifiers/direct.ts
@@ -1,0 +1,319 @@
+import type { Logger, VerifierResult } from '@chainlink/ccip-sdk/src/index.ts'
+
+import { type EndpointFailure, readAggregator } from './aggregator.ts'
+import {
+  type VerifierEndpointMap,
+  endpointsFor,
+  parseCcvData,
+  parseVerifierEndpoints,
+} from './endpoints.ts'
+
+/** The destination's CCV policy, as returned by `OffRamp.getCCVsForMessage`. */
+export type VerificationPolicy = {
+  requiredCCVs: readonly string[]
+  optionalCCVs: readonly string[]
+  optionalThreshold: number
+}
+
+/** What was attempted for one CCV, so a failure can name the CCV and every endpoint tried. */
+export type CcvFetchOutcome = {
+  ccvAddress: string
+  role: 'required' | 'optional'
+  status: 'ok' | 'pending' | 'unreachable' | 'unmapped'
+  servedBy: string | null
+  endpointsTried: string[]
+  ccvDataLength: number
+  failures: EndpointFailure[]
+}
+
+/** Result of fetching every CCV a message needs, directly from the verifiers. */
+export type DirectFetchResult = {
+  verifications: VerifierResult[]
+  outcomes: CcvFetchOutcome[]
+}
+
+/**
+ * Format a per-CCV diagnostic naming which CCV could not be satisfied, and why.
+ *
+ * @param outcomes - Per-CCV outcomes from {@link fetchVerificationsDirect}
+ * @param policy - The destination policy the outcomes were measured against
+ * @returns Multi-line, human-readable explanation
+ */
+export function formatCoverageFailure(
+  outcomes: readonly CcvFetchOutcome[],
+  policy: VerificationPolicy,
+): string {
+  const lines: string[] = []
+  const missing = outcomes.filter((o) => o.status !== 'ok')
+  lines.push(
+    `could not collect every attestation this message needs ` +
+      `(${outcomes.filter((o) => o.status === 'ok').length}/${outcomes.length} obtained)`,
+  )
+  for (const o of missing) {
+    if (o.status === 'unmapped') {
+      lines.push(
+        `  ${o.ccvAddress} (${o.role}): no endpoint supplied. ` +
+          `Add --verifier ${o.ccvAddress}=<scheme>://<host>[:port]`,
+      )
+      continue
+    }
+    if (o.status === 'pending') {
+      lines.push(
+        `  ${o.ccvAddress} (${o.role}): verifier reachable but has not attested this message yet. ` +
+          `Retry shortly; this is not an execution failure.`,
+      )
+      continue
+    }
+    lines.push(`  ${o.ccvAddress} (${o.role}): no endpoint served an attestation.`)
+    for (const f of o.failures) lines.push(`      ${f.endpoint}: ${f.reason}`)
+  }
+  if (policy.optionalThreshold > 0) {
+    lines.push(
+      `  note: this message also needs ${policy.optionalThreshold} of ` +
+        `${policy.optionalCCVs.length} optional CCV(s).`,
+    )
+  }
+  lines.push(
+    '  Every required CCV must be attested; a partial set cannot be executed and would revert onchain.',
+  )
+  return lines.join('\n')
+}
+
+/**
+ * Fetch attestations for every CCV the destination requires, directly from the verifiers.
+ *
+ * Required CCVs are fetched concurrently, but the endpoints *within* one CCV are tried in order
+ * (see {@link readAggregator}). Optional CCVs are fetched only up to `optionalThreshold`, since
+ * supplying more than the quorum needs is wasted work and extra information disclosure.
+ *
+ * @param policy - Required/optional CCVs and the optional threshold, read from the destination
+ * @param map - Parsed `--verifier` endpoints
+ * @param messageId - 0x-prefixed 32-byte message id
+ * @param opts - Optional logger and per-call deadline
+ * @returns The collected verifications and a per-CCV outcome for diagnostics
+ */
+export async function fetchVerificationsDirect(
+  policy: VerificationPolicy,
+  map: VerifierEndpointMap,
+  messageId: string,
+  opts?: { logger?: Logger; timeoutMs?: number },
+): Promise<DirectFetchResult> {
+  const logger = opts?.logger
+  const fetchOne = async (
+    ccvAddress: string,
+    role: 'required' | 'optional',
+  ): Promise<{ outcome: CcvFetchOutcome; results: VerifierResult[] }> => {
+    const endpoints = endpointsFor(map, ccvAddress)
+    const base = { ccvAddress, role, endpointsTried: endpoints.map((e) => e.raw) }
+    if (endpoints.length === 0) {
+      return {
+        outcome: { ...base, status: 'unmapped', servedBy: null, ccvDataLength: 0, failures: [] },
+        results: [],
+      }
+    }
+    logger?.info(`fetching ${ccvAddress} from ${endpoints.map((e) => e.raw).join(', ')}`)
+    const read = await readAggregator(endpoints, messageId, { timeoutMs: opts?.timeoutMs })
+    // Keep only the result issued by THIS ccv; an aggregator may serve several.
+    const mine = read.results.filter(
+      (r) => r.destAddress.toLowerCase() === ccvAddress.toLowerCase(),
+    )
+    const chosen = mine.length > 0 ? mine : read.results
+    if (chosen.length === 0) {
+      // Distinguish "reachable but nothing yet" from "nothing answered": the first is worth a
+      // retry, the second points at a wrong endpoint or a verifier that is down.
+      const reachable = read.failures.some((f) => f.reason.includes('holds no attestation'))
+      return {
+        outcome: {
+          ...base,
+          status: reachable ? 'pending' : 'unreachable',
+          servedBy: null,
+          ccvDataLength: 0,
+          failures: read.failures,
+        },
+        results: [],
+      }
+    }
+    return {
+      outcome: {
+        ...base,
+        status: 'ok',
+        servedBy: read.servedBy,
+        ccvDataLength: (chosen[0]!.ccvData as string).length / 2 - 1,
+        failures: read.failures,
+      },
+      results: chosen.slice(0, 1),
+    }
+  }
+
+  const required = await Promise.all(policy.requiredCCVs.map((ccv) => fetchOne(ccv, 'required')))
+  const optional: Awaited<ReturnType<typeof fetchOne>>[] = []
+  if (policy.optionalThreshold > 0) {
+    for (const ccv of policy.optionalCCVs) {
+      if (optional.filter((o) => o.outcome.status === 'ok').length >= policy.optionalThreshold)
+        break
+      optional.push(await fetchOne(ccv, 'optional'))
+    }
+  }
+
+  const all = [...required, ...optional]
+  return {
+    verifications: all.flatMap((a) => a.results),
+    outcomes: all.map((a) => a.outcome),
+  }
+}
+
+/**
+ * Assert the collected verifications satisfy the destination's policy, before signing anything.
+ *
+ * `OffRamp.execute` reverts `RequiredCCVMissing` when a required CCV has no result, and
+ * `OptionalCCVQuorumNotReached` when fewer than `optionalThreshold` optional CCVs are supplied.
+ * Checking here turns a paid onchain revert into a local error naming the offending CCV.
+ *
+ * @param verifications - The collected attestations
+ * @param policy - Required/optional CCVs and the optional threshold
+ * @returns Nothing; throws when coverage is insufficient
+ * @throws Error naming the uncovered CCVs
+ */
+export function assertCoverage(
+  verifications: readonly VerifierResult[],
+  policy: VerificationPolicy,
+): void {
+  const have = new Set(verifications.map((v) => v.destAddress.toLowerCase()))
+  const missing = policy.requiredCCVs.filter((c) => !have.has(c.toLowerCase()))
+  if (missing.length > 0) {
+    throw new Error(
+      `missing attestation for required CCV(s): ${missing.join(', ')}. ` +
+        `OffRamp.execute would revert RequiredCCVMissing.`,
+    )
+  }
+  if (policy.optionalThreshold > 0) {
+    const got = policy.optionalCCVs.filter((c) => have.has(c.toLowerCase())).length
+    if (got < policy.optionalThreshold) {
+      throw new Error(
+        `optional CCV quorum not reached: have ${got}, need ${policy.optionalThreshold} of ` +
+          `${policy.optionalCCVs.length}. OffRamp.execute would revert OptionalCCVQuorumNotReached.`,
+      )
+    }
+  }
+}
+
+/** A destination chain able to report the CCV policy for a message. */
+export type PolicyReader = {
+  getCCVsForEncodedMessage?(opts: { offRamp: string; encodedMessage: unknown }): Promise<{
+    requiredCCVs: readonly string[]
+    optionalCCVs: readonly string[]
+    optionalThreshold: number | bigint
+  }>
+  constructor: { name: string }
+}
+
+/**
+ * Collect the attestations a message needs, from supplied bytes and from the verifiers.
+ *
+ * The destination's CCV policy is read from its OffRamp, caller-supplied `--ccv-data` bytes are
+ * taken as given, the remaining CCVs are fetched, and the result is checked against the policy
+ * before any transaction is built.
+ *
+ * @param opts.dest - Destination chain, used to read the CCV policy
+ * @param opts.offRamp - Destination OffRamp address
+ * @param opts.encodedMessage - The encoded message, as emitted on the source chain
+ * @param opts.messageId - 0x-prefixed 32-byte message id
+ * @param opts.verifierEntries - Raw `--verifier` values
+ * @param opts.ccvDataEntries - Raw `--ccv-data` values
+ * @param opts.logger - Progress sink
+ * @returns The policy and the collected verifications
+ * @throws Error naming the CCVs whose attestations are missing
+ */
+export async function collectDirectVerifications(opts: {
+  dest: PolicyReader
+  offRamp: string
+  encodedMessage: unknown
+  messageId: string
+  verifierEntries: readonly string[]
+  ccvDataEntries: readonly string[]
+  logger: Logger
+}): Promise<{ verificationPolicy: VerificationPolicy; verifications: VerifierResult[] }> {
+  const { dest, offRamp, encodedMessage, messageId, verifierEntries, ccvDataEntries, logger } = opts
+  let policy: VerificationPolicy
+  try {
+    // Read the policy from the encoded message. Reconstructing it from decoded fields drops the
+    // token transfer when the message carries no dest token amounts, yielding the lane default
+    // instead of the pool-mandated CCV.
+    if (!dest.getCCVsForEncodedMessage)
+      throw new Error(`${dest.constructor.name} cannot read the CCV policy`)
+    const ccvs = await dest.getCCVsForEncodedMessage({ offRamp, encodedMessage })
+    policy = {
+      requiredCCVs: ccvs.requiredCCVs,
+      optionalCCVs: ccvs.optionalCCVs,
+      optionalThreshold: Number(ccvs.optionalThreshold),
+    }
+  } catch (err) {
+    throw new Error(
+      `could not read the destination CCV policy via OffRamp.getCCVsForMessage: ${
+        (err as Error).message
+      }`,
+      { cause: err },
+    )
+  }
+
+  logger.info(
+    `direct verifier fetch: ${policy.requiredCCVs.length} required CCV(s)`,
+    policy.optionalThreshold > 0
+      ? `+ ${policy.optionalThreshold} of ${policy.optionalCCVs.length} optional`
+      : '',
+  )
+
+  // Caller-supplied bytes win over anything fetched: the operator has stated these are the
+  // attestations to use. Only the CCVs left unsupplied are fetched.
+  const supplied = parseCcvData(ccvDataEntries)
+  const suppliedFor = new Set(supplied.map((s) => s.ccvAddress.toLowerCase()))
+  for (const s of supplied) {
+    logger.info(`  ${s.ccvAddress} (supplied): ${s.ccvData.length / 2 - 1} bytes via --ccv-data`)
+  }
+  const toFetch: VerificationPolicy = {
+    requiredCCVs: policy.requiredCCVs.filter((c) => !suppliedFor.has(c.toLowerCase())),
+    optionalCCVs: policy.optionalCCVs.filter((c) => !suppliedFor.has(c.toLowerCase())),
+    optionalThreshold: Math.max(
+      0,
+      policy.optionalThreshold -
+        policy.optionalCCVs.filter((c) => suppliedFor.has(c.toLowerCase())).length,
+    ),
+  }
+  const fetched =
+    toFetch.requiredCCVs.length > 0 || toFetch.optionalThreshold > 0
+      ? await fetchVerificationsDirect(
+          toFetch,
+          parseVerifierEndpoints(verifierEntries),
+          messageId,
+          {
+            logger,
+          },
+        )
+      : { verifications: [], outcomes: [] }
+
+  const verifications: VerifierResult[] = [
+    ...supplied.map((s) => ({
+      ccvData: s.ccvData,
+      destAddress: s.ccvAddress,
+      sourceAddress: s.ccvAddress,
+    })),
+    ...fetched.verifications,
+  ]
+  try {
+    assertCoverage(verifications, policy)
+  } catch (err) {
+    throw new Error(
+      `${(err as Error).message}\n${formatCoverageFailure(fetched.outcomes, policy)}`,
+      {
+        cause: err,
+      },
+    )
+  }
+  for (const o of fetched.outcomes) {
+    logger.info(
+      `  ${o.ccvAddress} (${o.role}): ${o.status}` +
+        (o.servedBy ? ` via ${o.servedBy} (${o.ccvDataLength} bytes)` : ''),
+    )
+  }
+  return { verificationPolicy: policy, verifications }
+}

--- a/ccip-cli/src/verifiers/endpoints.test.ts
+++ b/ccip-cli/src/verifiers/endpoints.test.ts
@@ -1,0 +1,117 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import {
+  endpointsFor,
+  parseCcvData,
+  parseVerifierEndpoints,
+  parseVerifierEntry,
+} from './endpoints.ts'
+
+const CCV = '0x345AEDB0988Ff1e897c26f9ad3AE84603Ed517E2'
+const OTHER = '0xD5C448Fc5B81EFd3108656Ce5FF9bacF2b582bdB'
+
+describe('parseVerifierEntry', () => {
+  it('should parse an address-mapped plaintext aggregator', () => {
+    const { ccvAddress, endpoint } = parseVerifierEntry(`${CCV}=grpc+plaintext://localhost:15051`)
+    assert.equal(ccvAddress, CCV)
+    assert.equal(endpoint.type, 'aggregator')
+    assert.equal(endpoint.target, 'localhost:15051')
+    assert.equal(endpoint.tls, false)
+  })
+
+  it('should select TLS from the scheme, never from the port', () => {
+    // The same port must be able to mean either transport; sniffing :443 would be a guess.
+    assert.equal(parseVerifierEntry(`${CCV}=grpc://host:443`).endpoint.tls, true)
+    assert.equal(parseVerifierEntry(`${CCV}=grpc+plaintext://host:443`).endpoint.tls, false)
+    assert.equal(parseVerifierEntry(`${CCV}=grpc://host:8443`).endpoint.tls, true)
+  })
+
+  it('should accept a bare endpoint as the fallback for every CCV', () => {
+    const { ccvAddress, endpoint } = parseVerifierEntry('grpc+plaintext://localhost:15051')
+    assert.equal(ccvAddress, null)
+    assert.equal(endpoint.target, 'localhost:15051')
+  })
+
+  it('should reject a bare host:port, which cannot express TLS', () => {
+    assert.throws(() => parseVerifierEntry(`${CCV}=localhost:15051`), /missing a scheme/)
+  })
+
+  it('should reject an unsupported scheme', () => {
+    assert.throws(() => parseVerifierEntry(`${CCV}=https://host/v1`), /unsupported scheme/)
+  })
+
+  it('should reject an invalid CCV address', () => {
+    assert.throws(() => parseVerifierEntry('0xNOTANADDRESS=grpc://host:443'), /invalid CCV address/)
+  })
+})
+
+describe('parseVerifierEndpoints', () => {
+  it('should accumulate a repeated address into an ORDERED failover list', () => {
+    // Order is the failover order: primary first, backup second. Never last-wins.
+    const map = parseVerifierEndpoints([`${CCV}=grpc://primary:443`, `${CCV}=grpc://backup:443`])
+    const eps = endpointsFor(map, CCV)
+    assert.equal(eps.length, 2)
+    assert.equal(eps[0]!.target, 'primary:443')
+    assert.equal(eps[1]!.target, 'backup:443')
+  })
+
+  it('should match the CCV address case-insensitively', () => {
+    const map = parseVerifierEndpoints([`${CCV.toLowerCase()}=grpc://host:443`])
+    assert.equal(endpointsFor(map, CCV.toUpperCase().replace('0X', '0x')).length, 1)
+  })
+
+  it('should keep per-CCV lists separate and fall back only when unmapped', () => {
+    const map = parseVerifierEndpoints([`${CCV}=grpc://for-ccv:443`, 'grpc://fallback:443'])
+    assert.equal(endpointsFor(map, CCV)[0]!.target, 'for-ccv:443')
+    assert.equal(endpointsFor(map, OTHER)[0]!.target, 'fallback:443')
+  })
+
+  it('should return no endpoints when nothing matches and no fallback was given', () => {
+    const map = parseVerifierEndpoints([`${CCV}=grpc://host:443`])
+    assert.equal(endpointsFor(map, OTHER).length, 0)
+  })
+})
+
+describe('comma-separated entries', () => {
+  it('should split a comma form identically to repeated flags', () => {
+    const commas = parseVerifierEndpoints([`${CCV}=grpc://a:443,${CCV}=grpc://b:443`])
+    const repeated = parseVerifierEndpoints([`${CCV}=grpc://a:443`, `${CCV}=grpc://b:443`])
+    assert.deepEqual(
+      endpointsFor(commas, CCV).map((e) => e.target),
+      endpointsFor(repeated, CCV).map((e) => e.target),
+    )
+    assert.equal(endpointsFor(commas, CCV).length, 2)
+  })
+
+  it('should not let a comma end up inside a host', () => {
+    const map = parseVerifierEndpoints([`${CCV}=grpc://a:443,${OTHER}=grpc://b:443`])
+    assert.equal(endpointsFor(map, CCV)[0]!.target, 'a:443')
+    assert.equal(endpointsFor(map, OTHER)[0]!.target, 'b:443')
+  })
+})
+
+describe('parseCcvData', () => {
+  it('should parse an address=hex pair', () => {
+    const [e] = parseCcvData([`${CCV}=0xdeadbeef`])
+    assert.equal(e!.ccvAddress, CCV)
+    assert.equal(e!.ccvData, '0xdeadbeef')
+  })
+
+  it('should accept repeated and comma-separated entries', () => {
+    const out = parseCcvData([`${CCV}=0xaabb,${OTHER}=0xccdd`])
+    assert.equal(out.length, 2)
+    assert.equal(out[1]!.ccvAddress, OTHER)
+  })
+
+  it('should require the CCV address, since bytes alone cannot say which CCV they are for', () => {
+    assert.throws(() => parseCcvData(['0xdeadbeef']), /must be <ccv-address>=<0x-hex>/)
+  })
+
+  it('should reject a bad address or malformed hex', () => {
+    assert.throws(() => parseCcvData(['0xNOPE=0xaabb']), /invalid CCV address/)
+    assert.throws(() => parseCcvData([`${CCV}=0xabc`]), /even digit count/)
+    assert.throws(() => parseCcvData([`${CCV}=0x`]), /non-empty/)
+    assert.throws(() => parseCcvData([`${CCV}=nothex`]), /0x-prefixed hex/)
+  })
+})

--- a/ccip-cli/src/verifiers/endpoints.ts
+++ b/ccip-cli/src/verifiers/endpoints.ts
@@ -1,0 +1,155 @@
+import type { VerifierEndpoint } from './aggregator.ts'
+
+/** Endpoints for one CCV in preference order, plus the fallback applied to unmapped CCVs. */
+export type VerifierEndpointMap = {
+  /** Lower-cased CCV address to its endpoints, in the order the user supplied them. */
+  byCcv: ReadonlyMap<string, VerifierEndpoint[]>
+  /** Endpoints given without an address, applied to any required CCV with no explicit mapping. */
+  fallback: VerifierEndpoint[]
+}
+
+const SCHEMES: Record<string, { type: 'aggregator'; tls: boolean }> = {
+  grpc: { type: 'aggregator', tls: true },
+  grpcs: { type: 'aggregator', tls: true },
+  'grpc+plaintext': { type: 'aggregator', tls: false },
+}
+
+/** Human-readable list of accepted schemes, for error messages. */
+const SCHEME_HELP =
+  'grpc:// (aggregator over TLS), grpcs:// (alias), grpc+plaintext:// (aggregator, no TLS)'
+
+/**
+ * Parse one `--verifier` entry into an endpoint, with an optional CCV address prefix.
+ *
+ * Grammar: `[<ccvAddress>=]<scheme>://<host>[:port]`. The scheme is mandatory and selects the
+ * transport and TLS: a bare `host:port` cannot express whether to use TLS, and sniffing the port
+ * is a guess that breaks when an operator runs TLS on a non-443 port.
+ *
+ * @param entry - One raw `--verifier` value
+ * @returns The CCV address it maps to (or null for the fallback) and the parsed endpoint
+ * @throws Error with actionable text when the entry is malformed
+ */
+export function parseVerifierEntry(entry: string): {
+  ccvAddress: string | null
+  endpoint: VerifierEndpoint
+} {
+  const trimmed = entry.trim()
+  if (!trimmed) throw new Error('--verifier entry is empty')
+
+  // Split on the FIRST '=' only: a URL may legally contain '=' in a query string.
+  const eq = trimmed.indexOf('=')
+  const hasAddress = eq !== -1 && !trimmed.slice(0, eq).includes('://')
+  const ccvAddress = hasAddress ? trimmed.slice(0, eq).trim() : null
+  const urlPart = hasAddress ? trimmed.slice(eq + 1).trim() : trimmed
+
+  const sep = urlPart.indexOf('://')
+  if (sep === -1) {
+    throw new Error(
+      `--verifier entry is missing a scheme: "${entry}". A bare host:port cannot say whether to ` +
+        `use TLS. Prefix it: ${SCHEME_HELP}`,
+    )
+  }
+  const scheme = urlPart.slice(0, sep).toLowerCase()
+  const target = urlPart.slice(sep + 3).replace(/\/+$/, '')
+  const known = SCHEMES[scheme]
+  if (!known) {
+    throw new Error(`--verifier entry has an unsupported scheme "${scheme}://": ${SCHEME_HELP}`)
+  }
+  if (!target) throw new Error(`--verifier entry has no host: "${entry}"`)
+
+  if (ccvAddress !== null && !/^0x[0-9a-fA-F]{40}$/.test(ccvAddress)) {
+    throw new Error(
+      `--verifier entry has an invalid CCV address "${ccvAddress}". Use the address reported by ` +
+        `\`ccip-cli show <messageId>\`, or omit it to apply one endpoint to every required CCV.`,
+    )
+  }
+
+  return {
+    ccvAddress,
+    endpoint: { type: known.type, target, tls: known.tls, raw: urlPart },
+  }
+}
+
+/**
+ * Build the endpoint map from all `--verifier` values.
+ *
+ * A repeated CCV address accumulates into a list rather than overwriting, because the order is the
+ * failover order: primary first, backup second. Entries may also be comma-separated.
+ *
+ * @param entries - Raw `--verifier` values as supplied on the command line
+ * @returns Endpoints grouped by CCV address, plus the address-less fallback list
+ */
+export function parseVerifierEndpoints(entries: readonly string[]): VerifierEndpointMap {
+  const byCcv = new Map<string, VerifierEndpoint[]>()
+  const fallback: VerifierEndpoint[] = []
+  // Split on commas here rather than only in the CLI's coerce, so a direct call behaves the same
+  // way. Otherwise a comma ends up inside a host and yields a bogus endpoint.
+  const flattened = entries.flatMap((e) => e.split(',')).map((e) => e.trim())
+  for (const entry of flattened) {
+    if (!entry) continue
+    const { ccvAddress, endpoint } = parseVerifierEntry(entry)
+    if (ccvAddress === null) {
+      fallback.push(endpoint)
+      continue
+    }
+    const key = ccvAddress.toLowerCase()
+    const existing = byCcv.get(key)
+    if (existing) existing.push(endpoint)
+    else byCcv.set(key, [endpoint])
+  }
+  return { byCcv, fallback }
+}
+
+/**
+ * Resolve the endpoints to try for one required CCV.
+ *
+ * @param map - The parsed endpoint map
+ * @param ccvAddress - The CCV address the destination requires
+ * @returns Its explicit endpoints if mapped, otherwise the address-less fallback
+ */
+export function endpointsFor(
+  map: VerifierEndpointMap,
+  ccvAddress: string,
+): readonly VerifierEndpoint[] {
+  return map.byCcv.get(ccvAddress.toLowerCase()) ?? map.fallback
+}
+
+/** A caller-supplied attestation: `<ccvAddress>=<0x-hex>`. */
+export type SuppliedCcvData = { ccvAddress: string; ccvData: string }
+
+/**
+ * Parse `--ccv-data <ccvAddress>=<0x-hex>` entries.
+ *
+ * The bottom of the source ladder: bytes obtained out of band, used when the API, the indexer and
+ * the verifier's own endpoint are all unavailable. The CCV's `verifyMessage` decides validity
+ * onchain, so wrong bytes can only waste the sender's gas, never make a bad message execute.
+ *
+ * @param entries - Raw `--ccv-data` values; comma-separated entries are split
+ * @returns One record per entry, in the order supplied
+ * @throws Error with actionable text when an entry is malformed
+ */
+export function parseCcvData(entries: readonly string[]): SuppliedCcvData[] {
+  const out: SuppliedCcvData[] = []
+  for (const raw of entries.flatMap((e) => e.split(',')).map((e) => e.trim())) {
+    if (!raw) continue
+    const eq = raw.indexOf('=')
+    if (eq === -1) {
+      throw new Error(
+        `--ccv-data entry must be <ccv-address>=<0x-hex>: "${raw}". The address says which CCV the ` +
+          `bytes belong to; without it the OffRamp cannot be told which verifier to query.`,
+      )
+    }
+    const ccvAddress = raw.slice(0, eq).trim()
+    const ccvData = raw.slice(eq + 1).trim()
+    if (!/^0x[0-9a-fA-F]{40}$/.test(ccvAddress)) {
+      throw new Error(`--ccv-data entry has an invalid CCV address "${ccvAddress}"`)
+    }
+    if (!/^0x([0-9a-fA-F]{2})*$/.test(ccvData) || ccvData === '0x') {
+      throw new Error(
+        `--ccv-data for ${ccvAddress} must be non-empty 0x-prefixed hex with an even digit count`,
+      )
+    }
+    out.push({ ccvAddress, ccvData })
+  }
+  return out
+}

--- a/ccip-cli/src/verifiers/proto/google/rpc/status.proto
+++ b/ccip-cli/src/verifiers/proto/google/rpc/status.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+package google.rpc;
+option go_package = "google.golang.org/genproto/googleapis/rpc/status;status";
+import "google/protobuf/any.proto";
+message Status {
+  int32 code = 1;
+  string message = 2;
+  repeated google.protobuf.Any details = 3;
+}

--- a/ccip-cli/src/verifiers/proto/verifier.proto
+++ b/ccip-cli/src/verifiers/proto/verifier.proto
@@ -1,0 +1,67 @@
+syntax = "proto3";
+
+package chainlink_ccv.verifier.v1;
+
+import "google/rpc/status.proto";
+
+option go_package = "github.com/smartcontractkit/chainlink-protos/chainlink-ccv/verifier/v1";
+
+service Verifier {
+  rpc GetVerifierResultsForMessage(GetVerifierResultsForMessageRequest) returns (GetVerifierResultsForMessageResponse);
+}
+
+message GetVerifierResultsForMessageRequest {
+  repeated bytes message_ids = 1;
+}
+
+message GetVerifierResultsForMessageResponse {
+  repeated VerifierResult results = 1;
+  repeated google.rpc.Status errors = 2;
+}
+
+message Message {
+  bytes sender = 1;
+  bytes data = 2;
+  bytes on_ramp_address = 3;
+  bytes token_transfer = 4;
+  bytes off_ramp_address = 5;
+  bytes dest_blob = 6;
+  bytes receiver = 7;
+  uint64 source_chain_selector = 8;
+  uint64 dest_chain_selector = 9;
+  uint64 sequence_number = 10;
+  uint32 execution_gas_limit = 11;
+  uint32 ccip_receive_gas_limit = 12;
+  uint32 finality = 13;
+  bytes ccv_and_executor_hash = 14;
+  uint32 dest_blob_length = 15;
+  uint32 token_transfer_length = 16;
+  uint32 data_length = 17;
+  uint32 receiver_length = 18;
+  uint32 sender_length = 19;
+  uint32 version = 20;
+  uint32 off_ramp_address_length = 21;
+  uint32 on_ramp_address_length = 22;
+}
+
+message VerifierResult {
+  // Message data 
+  Message message = 1;
+  // Addresses of the CCV specified for this message
+  repeated bytes message_ccv_addresses = 2;
+  // Address of the preferred executor
+  bytes message_executor_address = 3;
+  // Verification data required to execute the message on the destination (e.g. signatures)
+  bytes ccv_data = 4;
+  VerifierResultMetadata metadata = 5;  
+}
+
+message VerifierResultMetadata {
+  // Timestamp when the verifier result was created
+  int64 timestamp = 1; 
+  // Hint to easily identify the source CCV contract address
+  bytes verifier_source_address = 2;
+  // Execution hint so that executors can easily verify before writing on chain 
+  bytes verifier_dest_address = 3; 
+} 
+

--- a/ccip-sdk/src/chain.ts
+++ b/ccip-sdk/src/chain.ts
@@ -2529,6 +2529,19 @@ export abstract class Chain<F extends ChainFamily = ChainFamily> {
     offRamp: string
     message: GetRequiredCCVsMessage
   }): Promise<GetRequiredCCVsResult>
+
+  /**
+   * Read the CCV policy the destination enforces for an already-encoded message.
+   *
+   * @param opts.offRamp - Destination OffRamp address
+   * @param opts.encodedMessage - The encoded message, as emitted on the source chain
+   * @returns The required and optional CCVs, and the optional threshold
+   */
+  getCCVsForEncodedMessage?(opts: { offRamp: string; encodedMessage: BytesLike }): Promise<{
+    requiredCCVs: readonly string[]
+    optionalCCVs: readonly string[]
+    optionalThreshold: number
+  }>
 }
 
 /**

--- a/ccip-sdk/src/commits.test.ts
+++ b/ccip-sdk/src/commits.test.ts
@@ -1,12 +1,13 @@
 import './index.ts' // Register supported chains
 import assert from 'node:assert/strict'
-import { describe, it } from 'node:test'
+import { afterEach, describe, it, mock } from 'node:test'
 
 import { Interface } from 'ethers'
 import type { PickDeep } from 'type-fest'
 
 import { Chain } from './chain.ts'
-import { getOnchainCommitReport } from './commits.ts'
+import { fetchVerifications, getOnchainCommitReport } from './commits.ts'
+import { CCIPArgumentInvalidError, CCIPMessageNotVerifiedYetError } from './errors/index.ts'
 import CommitStore_1_2_ABI from './evm/abi/CommitStore_1_2.ts'
 import OffRamp_1_6_ABI from './evm/abi/OffRamp_1_6.ts'
 import { ChainFamily, networkInfo } from './networks.ts'
@@ -685,5 +686,192 @@ describe('getOnchainCommitReport', () => {
       result.report.merkleRoot,
       '0xcccc000000000000000000000000000000000000000000000000000000000000',
     )
+  })
+})
+
+const MESSAGE_ID = '0x7059dfb1000000000000000000000000000000000000000000000000000000ab'
+const INDEXER = 'https://indexer.example'
+
+/** Minimal successful indexer `/v1/verifierresults/:id` payload. */
+function indexerPayload(destAddress = '0x345AEDB0988Ff1e897c26f9ad3AE84603Ed517E2') {
+  return {
+    success: true,
+    messageID: MESSAGE_ID,
+    results: [
+      {
+        verifierResult: {
+          message_id: MESSAGE_ID,
+          message_ccv_addresses: [destAddress],
+          ccv_data: '0xdeadbeef',
+          timestamp: '2026-08-21T20:37:52.000Z',
+          verifier_source_address: '0x1111111111111111111111111111111111111111',
+          verifier_dest_address: destAddress,
+        },
+      },
+    ],
+  }
+}
+
+type FetchArgs = [input: string, init?: RequestInit]
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+describe('fetchVerifications', () => {
+  afterEach(() => {
+    mock.restoreAll()
+  })
+
+  it('should map an indexer response to VerifierResult[]', async () => {
+    const fetchFn = mock.fn((..._args: FetchArgs) =>
+      Promise.resolve(jsonResponse(indexerPayload())),
+    )
+
+    const res = await fetchVerifications(MESSAGE_ID, {
+      indexer: [INDEXER],
+      apiClient: null,
+      fetch: fetchFn as unknown as typeof globalThis.fetch,
+    })
+
+    assert.equal(res.length, 1)
+    assert.equal(res[0]!.ccvData, '0xdeadbeef')
+    assert.equal(res[0]!.destAddress, '0x345AEDB0988Ff1e897c26f9ad3AE84603Ed517E2')
+    assert.equal(res[0]!.sourceAddress, '0x1111111111111111111111111111111111111111')
+    // timestamp is seconds, not milliseconds
+    assert.equal(res[0]!.timestamp, Math.floor(Date.parse('2026-08-21T20:37:52.000Z') / 1000))
+  })
+
+  it('should use the injected fetch and hit the documented indexer path', async () => {
+    const fetchFn = mock.fn((..._args: FetchArgs) =>
+      Promise.resolve(jsonResponse(indexerPayload())),
+    )
+
+    await fetchVerifications(MESSAGE_ID, {
+      indexer: [`${INDEXER}/`], // trailing slash must be normalised away
+      apiClient: null,
+      fetch: fetchFn as unknown as typeof globalThis.fetch,
+    })
+
+    assert.equal(fetchFn.mock.callCount(), 1)
+    const url = fetchFn.mock.calls[0]!.arguments[0]
+    assert.equal(url, `${INDEXER}/v1/verifierresults/${MESSAGE_ID}`)
+  })
+
+  it('should send no credentials on the public indexer read', async () => {
+    const fetchFn = mock.fn((..._args: FetchArgs) =>
+      Promise.resolve(jsonResponse(indexerPayload())),
+    )
+
+    await fetchVerifications(MESSAGE_ID, {
+      indexer: [INDEXER],
+      apiClient: null,
+      fetch: fetchFn as unknown as typeof globalThis.fetch,
+    })
+
+    const init = fetchFn.mock.calls[0]!.arguments[1]
+    const headers = new Headers(init?.headers ?? {})
+    for (const name of ['authorization', 'x-api-key', 'x-hmac-signature', 'cookie']) {
+      assert.equal(headers.get(name), null, `unexpected ${name} header on a public read`)
+    }
+  })
+
+  it('should throw CCIPMessageNotVerifiedYetError when the indexer has no result', async () => {
+    const fetchFn = mock.fn((..._args: FetchArgs) =>
+      Promise.resolve(jsonResponse({ success: false, messageID: MESSAGE_ID, results: [] })),
+    )
+
+    await assert.rejects(
+      fetchVerifications(MESSAGE_ID, {
+        indexer: [INDEXER],
+        apiClient: null,
+        fetch: fetchFn as unknown as typeof globalThis.fetch,
+      }),
+      CCIPMessageNotVerifiedYetError,
+    )
+  })
+
+  it('should not poll when no watch signal is supplied', async () => {
+    const fetchFn = mock.fn((..._args: FetchArgs) =>
+      Promise.resolve(jsonResponse({ success: false, messageID: MESSAGE_ID, results: [] })),
+    )
+
+    await assert.rejects(
+      fetchVerifications(MESSAGE_ID, {
+        indexer: [INDEXER],
+        apiClient: null,
+        fetch: fetchFn as unknown as typeof globalThis.fetch,
+      }),
+      CCIPMessageNotVerifiedYetError,
+    )
+    // exactly one attempt: the poll loop is gated on `watch`
+    assert.equal(fetchFn.mock.callCount(), 1)
+  })
+
+  it('should retry while watch is live, then give up when it aborts', async () => {
+    const fetchFn = mock.fn((..._args: FetchArgs) =>
+      Promise.resolve(jsonResponse({ success: false, messageID: MESSAGE_ID, results: [] })),
+    )
+    const watch = AbortSignal.timeout(120)
+
+    await assert.rejects(
+      fetchVerifications(MESSAGE_ID, {
+        indexer: [INDEXER],
+        apiClient: null,
+        watch,
+        pollInterval: 20,
+        fetch: fetchFn as unknown as typeof globalThis.fetch,
+      }),
+    )
+    // polled more than once before the signal fired
+    assert.ok(
+      fetchFn.mock.callCount() > 1,
+      `expected multiple poll attempts, got ${fetchFn.mock.callCount()}`,
+    )
+  })
+
+  it('should reject a non-string indexer entry as a non-transient argument error', async () => {
+    // `--no-indexer` on the CLI's array-typed option yields [false]. Before the guard this reached
+    // `baseUrl.replace` and threw inside an async callback of Promise.any, so it was wrapped into a
+    // transient CCIPMessageNotVerifiedYetError: the caller was told to wait and retry on an invalid
+    // argument. The guard must fail fast and must NOT be classified as transient.
+    await assert.rejects(
+      fetchVerifications(MESSAGE_ID, {
+        indexer: [false] as unknown as readonly string[],
+        apiClient: null,
+      }),
+      (err: unknown) => {
+        assert.ok(
+          err instanceof CCIPArgumentInvalidError,
+          `expected CCIPArgumentInvalidError, got ${String(err)}`,
+        )
+        assert.ok(
+          !(err instanceof CCIPMessageNotVerifiedYetError),
+          'must not be mis-reported as a not-verified-yet error',
+        )
+        assert.equal(err.isTransient, false, 'must not be retryable')
+        return true
+      },
+    )
+  })
+
+  it('should return the first successful source when one indexer fails', async () => {
+    const fetchFn = mock.fn((url: string, _init?: RequestInit) =>
+      url.includes('bad')
+        ? Promise.resolve(jsonResponse({ error: 'boom' }, 500))
+        : Promise.resolve(jsonResponse(indexerPayload())),
+    )
+
+    const res = await fetchVerifications(MESSAGE_ID, {
+      indexer: ['https://bad.example', INDEXER],
+      apiClient: null,
+      fetch: fetchFn as unknown as typeof globalThis.fetch,
+    })
+
+    assert.equal(res.length, 1)
+    assert.equal(res[0]!.ccvData, '0xdeadbeef')
   })
 })

--- a/ccip-sdk/src/commits.ts
+++ b/ccip-sdk/src/commits.ts
@@ -3,10 +3,12 @@ import type { PickDeep } from 'type-fest'
 import type { CCIPAPIClient } from './api/index.ts'
 import type { Chain, ChainStatic, LogFilter } from './chain.ts'
 import {
+  CCIPArgumentInvalidError,
   CCIPCommitNotFoundError,
   CCIPHttpError,
   CCIPMessageNotVerifiedYetError,
 } from './errors/index.ts'
+import { fetchWithTimeout } from './fetch.ts'
 import { NetworkType } from './networks.ts'
 import {
   type CCIPRequest,
@@ -54,6 +56,46 @@ export type FetchVerificationsOpts = {
   watch?: AbortSignal
   /** Milliseconds between poll retries when `watch` is set (default: 5000). */
   pollInterval?: number
+  /** Custom fetch used for indexer requests; defaults to `globalThis.fetch`. */
+  fetch?: typeof globalThis.fetch
+  /** Per-request timeout in milliseconds for indexer requests (default: 30000). */
+  timeoutMs?: number
+}
+
+/**
+ * Validate that every indexer entry is a base URL string.
+ *
+ * yargs applies boolean negation regardless of the declared option type, so `--no-indexer` on the
+ * CLI's array-typed `--indexer` yields `[false]`. Rejecting it here keeps a non-string out of
+ * `baseUrl.replace` below, where it would escape as a raw `TypeError` rather than a `CCIPError` and
+ * render as a stack trace.
+ *
+ * @param indexer - Candidate indexer base URLs, unvalidated
+ * @throws {@link CCIPArgumentInvalidError} if it is not an array, or any entry is not a string
+ */
+function assertIndexerUrls(indexer: unknown): asserts indexer is readonly string[] {
+  // A bare string is iterable of strings, so a `for..of` type check alone would accept it and then
+  // fail later on `.map`. Require an actual array first.
+  if (!Array.isArray(indexer)) {
+    throw new CCIPArgumentInvalidError(
+      'indexer',
+      `expected an array of base URLs, got ${typeof indexer}`,
+      {
+        context: { indexer },
+      },
+    )
+  }
+  for (const url of indexer) {
+    if (typeof url !== 'string') {
+      throw new CCIPArgumentInvalidError(
+        'indexer',
+        `expected base URL strings, got ${typeof url}`,
+        {
+          context: { indexer },
+        },
+      )
+    }
+  }
 }
 
 /**
@@ -68,8 +110,9 @@ export type FetchVerificationsOpts = {
  *
  * @param messageId - The CCIP message ID (hex string)
  * @param opts - See {@link FetchVerificationsOpts}
- * @returns CCIPVerifications with verificationPolicy and verifier results
+ * @returns The verifier results served by the first source to respond successfully
  * @throws {@link CCIPMessageNotVerifiedYetError} if all sources fail or signal fires
+ * @throws {@link CCIPArgumentInvalidError} if `opts.indexer` contains a non-string entry
  */
 export async function fetchVerifications(
   messageId: string,
@@ -78,10 +121,14 @@ export async function fetchVerifications(
     apiClient,
     watch,
     pollInterval = 5_000,
+    fetch: fetchFn,
+    timeoutMs,
   }: FetchVerificationsOpts = {},
 ): Promise<VerifierResult[]> {
   if (indexer === NetworkType.Mainnet) indexer = MAINNET_INDEXER_URLS
   else if (indexer === NetworkType.Testnet) indexer = TESTNET_INDEXER_URLS
+
+  assertIndexerUrls(indexer)
 
   // Polling loop: retry on CCIPMessageNotVerifiedYetError only when watch is supplied.
   let lastErr
@@ -91,7 +138,11 @@ export async function fetchVerifications(
         ...(apiClient != null ? [apiClient.getVerifications(messageId, { signal: watch })] : []),
         ...indexer.map(async (baseUrl) => {
           const url = `${baseUrl.replace(/\/+$/, '')}/v1/verifierresults/${messageId}`
-          const res = await fetch(url, { signal: watch })
+          const res = await fetchWithTimeout(url, 'fetchVerifications', {
+            signal: watch,
+            fetch: fetchFn,
+            timeoutMs,
+          })
           if (!res.ok) throw new CCIPHttpError(res.status, res.statusText, { context: { url } })
           const json = (await res.json()) as IndexerResponse
           if (!json.success) throw new CCIPMessageNotVerifiedYetError(messageId)

--- a/ccip-sdk/src/evm/index.ts
+++ b/ccip-sdk/src/evm/index.ts
@@ -3070,6 +3070,37 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
   }
 
   /**
+   * Read the CCV policy the destination enforces for an already-encoded message.
+   *
+   * Calls `OffRamp.getCCVsForMessage(bytes)` with the message exactly as it was emitted, so the
+   * token transfer, extraArgs and finality it carries are the ones the policy is computed from.
+   * Reconstructing the message instead can drop the token transfer and yield the lane default.
+   *
+   * @param opts.offRamp - Destination OffRamp address
+   * @param opts.encodedMessage - The encoded message, as emitted on the source chain
+   * @returns The required and optional CCVs, and the optional threshold
+   */
+  override async getCCVsForEncodedMessage(opts: {
+    offRamp: string
+    encodedMessage: BytesLike
+  }): Promise<{
+    requiredCCVs: readonly string[]
+    optionalCCVs: readonly string[]
+    optionalThreshold: number
+  }> {
+    const contract = new Contract(
+      opts.offRamp,
+      interfaces.OffRamp_v2_0,
+      this.provider,
+    ) as unknown as TypedContract<typeof OffRamp_2_0_ABI>
+    const ccvs = await contract.getCCVsForMessage(hexlify(getDataBytes(opts.encodedMessage)))
+    const [requiredCCVs, optionalCCVs, optionalThreshold] = ccvs.map(
+      resultToObject,
+    ) as unknown as CleanAddressable<typeof ccvs>
+    return { requiredCCVs, optionalCCVs, optionalThreshold: Number(optionalThreshold) }
+  }
+
+  /**
    * Resolve the CCVs the destination OffRamp will require for a candidate message, and whether its
    * finality is accepted, via the on-chain `getCCVsForMessage(bytes)` view (a read; no send). Builds the
    * MessageV1 candidate with {@link encodeMessageV1}; a rejected finality throws

--- a/ccip-sdk/src/index.ts
+++ b/ccip-sdk/src/index.ts
@@ -95,6 +95,7 @@ export {
   type Logger,
   type MessageInput,
   type OffchainTokenData,
+  type VerifierResult,
   type WithLogger,
   CCIPVersion,
   ExecutionState,

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,6 +68,8 @@
         "@chainlink/ccip-sdk": "^1.13.0",
         "@coral-xyz/anchor": "^0.29.0",
         "@ethers-ext/signer-ledger": "^6.0.0-beta.1",
+        "@grpc/grpc-js": "^1.14.4",
+        "@grpc/proto-loader": "^0.8.1",
         "@inquirer/prompts": "8.5.2",
         "@ledgerhq/hw-app-aptos": "6.37.0",
         "@ledgerhq/hw-app-solana": "7.9.0",
@@ -6082,6 +6084,142 @@
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+      "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.8.0",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
+      "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.5.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/@grpc/proto-loader/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@hapi/address": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/@hapi/address/-/address-5.1.1.tgz",
@@ -6591,6 +6729,16 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
       }
     },
     "node_modules/@jsonjoy.com/base64": {
@@ -9151,6 +9299,63 @@
       "dependencies": {
         "@protobuf-ts/runtime": "^2.11.1"
       }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@redocly/ajv": {
       "version": "8.18.3",
@@ -18618,6 +18823,12 @@
       "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "license": "MIT"
     },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
+    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -18635,6 +18846,12 @@
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
       "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
     },
     "node_modules/longest-streak": {
       "version": "3.1.0",
@@ -24949,6 +25166,29 @@
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
       "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
       "license": "ISC"
+    },
+    "node_modules/protobufjs": {
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",


### PR DESCRIPTION
This pull request introduces major enhancements to the CCIP CLI and its documentation, focusing on flexible and robust support for CCV attestation sources during manual execution. It adds new CLI options and backend logic to fetch CCV attestations directly from verifiers or to supply them manually, ensuring messages can be executed even when attestations are not available via the default indexers or API. The CLI builder and documentation are updated to reflect these new capabilities, and tests are added to ensure correct grouping and rendering of options.

**Manual Execution & Verification Enhancements:**

- Added `--verifier`/`--verifier-endpoint` and `--ccv-data` CLI options, allowing users to fetch CCV attestations directly from verifier aggregators over gRPC or supply them out-of-band, ensuring execution is possible even when indexers lack the required CCV. The command logic ensures that these sources are used as fallbacks only when managed sources are insufficient, and prevents unverified execution that would revert onchain. [[1]](diffhunk://#diff-9b7385a4a8b934b4c3c047eb7f85e8cf4b1167e3e732954065caabf0d0d22deeR222-R294) [[2]](diffhunk://#diff-9b7385a4a8b934b4c3c047eb7f85e8cf4b1167e3e732954065caabf0d0d22deeR369-R417) [[3]](diffhunk://#diff-d031752a3dc854d38b0b2f7ba015c3d626d241205c336dfe5e0821d4656bff05R116-R164) [[4]](diffhunk://#diff-9b7385a4a8b934b4c3c047eb7f85e8cf4b1167e3e732954065caabf0d0d22deeR41) [[5]](diffhunk://#diff-9b7385a4a8b934b4c3c047eb7f85e8cf4b1167e3e732954065caabf0d0d22deeR26)

- Updated CLI option parsing and error handling to robustly process new verification flags, including improved coercion and validation for `--verifier`, `--ccv-data`, and `--indexer`.

**Documentation & CLI Builder Updates:**

- Expanded documentation for manual execution to detail the new verification source options, their formats, usage scenarios, and fallback behaviors. [[1]](diffhunk://#diff-f8054793b86b61f31b6f5670e3355675827311a85511663ce150884599dbf490R38-R85) [[2]](diffhunk://#diff-d509fd26ff682f49f0c054dcca5422c10bed45e76de696409168b0c5f5e2240bL212-R212) [[3]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR28-R29)

- Updated the CLI Builder UI to include a new "Verification Sources" group, ensuring the new options are visible and properly grouped in the interface. Added tests to guarantee correct rendering and grouping. [[1]](diffhunk://#diff-91fd72e2e3d04038423a0eb30bdf532c4dbb598118b6446d6092cacf2ec9d721R28-R56) [[2]](diffhunk://#diff-c12b5a66d6bc0194d0d25e3e729b3c985f2b459ed4570c56359fa67cf4f86893R54-R57) [[3]](diffhunk://#diff-2e37d950b8c9ec963fb3efd2dc511b970d563eb090c4139fe9212c283838d034L138-R139) [[4]](diffhunk://#diff-2e37d950b8c9ec963fb3efd2dc511b970d563eb090c4139fe9212c283838d034R23) [[5]](diffhunk://#diff-7a4272b06f8bed5b1b2f7059561b8a9c7175090df41098875758f6d937a846a0R1-R16) [[6]](diffhunk://#diff-1bfb49d5a9e9ec02b551b0f2b0e393e3594242650d761bcad513b4649d47b3b2R1-R15)

**Build & Dependency Changes:**

- Added new dependencies for gRPC support (`@grpc/grpc-js`, `@grpc/proto-loader`) and updated the build process to include necessary protocol buffer assets. [[1]](diffhunk://#diff-519884ba22c306f1ee7807a3c4296720af372fa1175f9b75350d8f55aea9088bR58-R59) [[2]](diffhunk://#diff-519884ba22c306f1ee7807a3c4296720af372fa1175f9b75350d8f55aea9088bL31-R36)

These changes significantly improve the flexibility and reliability of CCIP manual execution, especially for advanced or recovery scenarios where attestations are not available from standard sources.