### PR TITLE
fix(cli): accept an empty keystore password as valid, not missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `getMessageById` and `getExecutionReceipts` accept `since` too
 - Aptos: fix `getLogs` never emitting the event exactly at a full page boundary, and no longer split a ledger version's events across rounds on multi-topic streams
 - TON: remove the per-address `getTransactions` window cache (made redundant by `since`); long-lived watch streams no longer retain parsed account history in memory
+- CLI: a passwordless Foundry keystore (or JSON wallet) can be unlocked with `--no-interactive` by setting the password variable to an empty value; only an unset variable is treated as missing
 
 ## [1.12.0] - 2026-08-19
 

--- a/ccip-api-ref/docs-cli/configuration.mdx
+++ b/ccip-api-ref/docs-cli/configuration.mdx
@@ -164,6 +164,17 @@ Password resolution order:
 
 The keystore directory defaults to `~/.foundry/keystores/` and can be overridden with `$FOUNDRY_DIR`.
 
+A **passwordless** keystore (imported with `cast wallet import --unsafe-password ""`) is unlocked with the
+empty string, which is a real password rather than a missing one. Set the variable to an empty value to use
+one with `--no-interactive`:
+
+```bash
+FOUNDRY_KEYSTORE_PASSWORD="" ccip-cli send ... --wallet foundry:sender --no-interactive
+```
+
+Leaving the variable **unset** is different: with `--no-interactive` there is nothing to unlock with, so the
+command fails with `INTERACTIVE_REQUIRED` instead of guessing.
+
 ### Hardhat Keystore
 
 If you manage keys with [Hardhat's built-in keystore](https://hardhat.org/hardhat-runner/docs/guides/configuration-variables), use `hardhat:<name>`. The CLI runs `node_modules/.bin/hardhat keystore get` directly, so Hardhat must be installed as a dev dependency in your project:
@@ -181,6 +192,9 @@ Password resolution order:
 1. `$HARDHAT_KEYSTORE_PASSWORD` env var (piped silently to Hardhat)
 2. `$USER_KEY_PASSWORD` env var (piped silently to Hardhat)
 3. Interactive prompt (ccip-cli prompts, answer is piped to Hardhat)
+
+Hardhat decrypts the keystore itself and requires a password of at least 8 characters when one is created,
+so there is no passwordless Hardhat keystore. The CLI forwards whatever you set and lets Hardhat judge it.
 
 ### Ledger Hardware Wallet
 

--- a/ccip-cli/src/providers/evm.test.ts
+++ b/ccip-cli/src/providers/evm.test.ts
@@ -1,0 +1,139 @@
+import assert from 'node:assert/strict'
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { after, before, beforeEach, describe, it } from 'node:test'
+
+import { Wallet } from 'ethers'
+
+import { loadEvmWallet } from './evm.ts'
+
+// A passwordless keystore is encrypted with the empty string. Foundry creates these routinely
+// (`cast wallet import --unsafe-password ""`), and they are what `--no-interactive` must accept.
+const TEST_KEY = '0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d'
+const TEST_ADDRESS = '0x70997970C51812dc3A010C7d01b50e0d17dc79C8'
+
+const PASSWORD_VARS = [
+  'FOUNDRY_KEYSTORE_PASSWORD',
+  'HARDHAT_KEYSTORE_PASSWORD',
+  'USER_KEY_PASSWORD',
+] as const
+
+let tmp: string
+let foundryDir: string
+let jsonWalletPath: string
+const savedEnv = new Map<string, string | undefined>()
+const savedCwd = process.cwd()
+
+before(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'ccip-cli-keystore-'))
+  foundryDir = join(tmp, 'foundry')
+  mkdirSync(join(foundryDir, 'keystores'), { recursive: true })
+
+  // Encrypted with "" once and reused by every case: scrypt makes each encrypt/decrypt costly.
+  const keystoreJson = new Wallet(TEST_KEY).encryptSync('')
+  writeFileSync(join(foundryDir, 'keystores', 'passwordless'), keystoreJson)
+  jsonWalletPath = join(tmp, 'wallet.json')
+  writeFileSync(jsonWalletPath, keystoreJson)
+
+  for (const key of [...PASSWORD_VARS, 'FOUNDRY_DIR']) savedEnv.set(key, process.env[key])
+  process.env['FOUNDRY_DIR'] = foundryDir
+})
+
+after(() => {
+  for (const [key, value] of savedEnv) {
+    if (value === undefined) delete process.env[key]
+    else process.env[key] = value
+  }
+  process.chdir(savedCwd)
+  rmSync(tmp, { recursive: true, force: true })
+})
+
+beforeEach(() => {
+  for (const key of PASSWORD_VARS) delete process.env[key]
+})
+
+describe('Foundry keystore', () => {
+  it('should unlock a passwordless keystore when the password is set to the empty string', async () => {
+    // The bug: `!pw` treated "" as missing, so a passwordless keystore could not be used at all
+    // with --no-interactive. "" is the keystore's real password, not an absent one.
+    process.env['FOUNDRY_KEYSTORE_PASSWORD'] = ''
+    const signer = await loadEvmWallet(null as never, {
+      wallet: 'foundry:passwordless',
+      interactive: false,
+    })
+    assert.equal(await signer.getAddress(), TEST_ADDRESS)
+  })
+
+  it('should still refuse when the password is genuinely unset', async () => {
+    // The fix must not turn "missing" into "empty": an unset variable has nothing to unlock with.
+    await assert.rejects(
+      () => loadEvmWallet(null as never, { wallet: 'foundry:passwordless', interactive: false }),
+      { name: 'CCIPInteractiveRequiredError' },
+    )
+  })
+
+  it('should accept the empty password from USER_KEY_PASSWORD too', async () => {
+    process.env['USER_KEY_PASSWORD'] = ''
+    const signer = await loadEvmWallet(null as never, {
+      wallet: 'foundry:passwordless',
+      interactive: false,
+    })
+    assert.equal(await signer.getAddress(), TEST_ADDRESS)
+  })
+})
+
+describe('JSON wallet file', () => {
+  it('should unlock with an empty USER_KEY_PASSWORD under --no-interactive', async () => {
+    process.env['USER_KEY_PASSWORD'] = ''
+    const signer = await loadEvmWallet(null as never, {
+      wallet: jsonWalletPath,
+      interactive: false,
+    })
+    assert.equal(await signer.getAddress(), TEST_ADDRESS)
+  })
+
+  it('should still refuse when USER_KEY_PASSWORD is unset', async () => {
+    await assert.rejects(
+      () => loadEvmWallet(null as never, { wallet: jsonWalletPath, interactive: false }),
+      { name: 'CCIPInteractiveRequiredError' },
+    )
+  })
+})
+
+describe('Hardhat keystore', () => {
+  // Hardhat decrypts the keystore itself; ccip-cli only forwards the password to it. These cover
+  // the forwarding contract, not whether Hardhat accepts a given password (it rejects passwords
+  // shorter than 8 characters at creation time, so a passwordless Hardhat keystore cannot exist).
+  let projectDir: string
+
+  before(() => {
+    projectDir = join(tmp, 'hardhat-project')
+    mkdirSync(join(projectDir, 'node_modules', '.bin'), { recursive: true })
+    const fakeBin = join(projectDir, 'node_modules', '.bin', 'hardhat')
+    // Records what was piped in, then returns the key so the success path can be asserted.
+    writeFileSync(
+      fakeBin,
+      `#!/bin/sh\ncat > "${join(projectDir, 'stdin.txt')}"\necho "${TEST_KEY}"\n`,
+    )
+    chmodSync(fakeBin, 0o755)
+  })
+
+  it('should forward an empty password instead of rejecting it as missing', async () => {
+    process.chdir(projectDir)
+    process.env['HARDHAT_KEYSTORE_PASSWORD'] = ''
+    const signer = await loadEvmWallet(null as never, {
+      wallet: 'hardhat:acct',
+      interactive: false,
+    })
+    assert.equal(await signer.getAddress(), TEST_ADDRESS)
+  })
+
+  it('should still refuse when the password is genuinely unset', async () => {
+    process.chdir(projectDir)
+    await assert.rejects(
+      () => loadEvmWallet(null as never, { wallet: 'hardhat:acct', interactive: false }),
+      { name: 'CCIPInteractiveRequiredError' },
+    )
+  })
+})

--- a/ccip-cli/src/providers/evm.ts
+++ b/ccip-cli/src/providers/evm.ts
@@ -53,7 +53,10 @@ const KEYSTORE_PROVIDERS: Record<
         )
       }
       let pw = process.env['FOUNDRY_KEYSTORE_PASSWORD'] ?? process.env['USER_KEY_PASSWORD']
-      if (!pw && interactive === false) {
+      // A passwordless keystore is unlocked with the empty string (""), which is a valid password,
+      // not a missing one. Only `undefined` (env var unset) is genuinely missing, so gate on that;
+      // `!pw` wrongly rejected "" and made passwordless keystores unusable with --no-interactive.
+      if (pw === undefined && interactive === false) {
         throw new CCIPInteractiveRequiredError(
           'Keystore password required but --no-interactive is set',
           { recovery: 'Set FOUNDRY_KEYSTORE_PASSWORD or USER_KEY_PASSWORD environment variable' },
@@ -74,7 +77,8 @@ const KEYSTORE_PROVIDERS: Record<
         )
       }
       let pw = process.env['HARDHAT_KEYSTORE_PASSWORD'] ?? process.env['USER_KEY_PASSWORD']
-      if (!pw && interactive === false) {
+      // "" is a valid (empty) password; only an unset env var (undefined) is genuinely missing.
+      if (pw === undefined && interactive === false) {
         throw new CCIPInteractiveRequiredError(
           'Keystore password required but --no-interactive is set',
           { recovery: 'Set HARDHAT_KEYSTORE_PASSWORD or USER_KEY_PASSWORD environment variable' },
@@ -152,13 +156,14 @@ export async function loadEvmWallet(
   }
   if (existsSync(walletOpt)) {
     let pw = process.env['USER_KEY_PASSWORD']
-    if (!pw && interactive === false) {
+    // "" is a valid (empty) password; only an unset env var (undefined) is genuinely missing.
+    if (pw === undefined && interactive === false) {
       throw new CCIPInteractiveRequiredError(
         'JSON wallet password required but --no-interactive is set',
         { recovery: 'Set USER_KEY_PASSWORD environment variable' },
       )
     }
-    if (!pw) pw = await password({ message: 'Enter password for json wallet' })
+    if (pw === undefined) pw = await password({ message: 'Enter password for json wallet' })
     return (await Wallet.fromEncryptedJson(await readFile(walletOpt, 'utf8'), pw)).connect(provider)
   }
   return new BaseWallet(


### PR DESCRIPTION
This pull request improves support for passwordless keystores (those encrypted with an empty string as a password) in the CLI and its documentation. Previously, the CLI could not unlock such keystores in non-interactive mode because it treated an empty password as missing. The changes ensure that an empty string is accepted as a valid password, only treating an unset environment variable as missing. Comprehensive tests and documentation updates are included.

**Bug Fixes and Feature Improvements:**

* Accept empty string as a valid keystore password in non-interactive mode for Foundry keystores, JSON wallets, and Hardhat keystores, fixing the inability to unlock passwordless keystores with `--no-interactive`. [[1]](diffhunk://#diff-94efe9a70f8474b229514f407ec81a5eb118ead13e0a8e786a8df145eda1ec08L56-R59) [[2]](diffhunk://#diff-94efe9a70f8474b229514f407ec81a5eb118ead13e0a8e786a8df145eda1ec08L77-R81) [[3]](diffhunk://#diff-94efe9a70f8474b229514f407ec81a5eb118ead13e0a8e786a8df145eda1ec08L155-R166)

**Testing:**

* Added comprehensive tests in `ccip-cli/src/providers/evm.test.ts` to verify correct handling of passwordless keystores and empty passwords for Foundry, JSON, and Hardhat wallets.

**Documentation:**

* Updated CLI documentation to explain how to use passwordless keystores with the empty password string and clarify the difference between an empty and unset password variable.
* Clarified that Hardhat keystores cannot be passwordless and described how the CLI forwards passwords to Hardhat.

**Changelog:**

* Added a changelog entry describing support for unlocking passwordless Foundry keystores and JSON wallets by setting the password variable to an empty value.