### PR TITLE
fix(cct-sdk): Refactor and expand Solana CCT unit tests

### DIFF
--- a/ccip-sdk/src/cct/solana/index.test.ts
+++ b/ccip-sdk/src/cct/solana/index.test.ts
@@ -1,13 +1,22 @@
 import assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 
-import { Connection } from '@solana/web3.js'
+import { BorshAccountsCoder } from '@coral-xyz/anchor'
+import { TOKEN_PROGRAM_ID } from '@solana/spl-token'
+import { Connection, Keypair, PublicKey } from '@solana/web3.js'
 
 import { SolanaChain } from '../../solana/index.ts'
+import { deriveTokenAdminRegistryPda } from './programs/router.ts'
+import {
+  TOKEN_POOL_PROGRAMS,
+  deriveTokenPoolConfigPda,
+  deriveTokenPoolSignerPda,
+} from './programs/token-pool.ts'
 import type {
   GetTokenPoolStateParams,
   GetTokenPoolStateResult,
 } from './token-pool/operations/index.ts'
+import { METADATA_PROGRAM_ID } from './token/constants.ts'
 import {
   type RegisterAdminMethod,
   type TokenAuthorityType,
@@ -25,78 +34,6 @@ function stubChain(): SolanaChain {
 }
 
 describe('SolanaTokenManager (cct/solana)', () => {
-  it('fromChain exposes flat Solana CCT operations', () => {
-    const chain = stubChain()
-    const cct = SolanaTokenManager.fromChain(chain)
-    assert.equal(cct.chain, chain)
-    assert.equal(cct.provider, chain.connection)
-    // Token operations
-    assert.equal(typeof cct.generateUnsignedDeployToken, 'function')
-    assert.equal(typeof cct.deployToken, 'function')
-    assert.equal(typeof cct.generateUnsignedApproveToken, 'function')
-    assert.equal(typeof cct.approveToken, 'function')
-    assert.equal(typeof cct.generateUnsignedCreateTokenAccount, 'function')
-    assert.equal(typeof cct.createTokenAccount, 'function')
-    assert.equal(typeof cct.generateUnsignedMintTokens, 'function')
-    assert.equal(typeof cct.mintTokens, 'function')
-    assert.equal(typeof cct.generateUnsignedSetTokenAuthority, 'function')
-    assert.equal(typeof cct.setTokenAuthority, 'function')
-    assert.equal(typeof cct.generateUnsignedUpdateMetadataAuthority, 'function')
-    assert.equal(typeof cct.updateMetadataAuthority, 'function')
-
-    // Token admin registry operations
-    assert.equal(typeof cct.generateUnsignedAcceptAdmin, 'function')
-    assert.equal(typeof cct.acceptAdmin, 'function')
-    assert.equal(typeof cct.generateUnsignedCreateLookupTable, 'function')
-    assert.equal(typeof cct.createLookupTable, 'function')
-    assert.equal(typeof cct.generateUnsignedAppendToLookupTable, 'function')
-    assert.equal(typeof cct.appendToLookupTable, 'function')
-    assert.equal(typeof cct.generateUnsignedRegisterAdmin, 'function')
-    assert.equal(typeof cct.registerAdmin, 'function')
-    assert.equal(typeof cct.generateUnsignedSetPool, 'function')
-    assert.equal(typeof cct.setPool, 'function')
-    assert.equal(typeof cct.generateUnsignedTransferAdmin, 'function')
-    assert.equal(typeof cct.transferAdmin, 'function')
-    assert.equal(typeof cct.getTokenAdminRegistry, 'function')
-    assert.equal(typeof cct.getSupportedTokens, 'function')
-
-    // Token pool operations
-    assert.equal(typeof cct.generateUnsignedAppendRemotePoolAddresses, 'function')
-    assert.equal(typeof cct.appendRemotePoolAddresses, 'function')
-    assert.equal(typeof cct.generateUnsignedApplyChainUpdates, 'function')
-    assert.equal(typeof cct.applyChainUpdates, 'function')
-    assert.equal(typeof cct.generateUnsignedConfigureAllowlist, 'function')
-    assert.equal(typeof cct.configureAllowlist, 'function')
-    assert.equal(typeof cct.generateUnsignedCreateTokenMultisig, 'function')
-    assert.equal(typeof cct.createTokenMultisig, 'function')
-    assert.equal(typeof cct.generateUnsignedDeployTokenPool, 'function')
-    assert.equal(typeof cct.deployTokenPool, 'function')
-    assert.equal(typeof cct.generateUnsignedDeleteChainRemoteConfig, 'function')
-    assert.equal(typeof cct.deleteChainRemoteConfig, 'function')
-    assert.equal(typeof cct.generateUnsignedSetCanAcceptLiquidity, 'function')
-    assert.equal(typeof cct.setCanAcceptLiquidity, 'function')
-    assert.equal(typeof cct.generateUnsignedSetChainRateLimit, 'function')
-    assert.equal(typeof cct.setChainRateLimit, 'function')
-    assert.equal(typeof cct.generateUnsignedSetRateLimitAdmin, 'function')
-    assert.equal(typeof cct.setRateLimitAdmin, 'function')
-    assert.equal(typeof cct.generateUnsignedProvideLiquidity, 'function')
-    assert.equal(typeof cct.provideLiquidity, 'function')
-    assert.equal(typeof cct.generateUnsignedWithdrawLiquidity, 'function')
-    assert.equal(typeof cct.withdrawLiquidity, 'function')
-    assert.equal(typeof cct.generateUnsignedSetRebalancer, 'function')
-    assert.equal(typeof cct.setRebalancer, 'function')
-    assert.equal(typeof cct.generateUnsignedTransferOwnership, 'function')
-    assert.equal(typeof cct.transferOwnership, 'function')
-    assert.equal(typeof cct.generateUnsignedAcceptOwnership, 'function')
-    assert.equal(typeof cct.acceptOwnership, 'function')
-    assert.equal(typeof cct.generateUnsignedEditChainRemoteConfig, 'function')
-    assert.equal(typeof cct.editChainRemoteConfig, 'function')
-    assert.equal(typeof cct.generateUnsignedRemoveFromAllowlist, 'function')
-    assert.equal(typeof cct.removeFromAllowlist, 'function')
-    assert.equal(typeof cct.getTokenPoolRemotes, 'function')
-    assert.equal(typeof cct.getTokenPoolState, 'function')
-  })
-
   it('exports public CCT constants', () => {
     const authorityType: TokenAuthorityType = TOKEN_AUTHORITY_TYPES.MINT
     const method: RegisterAdminMethod = REGISTRATION_METHODS.OWNER
@@ -142,5 +79,596 @@ describe('SolanaTokenManager (cct/solana)', () => {
       cct.getTokenPoolState(opts)
 
     assert.equal(typeof read, 'function')
+  })
+
+  describe('facade operations', () => {
+    const payer = Keypair.generate().publicKey.toBase58()
+    const mint = Keypair.generate().publicKey.toBase58()
+    const pool = Keypair.generate().publicKey.toBase58()
+    const account = Keypair.generate().publicKey.toBase58()
+    const reader = Keypair.generate().publicKey.toBase58()
+    const remoteChainSelector = 5009297550715157269n
+
+    function chain(): SolanaChain {
+      const mintAccount = Buffer.alloc(82)
+      mintAccount.writeUInt32LE(1, 0)
+      new PublicKey(payer).toBuffer().copy(mintAccount, 4)
+      mintAccount[44] = 6
+      mintAccount[45] = 1
+      const tokenAccount = Buffer.alloc(165)
+      new PublicKey(mint).toBuffer().copy(tokenAccount, 0)
+      new PublicKey(payer).toBuffer().copy(tokenAccount, 32)
+      tokenAccount.writeBigUInt64LE(1n, 64)
+      tokenAccount.writeUInt32LE(1, 72)
+      deriveTokenPoolSignerPda(
+        new PublicKey(TOKEN_POOL_PROGRAMS['lock-release']),
+        new PublicKey(mint),
+      )
+        .toBuffer()
+        .copy(tokenAccount, 76)
+      tokenAccount[108] = 1
+      tokenAccount.writeBigUInt64LE(1n, 121)
+      const poolProgram = new PublicKey(TOKEN_POOL_PROGRAMS['lock-release'])
+      const poolStateAddress = deriveTokenPoolConfigPda(poolProgram, new PublicKey(mint))
+      const registryAddress = deriveTokenAdminRegistryPda(
+        new PublicKey(account),
+        new PublicKey(mint),
+      )
+      const readerRegistryAddress = deriveTokenAdminRegistryPda(
+        new PublicKey(pool),
+        new PublicKey(mint),
+      )
+      const registry = Buffer.alloc(170)
+      BorshAccountsCoder.accountDiscriminator('TokenAdminRegistry').copy(registry)
+      registry[8] = 2
+      new PublicKey(payer).toBuffer().copy(registry, 9)
+      new PublicKey(payer).toBuffer().copy(registry, 41)
+      new PublicKey(account).toBuffer().copy(registry, 73)
+      registry[120] = 0x19
+      new PublicKey(mint).toBuffer().copy(registry, 137)
+      registry[169] = 1
+      const [metadataAddress] = PublicKey.findProgramAddressSync(
+        [Buffer.from('metadata'), METADATA_PROGRAM_ID.toBuffer(), new PublicKey(mint).toBuffer()],
+        METADATA_PROGRAM_ID,
+      )
+      const metadata = Buffer.concat([
+        Buffer.from([4]),
+        new PublicKey(payer).toBuffer(),
+        new PublicKey(mint).toBuffer(),
+        Buffer.alloc(14),
+        Buffer.from([0, 0, 1, 0, 0, 0, 0, 0]),
+      ])
+      const poolState = Buffer.concat([
+        BorshAccountsCoder.accountDiscriminator('State'),
+        Buffer.from([1]),
+        poolProgram.toBuffer(),
+        new PublicKey(mint).toBuffer(),
+        Buffer.from([6]),
+        ...Array.from({ length: 8 }, () => new PublicKey(payer).toBuffer()),
+        Buffer.from([1, 1, 0, 0, 0, 0]),
+        new PublicKey(payer).toBuffer(),
+        new PublicKey(payer).toBuffer(),
+        new PublicKey(payer).toBuffer(),
+      ])
+      const accounts = new Map([
+        [new PublicKey(mint).toBase58(), { owner: TOKEN_PROGRAM_ID, data: mintAccount }],
+        [metadataAddress.toBase58(), { owner: METADATA_PROGRAM_ID, data: metadata }],
+        [poolStateAddress.toBase58(), { owner: poolProgram, data: poolState }],
+        [registryAddress.toBase58(), null],
+        [readerRegistryAddress.toBase58(), { data: registry }],
+      ])
+      const defaultAccount = { owner: TOKEN_PROGRAM_ID, data: tokenAccount }
+
+      return {
+        logger: { debug() {}, info() {}, warn() {}, error() {} },
+        connection: {
+          rpcEndpoint: 'http://localhost:8899',
+          getAccountInfo: async (address: PublicKey) => {
+            const key = address.toBase58()
+            return accounts.has(key) ? accounts.get(key) : defaultAccount
+          },
+          getMinimumBalanceForRentExemption: async () => 1,
+          getSlot: async () => 1,
+          getAddressLookupTable: async () => ({
+            value: {
+              state: {
+                authority: new PublicKey(payer),
+                addresses: [
+                  PublicKey.default,
+                  PublicKey.default,
+                  PublicKey.default,
+                  new PublicKey(pool),
+                ],
+              },
+            },
+          }),
+          simulateTransaction: async () => ({ value: { err: null, logs: [], unitsConsumed: 1 } }),
+          getLatestBlockhash: async () => ({
+            blockhash: PublicKey.default.toBase58(),
+            lastValidBlockHeight: 1,
+          }),
+          sendTransaction: async () => PublicKey.default.toBase58(),
+          confirmTransaction: async () => ({ value: { err: null } }),
+        },
+        getTokenAdminRegistryFor: async (address: string) => (address === reader ? pool : account),
+        getSupportedTokens: async () => [mint],
+        getTokenPoolRemotes: async () => ({}),
+        getRegistryTokenConfig: async () => ({ administrator: payer, pendingAdministrator: payer }),
+      } as unknown as SolanaChain
+    }
+
+    const facadeChain = chain()
+
+    it('runs every unsigned facade operation', async () => {
+      const cct = SolanaTokenManager.fromChain(facadeChain)
+      const common = {
+        payer,
+        tokenAddress: mint,
+        authority: payer,
+        poolType: 'lock-release' as const,
+      }
+      const cases: Array<
+        [string, () => Promise<{ instructions: unknown[] } | { instructions: unknown[] }[]>]
+      > = [
+        [
+          'deployToken',
+          () => cct.generateUnsignedDeployToken({ payer, decimals: 6, withMetaplex: false }),
+        ],
+        [
+          'approveToken',
+          () => cct.generateUnsignedApproveToken({ ...common, delegate: account, amount: 1n }),
+        ],
+        [
+          'createTokenAccount',
+          () =>
+            cct.generateUnsignedCreateTokenAccount({
+              payer,
+              tokenAddress: mint,
+              ownerAddress: account,
+            }),
+        ],
+        [
+          'mintTokens',
+          () => cct.generateUnsignedMintTokens({ ...common, recipient: account, amount: 1n }),
+        ],
+        [
+          'setTokenAuthority',
+          () =>
+            cct.generateUnsignedSetTokenAuthority({
+              ...common,
+              newAuthority: account,
+              authorityTypes: ['mint'],
+            }),
+        ],
+        [
+          'updateMetadataAuthority',
+          () => cct.generateUnsignedUpdateMetadataAuthority({ ...common, newAuthority: account }),
+        ],
+        [
+          'createTokenMultisig',
+          () =>
+            cct.generateUnsignedCreateTokenMultisig({
+              payer,
+              tokenAddress: mint,
+              poolType: 'lock-release',
+              threshold: 1,
+            }),
+        ],
+        [
+          'createLookupTable',
+          () =>
+            cct.generateUnsignedCreateLookupTable({ payer, authority: payer, mode: 'createEmpty' }),
+        ],
+        [
+          'configureAllowlist',
+          () =>
+            cct.generateUnsignedConfigureAllowlist({ ...common, add: [account], enabled: true }),
+        ],
+        ['deployTokenPool', () => cct.generateUnsignedDeployTokenPool(common)],
+        [
+          'applyChainUpdates',
+          () =>
+            cct.generateUnsignedApplyChainUpdates({
+              ...common,
+              remoteChainSelectorsToRemove: [],
+              chainsToAdd: [
+                {
+                  remoteChainSelector,
+                  remoteTokenAddress: '0x01',
+                  remotePoolAddresses: ['0x02'],
+                  remoteTokenDecimals: 6,
+                  inboundRateLimiterConfig: { enabled: false },
+                  outboundRateLimiterConfig: { enabled: false },
+                },
+              ],
+            }),
+        ],
+        [
+          'appendRemotePoolAddresses',
+          () =>
+            cct.generateUnsignedAppendRemotePoolAddresses({
+              ...common,
+              remoteChainSelector,
+              remotePoolAddresses: ['0x01'],
+            }),
+        ],
+        [
+          'initChainRemoteConfig',
+          () =>
+            cct.generateUnsignedInitChainRemoteConfig({
+              ...common,
+              remoteChainSelector,
+              remoteTokenAddress: '0x01',
+              remoteTokenDecimals: 6,
+            }),
+        ],
+        [
+          'deleteChainRemoteConfig',
+          () => cct.generateUnsignedDeleteChainRemoteConfig({ ...common, remoteChainSelector }),
+        ],
+        [
+          'setRateLimitAdmin',
+          () => cct.generateUnsignedSetRateLimitAdmin({ ...common, newRateLimitAdmin: account }),
+        ],
+        ['provideLiquidity', () => cct.generateUnsignedProvideLiquidity({ ...common, amount: 1n })],
+        [
+          'withdrawLiquidity',
+          () => cct.generateUnsignedWithdrawLiquidity({ ...common, amount: 1n }),
+        ],
+        [
+          'setCanAcceptLiquidity',
+          () => cct.generateUnsignedSetCanAcceptLiquidity({ ...common, allow: true }),
+        ],
+        [
+          'setRebalancer',
+          () => cct.generateUnsignedSetRebalancer({ ...common, rebalancer: account }),
+        ],
+        [
+          'transferOwnership',
+          () => cct.generateUnsignedTransferOwnership({ ...common, newOwner: account }),
+        ],
+        ['acceptOwnership', () => cct.generateUnsignedAcceptOwnership(common)],
+        [
+          'setChainRateLimit',
+          () =>
+            cct.generateUnsignedSetChainRateLimit({
+              ...common,
+              remoteChainSelector,
+              inbound: { enabled: false },
+              outbound: { enabled: false },
+            }),
+        ],
+        [
+          'editChainRemoteConfig',
+          () =>
+            cct.generateUnsignedEditChainRemoteConfig({
+              ...common,
+              remoteChainSelector,
+              remoteTokenAddress: '0x01',
+              remotePoolAddresses: ['0x02'],
+              remoteTokenDecimals: 6,
+            }),
+        ],
+        [
+          'appendToLookupTable',
+          () =>
+            cct.generateUnsignedAppendToLookupTable({
+              payer,
+              lookupTableAddress: account,
+              additionalAddresses: [mint],
+            }),
+        ],
+        ['acceptAdmin', () => cct.generateUnsignedAcceptAdmin({ ...common, address: account })],
+        ['registerAdmin', () => cct.generateUnsignedRegisterAdmin({ ...common, address: account })],
+        [
+          'removeFromAllowlist',
+          () => cct.generateUnsignedRemoveFromAllowlist({ ...common, remove: [account] }),
+        ],
+        [
+          'setPool',
+          () =>
+            cct.generateUnsignedSetPool({
+              ...common,
+              address: account,
+              poolLookupTableAddress: account,
+            }),
+        ],
+        [
+          'transferAdmin',
+          () =>
+            cct.generateUnsignedTransferAdmin({ ...common, address: account, newAdmin: account }),
+        ],
+      ]
+
+      for (const [name, operation] of cases) {
+        const result = await operation()
+        assert.ok(
+          (Array.isArray(result) ? result[0] : result)?.instructions.length,
+          `${name} returns instructions`,
+        )
+      }
+    })
+
+    it('runs every signed facade operation', async () => {
+      const cct = SolanaTokenManager.fromChain(facadeChain)
+      const wallet = { publicKey: new PublicKey(payer), signTransaction: async <T>(tx: T) => tx }
+      const signed: Array<
+        [string, () => Promise<{ hash: string } | { hash: string }[] | { hashes: string[] }>]
+      > = [
+        ['deployToken', () => cct.deployToken({ wallet, decimals: 6, withMetaplex: false })],
+        [
+          'approveToken',
+          () => cct.approveToken({ wallet, tokenAddress: mint, delegate: account, amount: 1n }),
+        ],
+        [
+          'createTokenAccount',
+          () => cct.createTokenAccount({ wallet, tokenAddress: mint, ownerAddress: account }),
+        ],
+        [
+          'mintTokens',
+          () => cct.mintTokens({ wallet, tokenAddress: mint, recipient: account, amount: 1n }),
+        ],
+        [
+          'setTokenAuthority',
+          () =>
+            cct.setTokenAuthority({
+              wallet,
+              tokenAddress: mint,
+              newAuthority: account,
+              authorityTypes: ['mint'],
+            }),
+        ],
+        [
+          'updateMetadataAuthority',
+          () => cct.updateMetadataAuthority({ wallet, tokenAddress: mint, newAuthority: account }),
+        ],
+        [
+          'createTokenMultisig',
+          () =>
+            cct.createTokenMultisig({
+              wallet,
+              tokenAddress: mint,
+              poolType: 'lock-release',
+              threshold: 1,
+            }),
+        ],
+        ['createLookupTable', () => cct.createLookupTable({ wallet, mode: 'createEmpty' })],
+        [
+          'configureAllowlist',
+          () =>
+            cct.configureAllowlist({
+              wallet,
+              tokenAddress: mint,
+              poolType: 'lock-release',
+              add: [account],
+              enabled: true,
+            }),
+        ],
+        [
+          'deployTokenPool',
+          () => cct.deployTokenPool({ wallet, tokenAddress: mint, poolType: 'lock-release' }),
+        ],
+        [
+          'applyChainUpdates',
+          () =>
+            cct.applyChainUpdates({
+              wallet,
+              tokenAddress: mint,
+              poolType: 'lock-release',
+              remoteChainSelectorsToRemove: [],
+              chainsToAdd: [
+                {
+                  remoteChainSelector,
+                  remoteTokenAddress: '0x01',
+                  remotePoolAddresses: ['0x02'],
+                  remoteTokenDecimals: 6,
+                  inboundRateLimiterConfig: { enabled: false },
+                  outboundRateLimiterConfig: { enabled: false },
+                },
+              ],
+            }),
+        ],
+        [
+          'appendRemotePoolAddresses',
+          () =>
+            cct.appendRemotePoolAddresses({
+              wallet,
+              tokenAddress: mint,
+              poolType: 'lock-release',
+              remoteChainSelector,
+              remotePoolAddresses: ['0x01'],
+            }),
+        ],
+        [
+          'initChainRemoteConfig',
+          () =>
+            cct.initChainRemoteConfig({
+              wallet,
+              tokenAddress: mint,
+              poolType: 'lock-release',
+              remoteChainSelector,
+              remoteTokenAddress: '0x01',
+              remoteTokenDecimals: 6,
+            }),
+        ],
+        [
+          'deleteChainRemoteConfig',
+          () =>
+            cct.deleteChainRemoteConfig({
+              wallet,
+              tokenAddress: mint,
+              poolType: 'lock-release',
+              remoteChainSelector,
+            }),
+        ],
+        [
+          'setRateLimitAdmin',
+          () =>
+            cct.setRateLimitAdmin({
+              wallet,
+              tokenAddress: mint,
+              poolType: 'lock-release',
+              newRateLimitAdmin: account,
+            }),
+        ],
+        [
+          'provideLiquidity',
+          () =>
+            cct.provideLiquidity({
+              wallet,
+              tokenAddress: mint,
+              poolType: 'lock-release',
+              amount: 1n,
+            }),
+        ],
+        [
+          'withdrawLiquidity',
+          () =>
+            cct.withdrawLiquidity({
+              wallet,
+              tokenAddress: mint,
+              poolType: 'lock-release',
+              amount: 1n,
+            }),
+        ],
+        [
+          'setCanAcceptLiquidity',
+          () =>
+            cct.setCanAcceptLiquidity({
+              wallet,
+              tokenAddress: mint,
+              poolType: 'lock-release',
+              allow: true,
+            }),
+        ],
+        [
+          'setRebalancer',
+          () =>
+            cct.setRebalancer({
+              wallet,
+              tokenAddress: mint,
+              poolType: 'lock-release',
+              rebalancer: account,
+            }),
+        ],
+        [
+          'transferOwnership',
+          () =>
+            cct.transferOwnership({
+              wallet,
+              tokenAddress: mint,
+              poolType: 'lock-release',
+              newOwner: account,
+            }),
+        ],
+        [
+          'acceptOwnership',
+          () => cct.acceptOwnership({ wallet, tokenAddress: mint, poolType: 'lock-release' }),
+        ],
+        [
+          'setChainRateLimit',
+          () =>
+            cct.setChainRateLimit({
+              wallet,
+              tokenAddress: mint,
+              poolType: 'lock-release',
+              remoteChainSelector,
+              inbound: { enabled: false },
+              outbound: { enabled: false },
+            }),
+        ],
+        [
+          'editChainRemoteConfig',
+          () =>
+            cct.editChainRemoteConfig({
+              wallet,
+              tokenAddress: mint,
+              poolType: 'lock-release',
+              remoteChainSelector,
+              remoteTokenAddress: '0x01',
+              remotePoolAddresses: ['0x02'],
+              remoteTokenDecimals: 6,
+            }),
+        ],
+        [
+          'appendToLookupTable',
+          () =>
+            cct.appendToLookupTable({
+              wallet,
+              lookupTableAddress: account,
+              additionalAddresses: [mint],
+            }),
+        ],
+        ['acceptAdmin', () => cct.acceptAdmin({ wallet, tokenAddress: mint, address: account })],
+        [
+          'registerAdmin',
+          () => cct.registerAdmin({ wallet, tokenAddress: mint, address: account }),
+        ],
+        [
+          'removeFromAllowlist',
+          () =>
+            cct.removeFromAllowlist({
+              wallet,
+              tokenAddress: mint,
+              poolType: 'lock-release',
+              remove: [account],
+            }),
+        ],
+        [
+          'setPool',
+          () =>
+            cct.setPool({
+              wallet,
+              tokenAddress: mint,
+              address: account,
+              poolLookupTableAddress: account,
+            }),
+        ],
+        [
+          'transferAdmin',
+          () =>
+            cct.transferAdmin({ wallet, tokenAddress: mint, address: account, newAdmin: account }),
+        ],
+      ]
+
+      for (const [name, operation] of signed) {
+        const result = await operation()
+        const hashes = Array.isArray(result)
+          ? result.map(({ hash }) => hash)
+          : 'hashes' in result
+            ? result.hashes
+            : [result.hash]
+        assert.ok(hashes.length && hashes.every(Boolean), `${name} returns transaction hashes`)
+      }
+    })
+
+    it('runs every read facade operation', async () => {
+      const cct = SolanaTokenManager.fromChain(facadeChain)
+      const reads: Array<[string, () => Promise<object | string[]>]> = [
+        [
+          'getTokenPoolRemotes',
+          () =>
+            cct.getTokenPoolRemotes({
+              tokenAddress: mint,
+              poolType: 'lock-release',
+              remoteChainSelector,
+            }),
+        ],
+        [
+          'getTokenPoolState',
+          () => cct.getTokenPoolState({ tokenAddress: mint, poolType: 'lock-release' }),
+        ],
+        [
+          'getTokenAdminRegistry',
+          () => cct.getTokenAdminRegistry({ tokenAddress: mint, address: reader }),
+        ],
+        ['getSupportedTokens', () => cct.getSupportedTokens({ address: reader })],
+      ]
+
+      for (const [name, read] of reads) {
+        const result = await read()
+        assert.ok(typeof result === 'object', `${name} returns a result`)
+      }
+    })
   })
 })

--- a/ccip-sdk/src/cct/solana/token-admin-registry/operations/accept-admin.test.ts
+++ b/ccip-sdk/src/cct/solana/token-admin-registry/operations/accept-admin.test.ts
@@ -3,20 +3,21 @@ import { describe, it } from 'node:test'
 
 import { Keypair, PublicKey } from '@solana/web3.js'
 
+import { CCIPWalletInvalidError } from '../../../../errors/index.ts'
 import { ChainFamily } from '../../../../networks.ts'
 import type { SolanaChain } from '../../../../solana/index.ts'
 import { CCTParamsInvalidError } from '../../../errors.ts'
-import { SolanaTokenManager } from '../../index.ts'
 import { deriveRouterConfigPda, deriveTokenAdminRegistryPda } from '../../programs/router.ts'
-import type { GenerateAcceptAdminParams } from './accept-admin.ts'
+import { type GenerateAcceptAdminParams, AcceptAdmin } from './accept-admin.ts'
 
 const TOKEN = Keypair.generate().publicKey.toBase58()
 const ADDRESS = Keypair.generate().publicKey.toBase58()
 const ROUTER = Keypair.generate().publicKey.toBase58()
 const PAYER = Keypair.generate().publicKey.toBase58()
 const PENDING_ADMIN = Keypair.generate().publicKey.toBase58()
+const HASH = Keypair.generate().publicKey.toBase58()
 const WALLET = {
-  publicKey: Keypair.generate().publicKey,
+  publicKey: new PublicKey(PENDING_ADMIN),
   signTransaction: async <T>(tx: T) => tx,
 }
 
@@ -35,8 +36,22 @@ function stubChain(
   } as unknown as SolanaChain
 }
 
+function submitChain(): SolanaChain {
+  return Object.assign(stubChain(), {
+    connection: {
+      simulateTransaction: async () => ({ value: { err: null, logs: [], unitsConsumed: 1 } }),
+      getLatestBlockhash: async () => ({
+        blockhash: PublicKey.default.toBase58(),
+        lastValidBlockHeight: 1,
+      }),
+      sendTransaction: async () => HASH,
+      confirmTransaction: async () => ({ value: { err: null } }),
+    },
+  })
+}
+
 function generate(opts: Partial<GenerateAcceptAdminParams> = {}) {
-  return SolanaTokenManager.fromChain(stubChain()).generateUnsignedAcceptAdmin({
+  return new AcceptAdmin().generate(stubChain(), {
     tokenAddress: TOKEN,
     address: ADDRESS,
     payer: PAYER,
@@ -84,16 +99,15 @@ describe('AcceptAdmin (cct/solana)', () => {
 
     it('resolves the router from address', async () => {
       let requestedAddress: string | undefined
-      const cct = SolanaTokenManager.fromChain(
+      await new AcceptAdmin().generate(
         stubChain(PENDING_ADMIN, (address) => (requestedAddress = address)),
+        {
+          tokenAddress: TOKEN,
+          address: ADDRESS,
+          payer: PAYER,
+          authority: PENDING_ADMIN,
+        },
       )
-
-      await cct.generateUnsignedAcceptAdmin({
-        tokenAddress: TOKEN,
-        address: ADDRESS,
-        payer: PAYER,
-        authority: PENDING_ADMIN,
-      })
 
       assert.equal(requestedAddress, ADDRESS)
     })
@@ -117,7 +131,7 @@ describe('AcceptAdmin (cct/solana)', () => {
 
       await assert.rejects(
         () =>
-          SolanaTokenManager.fromChain(noPendingChain).generateUnsignedAcceptAdmin({
+          new AcceptAdmin().generate(noPendingChain, {
             tokenAddress: TOKEN,
             address: ADDRESS,
             payer: PAYER,
@@ -132,13 +146,35 @@ describe('AcceptAdmin (cct/solana)', () => {
   })
 
   describe('execute', () => {
+    it('signs, submits, and returns the tx hash', async () => {
+      assert.deepEqual(
+        await new AcceptAdmin().execute(submitChain(), {
+          tokenAddress: TOKEN,
+          address: ADDRESS,
+          wallet: WALLET,
+        }),
+        { hash: HASH },
+      )
+    })
+
+    it('rejects an invalid wallet before generating instructions', async () => {
+      await assert.rejects(
+        new AcceptAdmin().execute(stubChain(), {
+          tokenAddress: TOKEN,
+          address: ADDRESS,
+          wallet: {},
+        }),
+        CCIPWalletInvalidError,
+      )
+    })
+
     it('requires the pending admin to be the executing wallet', async () => {
       await assert.rejects(
         () =>
-          SolanaTokenManager.fromChain(stubChain()).acceptAdmin({
+          new AcceptAdmin().execute(stubChain(), {
             tokenAddress: TOKEN,
             address: ADDRESS,
-            authority: PENDING_ADMIN,
+            authority: PAYER,
             wallet: WALLET,
           }),
         (err: unknown) =>

--- a/ccip-sdk/src/cct/solana/token-admin-registry/operations/append-to-lookup-table.test.ts
+++ b/ccip-sdk/src/cct/solana/token-admin-registry/operations/append-to-lookup-table.test.ts
@@ -7,9 +7,9 @@ import { AddressLookupTableProgram, Keypair, PublicKey } from '@solana/web3.js'
 import { ChainFamily } from '../../../../networks.ts'
 import type { SolanaChain } from '../../../../solana/index.ts'
 import { CCTParamsInvalidError } from '../../../errors.ts'
-import { SolanaTokenManager } from '../../index.ts'
 import { deriveCcipLookupTableAddresses } from '../../programs/alt.ts'
 import { TOKEN_POOL_PROGRAMS } from '../../programs/token-pool.ts'
+import { AppendToLookupTable } from './append-to-lookup-table.ts'
 
 const TOKEN = Keypair.generate().publicKey.toBase58()
 const POOL_PROGRAM = Keypair.generate().publicKey.toBase58()
@@ -19,21 +19,24 @@ const PAYER = Keypair.generate().publicKey.toBase58()
 const AUTHORITY = Keypair.generate().publicKey.toBase58()
 const LOOKUP_TABLE = Keypair.generate().publicKey.toBase58()
 const ALT_EXTEND_ADDRESSES_OFFSET = 12 // 4-byte discriminator + 8-byte address vector length
+const HASH = Keypair.generate().publicKey.toBase58()
 const WALLET = {
-  publicKey: Keypair.generate().publicKey,
+  publicKey: new PublicKey(AUTHORITY),
   signTransaction: async <T>(tx: T) => tx,
 }
 
 type StubChainOptions = {
   addresses?: PublicKey[]
-  authority?: string
+  authority?: string | null
   onGetLookupTable?: () => void
+  missingLookupTable?: boolean
 }
 
 function stubChain({
   addresses = [],
   authority = AUTHORITY,
   onGetLookupTable,
+  missingLookupTable = false,
 }: StubChainOptions = {}): SolanaChain {
   return {
     logger: { debug() {}, info() {}, warn() {}, error() {} },
@@ -42,14 +45,23 @@ function stubChain({
       getAddressLookupTable: async () => {
         onGetLookupTable?.()
         return {
-          value: {
-            state: {
-              authority: new PublicKey(authority),
-              addresses,
-            },
-          },
+          value: missingLookupTable
+            ? null
+            : {
+                state: {
+                  authority: authority ? new PublicKey(authority) : undefined,
+                  addresses,
+                },
+              },
         }
       },
+      simulateTransaction: async () => ({ value: { err: null, logs: [], unitsConsumed: 1 } }),
+      getLatestBlockhash: async () => ({
+        blockhash: PublicKey.default.toBase58(),
+        lastValidBlockHeight: 1,
+      }),
+      sendTransaction: async () => HASH,
+      confirmTransaction: async () => ({ value: { err: null } }),
     },
     getTokenPoolConfig: async () => ({
       token: TOKEN,
@@ -61,7 +73,7 @@ function stubChain({
 }
 
 function generate(opts = {}, chain = stubChain()) {
-  return SolanaTokenManager.fromChain(chain).generateUnsignedAppendToLookupTable({
+  return new AppendToLookupTable().generate(chain, {
     lookupTableAddress: LOOKUP_TABLE,
     payer: PAYER,
     authority: AUTHORITY,
@@ -171,6 +183,16 @@ describe('AppendToLookupTable (cct/solana)', () => {
       )
     })
 
+    it('defaults omitted additional addresses to an empty list', async () => {
+      const unsigned = await generate({
+        additionalAddresses: undefined,
+        tokenAddress: TOKEN,
+        poolProgramAddress: POOL_PROGRAM,
+      })
+
+      assert.equal(unsigned.instructions.length, 1)
+    })
+
     it('rejects authority mismatch', async () => {
       await assert.rejects(
         () => generate({}, stubChain({ authority: Keypair.generate().publicKey.toBase58() })),
@@ -178,6 +200,13 @@ describe('AppendToLookupTable (cct/solana)', () => {
           err instanceof CCTParamsInvalidError &&
           err.context.operation === 'appendToLookupTable' &&
           err.context.param === 'authority',
+      )
+    })
+
+    it('rejects an ALT with no authority', async () => {
+      await assert.rejects(
+        () => generate({}, stubChain({ authority: null })),
+        (err: unknown) => err instanceof CCTParamsInvalidError && err.context.param === 'authority',
       )
     })
 
@@ -195,19 +224,28 @@ describe('AppendToLookupTable (cct/solana)', () => {
   })
 
   describe('validation', () => {
+    it('rejects a missing lookup table', async () => {
+      await assert.rejects(
+        () => generate({}, stubChain({ missingLookupTable: true })),
+        (err: unknown) =>
+          err instanceof CCTParamsInvalidError && err.context.param === 'lookupTableAddress',
+      )
+    })
+
     it('rejects an ambiguous pool reference before the ALT RPC', async () => {
       let getLookupTableCalls = 0
 
       await assert.rejects(
-        SolanaTokenManager.fromChain(
+        new AppendToLookupTable().generate(
           stubChain({ onGetLookupTable: () => getLookupTableCalls++ }),
-        ).generateUnsignedAppendToLookupTable({
-          lookupTableAddress: LOOKUP_TABLE,
-          payer: PAYER,
-          tokenAddress: TOKEN,
-          poolType: 'burn-mint',
-          poolProgramAddress: POOL_PROGRAM,
-        } as never),
+          {
+            lookupTableAddress: LOOKUP_TABLE,
+            payer: PAYER,
+            tokenAddress: TOKEN,
+            poolType: 'burn-mint',
+            poolProgramAddress: POOL_PROGRAM,
+          } as never,
+        ),
         CCTParamsInvalidError,
       )
 
@@ -218,14 +256,15 @@ describe('AppendToLookupTable (cct/solana)', () => {
       let getLookupTableCalls = 0
 
       await assert.rejects(
-        SolanaTokenManager.fromChain(
+        new AppendToLookupTable().generate(
           stubChain({ onGetLookupTable: () => getLookupTableCalls++ }),
-        ).generateUnsignedAppendToLookupTable({
-          lookupTableAddress: LOOKUP_TABLE,
-          payer: PAYER,
-          tokenAddress: TOKEN,
-          poolProgramAddress: 'invalid',
-        }),
+          {
+            lookupTableAddress: LOOKUP_TABLE,
+            payer: PAYER,
+            tokenAddress: TOKEN,
+            poolProgramAddress: 'invalid',
+          },
+        ),
         CCTParamsInvalidError,
       )
 
@@ -254,13 +293,24 @@ describe('AppendToLookupTable (cct/solana)', () => {
   })
 
   describe('execute', () => {
+    it('signs, submits, and returns the tx hash', async () => {
+      assert.deepEqual(
+        await new AppendToLookupTable().execute(stubChain(), {
+          lookupTableAddress: LOOKUP_TABLE,
+          wallet: WALLET,
+          additionalAddresses: [Keypair.generate().publicKey.toBase58()],
+        }),
+        { hash: HASH },
+      )
+    })
+
     it('rejects signed append when authority is not the wallet', async () => {
       await assert.rejects(
         () =>
-          SolanaTokenManager.fromChain(stubChain()).appendToLookupTable({
+          new AppendToLookupTable().execute(stubChain(), {
             lookupTableAddress: LOOKUP_TABLE,
             wallet: WALLET,
-            authority: AUTHORITY,
+            authority: PAYER,
             additionalAddresses: [Keypair.generate().publicKey.toBase58()],
           }),
         (err: unknown) =>

--- a/ccip-sdk/src/cct/solana/token-admin-registry/operations/create-lookup-table.test.ts
+++ b/ccip-sdk/src/cct/solana/token-admin-registry/operations/create-lookup-table.test.ts
@@ -7,8 +7,8 @@ import { AddressLookupTableProgram, Keypair, PublicKey } from '@solana/web3.js'
 import { ChainFamily } from '../../../../networks.ts'
 import type { SolanaChain } from '../../../../solana/index.ts'
 import { CCTParamsInvalidError } from '../../../errors.ts'
-import { SolanaTokenManager } from '../../index.ts'
 import { TOKEN_POOL_PROGRAMS } from '../../programs/token-pool.ts'
+import { CreateLookupTable } from './create-lookup-table.ts'
 
 const TOKEN = Keypair.generate().publicKey.toBase58()
 const POOL_PROGRAM = Keypair.generate().publicKey.toBase58()
@@ -16,8 +16,9 @@ const ROUTER = Keypair.generate().publicKey.toBase58()
 const FEE_QUOTER = Keypair.generate().publicKey
 const PAYER = Keypair.generate().publicKey.toBase58()
 const AUTHORITY = Keypair.generate().publicKey.toBase58()
+const HASH = Keypair.generate().publicKey.toBase58()
 const WALLET = {
-  publicKey: Keypair.generate().publicKey,
+  publicKey: new PublicKey(AUTHORITY),
   signTransaction: async <T>(tx: T) => tx,
 }
 
@@ -30,6 +31,13 @@ function stubChain(onGetSlot?: () => void): SolanaChain {
         return 123
       },
       getAccountInfo: async () => ({ owner: TOKEN_PROGRAM_ID }),
+      simulateTransaction: async () => ({ value: { err: null, logs: [], unitsConsumed: 1 } }),
+      getLatestBlockhash: async () => ({
+        blockhash: PublicKey.default.toBase58(),
+        lastValidBlockHeight: 1,
+      }),
+      sendTransaction: async () => HASH,
+      confirmTransaction: async () => ({ value: { err: null } }),
     },
     getTokenPoolConfig: async () => ({
       token: TOKEN,
@@ -41,7 +49,7 @@ function stubChain(onGetSlot?: () => void): SolanaChain {
 }
 
 function generate(opts = {}) {
-  return SolanaTokenManager.fromChain(stubChain()).generateUnsignedCreateLookupTable({
+  return new CreateLookupTable().generate(stubChain(), {
     tokenAddress: TOKEN,
     poolProgramAddress: POOL_PROGRAM,
     payer: PAYER,
@@ -73,9 +81,7 @@ describe('CreateLookupTable (cct/solana)', () => {
     })
 
     it('accepts a canonical pool type', async () => {
-      const unsigned = await SolanaTokenManager.fromChain(
-        stubChain(),
-      ).generateUnsignedCreateLookupTable({
+      const unsigned = await new CreateLookupTable().generate(stubChain(), {
         tokenAddress: TOKEN,
         poolType: 'burn-mint',
         payer: PAYER,
@@ -90,9 +96,7 @@ describe('CreateLookupTable (cct/solana)', () => {
     })
 
     it('builds create-only ALT instruction in createEmpty mode', async () => {
-      const unsigned = await SolanaTokenManager.fromChain(
-        stubChain(),
-      ).generateUnsignedCreateLookupTable({
+      const unsigned = await new CreateLookupTable().generate(stubChain(), {
         payer: PAYER,
         authority: AUTHORITY,
         mode: 'createEmpty',
@@ -113,9 +117,7 @@ describe('CreateLookupTable (cct/solana)', () => {
     })
 
     it('defaults createEmpty authority to payer', async () => {
-      const unsigned = await SolanaTokenManager.fromChain(
-        stubChain(),
-      ).generateUnsignedCreateLookupTable({
+      const unsigned = await new CreateLookupTable().generate(stubChain(), {
         payer: PAYER,
         mode: 'createEmpty',
       })
@@ -158,14 +160,15 @@ describe('CreateLookupTable (cct/solana)', () => {
       let getSlotCalls = 0
 
       await assert.rejects(
-        SolanaTokenManager.fromChain(
+        new CreateLookupTable().generate(
           stubChain(() => getSlotCalls++),
-        ).generateUnsignedCreateLookupTable({
-          tokenAddress: TOKEN,
-          poolType: 'burn-mint',
-          poolProgramAddress: POOL_PROGRAM,
-          payer: PAYER,
-        } as never),
+          {
+            tokenAddress: TOKEN,
+            poolType: 'burn-mint',
+            poolProgramAddress: POOL_PROGRAM,
+            payer: PAYER,
+          } as never,
+        ),
         CCTParamsInvalidError,
       )
 
@@ -174,14 +177,25 @@ describe('CreateLookupTable (cct/solana)', () => {
   })
 
   describe('execute', () => {
+    it('signs, submits, and returns the lookup table address', async () => {
+      const result = await new CreateLookupTable().execute(stubChain(), {
+        tokenAddress: TOKEN,
+        poolProgramAddress: POOL_PROGRAM,
+        wallet: WALLET,
+      })
+
+      assert.equal(result.hash, HASH)
+      assert.match(result.lookupTableAddress, /^[1-9A-HJ-NP-Za-km-z]+$/)
+    })
+
     it('rejects signed create+extend when authority is not the wallet', async () => {
       await assert.rejects(
         () =>
-          SolanaTokenManager.fromChain(stubChain()).createLookupTable({
+          new CreateLookupTable().execute(stubChain(), {
             tokenAddress: TOKEN,
             poolProgramAddress: POOL_PROGRAM,
             wallet: WALLET,
-            authority: AUTHORITY,
+            authority: PAYER,
           }),
         (err: unknown) =>
           err instanceof CCTParamsInvalidError &&

--- a/ccip-sdk/src/cct/solana/token-admin-registry/operations/get-token-admin-registry.test.ts
+++ b/ccip-sdk/src/cct/solana/token-admin-registry/operations/get-token-admin-registry.test.ts
@@ -10,8 +10,8 @@ import {
 } from '../../../../errors/index.ts'
 import type { SolanaChain } from '../../../../solana/index.ts'
 import { CCTParamsInvalidError } from '../../../errors.ts'
-import { SolanaTokenManager } from '../../index.ts'
 import { deriveTokenAdminRegistryPda } from '../../programs/router.ts'
+import { GetTokenAdminRegistry } from './get-token-admin-registry.ts'
 
 const ROUTER = Keypair.generate().publicKey
 const TOKEN = Keypair.generate().publicKey
@@ -59,7 +59,7 @@ function stubChain(account: { data: Buffer } | null = registryAccount()): Solana
 describe('GetTokenAdminRegistry (cct/solana)', () => {
   describe('query', () => {
     it('returns configured administrators, lookup table, and writable indexes', async () => {
-      const config = await SolanaTokenManager.fromChain(stubChain()).getTokenAdminRegistry({
+      const config = await new GetTokenAdminRegistry().query(stubChain(), {
         address: ROUTER.toBase58(),
         tokenAddress: TOKEN.toBase58(),
       })
@@ -76,9 +76,10 @@ describe('GetTokenAdminRegistry (cct/solana)', () => {
     })
 
     it('omits optional fields when unset', async () => {
-      const config = await SolanaTokenManager.fromChain(
+      const config = await new GetTokenAdminRegistry().query(
         stubChain(registryAccount(PublicKey.default, PublicKey.default, false, false)),
-      ).getTokenAdminRegistry({ address: ROUTER.toBase58(), tokenAddress: TOKEN.toBase58() })
+        { address: ROUTER.toBase58(), tokenAddress: TOKEN.toBase58() },
+      )
 
       assert.deepEqual(config, {
         mint: TOKEN.toBase58(),
@@ -89,17 +90,19 @@ describe('GetTokenAdminRegistry (cct/solana)', () => {
     })
 
     it('returns disabled auto derivation setting', async () => {
-      const config = await SolanaTokenManager.fromChain(
+      const config = await new GetTokenAdminRegistry().query(
         stubChain(registryAccount(PENDING_ADMINISTRATOR, LOOKUP_TABLE, false)),
-      ).getTokenAdminRegistry({ address: ROUTER.toBase58(), tokenAddress: TOKEN.toBase58() })
+        { address: ROUTER.toBase58(), tokenAddress: TOKEN.toBase58() },
+      )
 
       assert.equal(config.supportsAutoDerivation, false)
     })
 
     it('omits the system program as pending administrator', async () => {
-      const config = await SolanaTokenManager.fromChain(
+      const config = await new GetTokenAdminRegistry().query(
         stubChain(registryAccount(SystemProgram.programId)),
-      ).getTokenAdminRegistry({ address: ROUTER.toBase58(), tokenAddress: TOKEN.toBase58() })
+        { address: ROUTER.toBase58(), tokenAddress: TOKEN.toBase58() },
+      )
 
       assert.equal(config.pendingAdministrator, undefined)
     })
@@ -107,7 +110,7 @@ describe('GetTokenAdminRegistry (cct/solana)', () => {
     it('rejects malformed registry data', async () => {
       await assert.rejects(
         () =>
-          SolanaTokenManager.fromChain(stubChain({ data: Buffer.alloc(8) })).getTokenAdminRegistry({
+          new GetTokenAdminRegistry().query(stubChain({ data: Buffer.alloc(8) }), {
             address: ROUTER.toBase58(),
             tokenAddress: TOKEN.toBase58(),
           }),
@@ -118,7 +121,7 @@ describe('GetTokenAdminRegistry (cct/solana)', () => {
     it('rejects unregistered tokens', async () => {
       await assert.rejects(
         () =>
-          SolanaTokenManager.fromChain(stubChain(null)).getTokenAdminRegistry({
+          new GetTokenAdminRegistry().query(stubChain(null), {
             address: ROUTER.toBase58(),
             tokenAddress: TOKEN.toBase58(),
           }),
@@ -131,7 +134,7 @@ describe('GetTokenAdminRegistry (cct/solana)', () => {
     it('rejects an invalid router address', async () => {
       await assert.rejects(
         () =>
-          SolanaTokenManager.fromChain(stubChain()).getTokenAdminRegistry({
+          new GetTokenAdminRegistry().query(stubChain(), {
             address: 'invalid',
             tokenAddress: TOKEN.toBase58(),
           }),
@@ -143,7 +146,7 @@ describe('GetTokenAdminRegistry (cct/solana)', () => {
     it('rejects an invalid token address', async () => {
       await assert.rejects(
         () =>
-          SolanaTokenManager.fromChain(stubChain()).getTokenAdminRegistry({
+          new GetTokenAdminRegistry().query(stubChain(), {
             address: ROUTER.toBase58(),
             tokenAddress: 'invalid',
           }),

--- a/ccip-sdk/src/cct/solana/token-admin-registry/operations/index.ts
+++ b/ccip-sdk/src/cct/solana/token-admin-registry/operations/index.ts
@@ -3,13 +3,6 @@ export * from './append-to-lookup-table.ts'
 export * from './create-lookup-table.ts'
 export * from './get-supported-tokens.ts'
 export * from './get-token-admin-registry.ts'
-export { RegisterAdmin } from './register-admin.ts'
-export type {
-  ExecuteRegisterAdminParams,
-  ExecuteRegisterAdminResult,
-  GenerateRegisterAdminParams,
-  GenerateRegisterAdminResult,
-  RegisterAdminMethod,
-} from './register-admin.ts'
+export * from './register-admin.ts'
 export * from './set-pool.ts'
 export * from './transfer-admin.ts'

--- a/ccip-sdk/src/cct/solana/token-admin-registry/operations/register-admin.test.ts
+++ b/ccip-sdk/src/cct/solana/token-admin-registry/operations/register-admin.test.ts
@@ -8,8 +8,8 @@ import { Keypair, PublicKey } from '@solana/web3.js'
 import { ChainFamily } from '../../../../networks.ts'
 import type { SolanaChain } from '../../../../solana/index.ts'
 import { CCTParamsInvalidError } from '../../../errors.ts'
-import { SolanaTokenManager } from '../../index.ts'
 import { deriveRouterConfigPda, deriveTokenAdminRegistryPda } from '../../programs/router.ts'
+import { RegisterAdmin } from './register-admin.ts'
 
 const TOKEN = Keypair.generate().publicKey
 const MINT_AUTHORITY = Keypair.generate().publicKey
@@ -20,6 +20,11 @@ const CCIP_ADMIN = Keypair.generate().publicKey
 const ADMINISTRATOR = Keypair.generate().publicKey
 const CONFIG = deriveRouterConfigPda(new PublicKey(ROUTER))
 const TOKEN_ADMIN_REGISTRY = deriveTokenAdminRegistryPda(new PublicKey(ROUTER), TOKEN)
+const HASH = Keypair.generate().publicKey.toBase58()
+const SUBMIT_WALLET = {
+  publicKey: MINT_AUTHORITY,
+  signTransaction: async <T>(tx: T) => tx,
+}
 const WALLET = {
   publicKey: Keypair.generate().publicKey,
   signTransaction: async <T>(tx: T) => tx,
@@ -64,15 +69,20 @@ function stubChain(
         context: { slot: 0 },
         value: await getAccountInfo(address),
       }),
+      simulateTransaction: async () => ({ value: { err: null, logs: [], unitsConsumed: 1 } }),
+      getLatestBlockhash: async () => ({
+        blockhash: PublicKey.default.toBase58(),
+        lastValidBlockHeight: 1,
+      }),
+      sendTransaction: async () => HASH,
+      confirmTransaction: async () => ({ value: { err: null } }),
     },
     getTokenAdminRegistryFor: async () => ROUTER,
   } as unknown as SolanaChain
 }
 
 function generate(opts = {}, registered = false, mintAuthority: PublicKey | null = MINT_AUTHORITY) {
-  return SolanaTokenManager.fromChain(
-    stubChain(registered, mintAuthority),
-  ).generateUnsignedRegisterAdmin({
+  return new RegisterAdmin().generate(stubChain(registered, mintAuthority), {
     tokenAddress: TOKEN.toBase58(),
     address: ADDRESS,
     payer: PAYER,
@@ -131,6 +141,19 @@ describe('RegisterAdmin (cct/solana)', () => {
       )
     })
 
+    it('rejects owner registration without a mint authority', async () => {
+      await assert.rejects(
+        () =>
+          generate(
+            { registrationMethod: 'owner', administrator: ADMINISTRATOR.toBase58() },
+            false,
+            null,
+          ),
+        (err: unknown) =>
+          err instanceof CCTParamsInvalidError && err.context.param === 'tokenAddress',
+      )
+    })
+
     it('requires an administrator for CCIP-admin registration without a mint authority', async () => {
       await assert.rejects(
         () =>
@@ -147,9 +170,7 @@ describe('RegisterAdmin (cct/solana)', () => {
     it('rejects a missing Router config with a typed error', async () => {
       await assert.rejects(
         () =>
-          SolanaTokenManager.fromChain(
-            stubChain(false, MINT_AUTHORITY, false),
-          ).generateUnsignedRegisterAdmin({
+          new RegisterAdmin().generate(stubChain(false, MINT_AUTHORITY, false), {
             tokenAddress: TOKEN.toBase58(),
             address: ADDRESS,
             registrationMethod: 'ccip-admin',
@@ -177,10 +198,22 @@ describe('RegisterAdmin (cct/solana)', () => {
   })
 
   describe('execute', () => {
+    it('signs, submits, and returns the tx hash', async () => {
+      assert.deepEqual(
+        await new RegisterAdmin().execute(stubChain(), {
+          tokenAddress: TOKEN.toBase58(),
+          address: ADDRESS,
+          registrationMethod: 'owner',
+          wallet: SUBMIT_WALLET,
+        }),
+        { hash: HASH },
+      )
+    })
+
     it('rejects an authority that differs from the executing wallet', async () => {
       await assert.rejects(
         () =>
-          SolanaTokenManager.fromChain(stubChain()).registerAdmin({
+          new RegisterAdmin().execute(stubChain(), {
             tokenAddress: TOKEN.toBase58(),
             address: ADDRESS,
             registrationMethod: 'owner',

--- a/ccip-sdk/src/cct/solana/token-admin-registry/operations/set-pool.test.ts
+++ b/ccip-sdk/src/cct/solana/token-admin-registry/operations/set-pool.test.ts
@@ -7,7 +7,8 @@ import { CCIPWalletInvalidError } from '../../../../errors/index.ts'
 import { ChainFamily } from '../../../../networks.ts'
 import type { SolanaChain } from '../../../../solana/index.ts'
 import { CCTParamsInvalidError } from '../../../errors.ts'
-import { DEFAULT_WRITABLE_INDEXES, SolanaTokenManager } from '../../index.ts'
+import { DEFAULT_WRITABLE_INDEXES } from '../constants.ts'
+import { SetPool } from './set-pool.ts'
 
 const BLOCKHASH = PublicKey.default.toBase58()
 const TOKEN = Keypair.generate().publicKey.toBase58()
@@ -32,7 +33,7 @@ function stubChain(router = ROUTER, onAddress?: (address: string) => void): Sola
 }
 
 function generate(opts = {}) {
-  return SolanaTokenManager.fromChain(stubChain()).generateUnsignedSetPool({
+  return new SetPool().generate(stubChain(), {
     tokenAddress: TOKEN,
     address: ADDRESS,
     poolLookupTableAddress: POOL_LOOKUP_TABLE,
@@ -75,16 +76,15 @@ describe('SetPool (cct/solana)', () => {
 
     it('resolves the router from address', async () => {
       let requestedAddress: string | undefined
-      const cct = SolanaTokenManager.fromChain(
+      const unsigned = await new SetPool().generate(
         stubChain(ROUTER, (address) => (requestedAddress = address)),
+        {
+          tokenAddress: TOKEN,
+          address: ADDRESS,
+          poolLookupTableAddress: POOL_LOOKUP_TABLE,
+          payer: PAYER,
+        },
       )
-
-      const unsigned = await cct.generateUnsignedSetPool({
-        tokenAddress: TOKEN,
-        address: ADDRESS,
-        poolLookupTableAddress: POOL_LOOKUP_TABLE,
-        payer: PAYER,
-      })
 
       assert.equal(requestedAddress, ADDRESS)
       assert.equal(unsigned.instructions[0]!.programId.toBase58(), ROUTER)
@@ -102,15 +102,16 @@ describe('SetPool (cct/solana)', () => {
       let routerLookups = 0
 
       await assert.rejects(
-        SolanaTokenManager.fromChain(
+        new SetPool().generate(
           stubChain(ROUTER, () => routerLookups++),
-        ).generateUnsignedSetPool({
-          tokenAddress: TOKEN,
-          address: ADDRESS,
-          poolLookupTableAddress: POOL_LOOKUP_TABLE,
-          payer: PAYER,
-          writableIndexes: [],
-        }),
+          {
+            tokenAddress: TOKEN,
+            address: ADDRESS,
+            poolLookupTableAddress: POOL_LOOKUP_TABLE,
+            payer: PAYER,
+            writableIndexes: [],
+          },
+        ),
         CCTParamsInvalidError,
       )
 
@@ -121,7 +122,7 @@ describe('SetPool (cct/solana)', () => {
   describe('execute', () => {
     it('rejects an invalid wallet before generating instructions', async () => {
       await assert.rejects(
-        SolanaTokenManager.fromChain(stubChain()).setPool({
+        new SetPool().execute(stubChain(), {
           tokenAddress: TOKEN,
           address: ADDRESS,
           poolLookupTableAddress: POOL_LOOKUP_TABLE,

--- a/ccip-sdk/src/cct/solana/token-admin-registry/operations/transfer-admin.test.ts
+++ b/ccip-sdk/src/cct/solana/token-admin-registry/operations/transfer-admin.test.ts
@@ -6,9 +6,8 @@ import { Keypair, PublicKey } from '@solana/web3.js'
 import { ChainFamily } from '../../../../networks.ts'
 import type { SolanaChain } from '../../../../solana/index.ts'
 import { CCTParamsInvalidError } from '../../../errors.ts'
-import { SolanaTokenManager } from '../../index.ts'
 import { deriveRouterConfigPda, deriveTokenAdminRegistryPda } from '../../programs/router.ts'
-import type { GenerateTransferAdminParams } from './transfer-admin.ts'
+import { type GenerateTransferAdminParams, TransferAdmin } from './transfer-admin.ts'
 
 const TOKEN = Keypair.generate().publicKey.toBase58()
 const ADDRESS = Keypair.generate().publicKey.toBase58()
@@ -16,6 +15,11 @@ const ROUTER = Keypair.generate().publicKey.toBase58()
 const PAYER = Keypair.generate().publicKey.toBase58()
 const NEW_ADMIN = Keypair.generate().publicKey.toBase58()
 const CURRENT_ADMIN = Keypair.generate().publicKey.toBase58()
+const HASH = Keypair.generate().publicKey.toBase58()
+const SUBMIT_WALLET = {
+  publicKey: new PublicKey(CURRENT_ADMIN),
+  signTransaction: async <T>(tx: T) => tx,
+}
 const WALLET = {
   publicKey: Keypair.generate().publicKey,
   signTransaction: async <T>(tx: T) => tx,
@@ -28,7 +32,15 @@ function stubChain(
 ): SolanaChain {
   return {
     logger: { debug() {}, info() {}, warn() {}, error() {} },
-    connection: {},
+    connection: {
+      simulateTransaction: async () => ({ value: { err: null, logs: [], unitsConsumed: 1 } }),
+      getLatestBlockhash: async () => ({
+        blockhash: PublicKey.default.toBase58(),
+        lastValidBlockHeight: 1,
+      }),
+      sendTransaction: async () => HASH,
+      confirmTransaction: async () => ({ value: { err: null } }),
+    },
     getTokenAdminRegistryFor: async (address: string) => {
       onAddress?.(address)
       return ROUTER
@@ -38,7 +50,7 @@ function stubChain(
 }
 
 function generate(opts: Partial<GenerateTransferAdminParams> = {}) {
-  return SolanaTokenManager.fromChain(stubChain()).generateUnsignedTransferAdmin({
+  return new TransferAdmin().generate(stubChain(), {
     tokenAddress: TOKEN,
     address: ADDRESS,
     newAdmin: NEW_ADMIN,
@@ -88,17 +100,16 @@ describe('TransferAdmin (cct/solana)', () => {
 
     it('resolves the router from address', async () => {
       let requestedAddress: string | undefined
-      const cct = SolanaTokenManager.fromChain(
+      await new TransferAdmin().generate(
         stubChain(CURRENT_ADMIN, (address) => (requestedAddress = address)),
+        {
+          tokenAddress: TOKEN,
+          address: ADDRESS,
+          newAdmin: NEW_ADMIN,
+          payer: PAYER,
+          authority: CURRENT_ADMIN,
+        },
       )
-
-      await cct.generateUnsignedTransferAdmin({
-        tokenAddress: TOKEN,
-        address: ADDRESS,
-        newAdmin: NEW_ADMIN,
-        payer: PAYER,
-        authority: CURRENT_ADMIN,
-      })
 
       assert.equal(requestedAddress, ADDRESS)
     })
@@ -113,19 +124,18 @@ describe('TransferAdmin (cct/solana)', () => {
     })
 
     it('requires a pending admin to accept the initial registration before transferring', async () => {
-      const cct = SolanaTokenManager.fromChain(
-        stubChain(PublicKey.default.toBase58(), undefined, CURRENT_ADMIN),
-      )
-
       await assert.rejects(
         () =>
-          cct.generateUnsignedTransferAdmin({
-            tokenAddress: TOKEN,
-            address: ADDRESS,
-            newAdmin: NEW_ADMIN,
-            payer: PAYER,
-            authority: CURRENT_ADMIN,
-          }),
+          new TransferAdmin().generate(
+            stubChain(PublicKey.default.toBase58(), undefined, CURRENT_ADMIN),
+            {
+              tokenAddress: TOKEN,
+              address: ADDRESS,
+              newAdmin: NEW_ADMIN,
+              payer: PAYER,
+              authority: CURRENT_ADMIN,
+            },
+          ),
         (err: unknown) =>
           err instanceof CCTParamsInvalidError &&
           err.context.param === 'authority' &&
@@ -136,10 +146,22 @@ describe('TransferAdmin (cct/solana)', () => {
   })
 
   describe('execute', () => {
+    it('signs, submits, and returns the tx hash', async () => {
+      assert.deepEqual(
+        await new TransferAdmin().execute(stubChain(), {
+          tokenAddress: TOKEN,
+          address: ADDRESS,
+          newAdmin: NEW_ADMIN,
+          wallet: SUBMIT_WALLET,
+        }),
+        { hash: HASH },
+      )
+    })
+
     it('requires the current admin to be the executing wallet', async () => {
       await assert.rejects(
         () =>
-          SolanaTokenManager.fromChain(stubChain()).transferAdmin({
+          new TransferAdmin().execute(stubChain(), {
             tokenAddress: TOKEN,
             address: ADDRESS,
             newAdmin: NEW_ADMIN,

--- a/ccip-sdk/src/cct/solana/token-pool/operations/accept-ownership.test.ts
+++ b/ccip-sdk/src/cct/solana/token-pool/operations/accept-ownership.test.ts
@@ -8,8 +8,8 @@ import { ChainFamily } from '../../../../networks.ts'
 import { tokenPoolCoder } from '../../../../solana/idl/token-pool-coder.ts'
 import type { SolanaChain } from '../../../../solana/index.ts'
 import { CCTParamsInvalidError } from '../../../errors.ts'
-import { SolanaTokenManager } from '../../index.ts'
 import { deriveTokenPoolConfigPda, resolveTokenPoolProgram } from '../../programs/token-pool.ts'
+import { AcceptOwnership } from './accept-ownership.ts'
 
 const TOKEN = Keypair.generate().publicKey.toBase58()
 const PAYER = Keypair.generate().publicKey.toBase58()
@@ -71,7 +71,7 @@ function submitChain(): SolanaChain {
 }
 
 function generate(opts = {}) {
-  return SolanaTokenManager.fromChain(chain()).generateUnsignedAcceptOwnership({
+  return new AcceptOwnership().generate(chain(), {
     tokenAddress: TOKEN,
     poolType: 'burn-mint',
     payer: PAYER,
@@ -112,9 +112,7 @@ describe('AcceptOwnership (cct/solana)', () => {
     })
 
     it('defaults authority to payer', async () => {
-      const unsigned = await SolanaTokenManager.fromChain(
-        chain(PAYER),
-      ).generateUnsignedAcceptOwnership({
+      const unsigned = await new AcceptOwnership().generate(chain(PAYER), {
         tokenAddress: TOKEN,
         poolType: 'burn-mint',
         payer: PAYER,
@@ -143,11 +141,9 @@ describe('AcceptOwnership (cct/solana)', () => {
     })
 
     it('rejects when there is no proposed owner', async () => {
-      const cct = SolanaTokenManager.fromChain(chain(PublicKey.default.toBase58()))
-
       await assert.rejects(
         () =>
-          cct.generateUnsignedAcceptOwnership({
+          new AcceptOwnership().generate(chain(PublicKey.default.toBase58()), {
             tokenAddress: TOKEN,
             poolType: 'burn-mint',
             payer: PAYER,
@@ -174,7 +170,7 @@ describe('AcceptOwnership (cct/solana)', () => {
 
   describe('execute', () => {
     it('signs, submits, and returns the tx hash', async () => {
-      const result = await SolanaTokenManager.fromChain(submitChain()).acceptOwnership({
+      const result = await new AcceptOwnership().execute(submitChain(), {
         tokenAddress: TOKEN,
         poolType: 'burn-mint',
         wallet: WALLET,
@@ -186,7 +182,7 @@ describe('AcceptOwnership (cct/solana)', () => {
     it('rejects a non-wallet authority for signed acceptance', async () => {
       await assert.rejects(
         () =>
-          SolanaTokenManager.fromChain(chain()).acceptOwnership({
+          new AcceptOwnership().execute(chain(), {
             tokenAddress: TOKEN,
             poolType: 'burn-mint',
             authority: AUTHORITY,

--- a/ccip-sdk/src/cct/solana/token-pool/operations/append-remote-pool-addresses.test.ts
+++ b/ccip-sdk/src/cct/solana/token-pool/operations/append-remote-pool-addresses.test.ts
@@ -7,12 +7,12 @@ import { ChainFamily } from '../../../../networks.ts'
 import { tokenPoolCoder } from '../../../../solana/idl/token-pool-coder.ts'
 import type { SolanaChain } from '../../../../solana/index.ts'
 import { CCTParamsInvalidError } from '../../../errors.ts'
-import { SolanaTokenManager } from '../../index.ts'
 import {
   deriveTokenPoolChainConfigPda,
   deriveTokenPoolConfigPda,
   resolveTokenPoolProgram,
 } from '../../programs/token-pool.ts'
+import { AppendRemotePoolAddresses } from './append-remote-pool-addresses.ts'
 
 const TOKEN = Keypair.generate().publicKey.toBase58()
 const PAYER = Keypair.generate().publicKey.toBase58()
@@ -47,7 +47,7 @@ function submitChain(): SolanaChain {
 }
 
 function generate(opts = {}) {
-  return SolanaTokenManager.fromChain(chain()).generateUnsignedAppendRemotePoolAddresses({
+  return new AppendRemotePoolAddresses().generate(chain(), {
     tokenAddress: TOKEN,
     poolType: 'burn-mint',
     payer: PAYER,
@@ -139,7 +139,7 @@ describe('AppendRemotePoolAddresses (cct/solana)', () => {
 
   describe('execute', () => {
     it('signs, submits, and returns the tx hash', async () => {
-      const result = await SolanaTokenManager.fromChain(submitChain()).appendRemotePoolAddresses({
+      const result = await new AppendRemotePoolAddresses().execute(submitChain(), {
         tokenAddress: TOKEN,
         poolType: 'burn-mint',
         remoteChainSelector: SELECTOR,
@@ -153,7 +153,7 @@ describe('AppendRemotePoolAddresses (cct/solana)', () => {
     it('rejects a non-wallet authority for signed appending', async () => {
       await assert.rejects(
         () =>
-          SolanaTokenManager.fromChain(chain()).appendRemotePoolAddresses({
+          new AppendRemotePoolAddresses().execute(chain(), {
             tokenAddress: TOKEN,
             poolType: 'burn-mint',
             authority: AUTHORITY,

--- a/ccip-sdk/src/cct/solana/token-pool/operations/apply-chain-updates.test.ts
+++ b/ccip-sdk/src/cct/solana/token-pool/operations/apply-chain-updates.test.ts
@@ -8,8 +8,8 @@ import { ChainFamily } from '../../../../networks.ts'
 import { tokenPoolCoder } from '../../../../solana/idl/token-pool-coder.ts'
 import type { SolanaChain } from '../../../../solana/index.ts'
 import { CCTParamsInvalidError } from '../../../errors.ts'
-import { SolanaTokenManager } from '../../index.ts'
 import { resolveTokenPoolProgram } from '../../programs/token-pool.ts'
+import { ApplyChainUpdates } from './apply-chain-updates.ts'
 
 const TOKEN = Keypair.generate().publicKey.toBase58()
 const PAYER = Keypair.generate().publicKey.toBase58()
@@ -54,7 +54,7 @@ function batchChains() {
 }
 
 function generateBatches(opts = {}) {
-  return SolanaTokenManager.fromChain(chain()).generateUnsignedApplyChainUpdates({
+  return new ApplyChainUpdates().generateBatch(chain(), {
     tokenAddress: TOKEN,
     poolType: 'burn-mint',
     payer: PAYER,
@@ -81,6 +81,35 @@ async function generate(opts = {}) {
 
 describe('ApplyChainUpdates (cct/solana)', () => {
   describe('generate', () => {
+    it('requires the batch API', async () => {
+      assert.throws(
+        () => new ApplyChainUpdates().generate(chain(), {} as never),
+        (error: unknown) => CCIPError.isCCIPError(error) && error.code === 'METHOD_UNSUPPORTED',
+      )
+      assert.throws(
+        () => new ApplyChainUpdates().execute(chain(), {} as never),
+        (error: unknown) => CCIPError.isCCIPError(error) && error.code === 'METHOD_UNSUPPORTED',
+      )
+    })
+
+    it('builds a single unsigned transaction internally', async () => {
+      const operation = new ApplyChainUpdates()
+      const params = {
+        tokenAddress: TOKEN,
+        poolType: 'burn-mint' as const,
+        payer: PAYER,
+        authority: AUTHORITY,
+        remoteChainSelectorsToRemove: [SELECTOR],
+        chainsToAdd: [],
+      }
+      const unsigned = await (operation as any).buildUnsigned(
+        chain(),
+        (operation as any).prepare(params),
+      )
+
+      assert.equal(unsigned.instructions.length, 1)
+    })
+
     it('builds delete, initialize, edit, and rate-limit instructions', async () => {
       const unsigned = await generate()
       const poolProgram = resolveTokenPoolProgram('burn-mint')
@@ -155,16 +184,14 @@ describe('ApplyChainUpdates (cct/solana)', () => {
     })
 
     it('packs large updates without splitting a chain instruction group', async () => {
-      const batches = await SolanaTokenManager.fromChain(chain()).generateUnsignedApplyChainUpdates(
-        {
-          tokenAddress: TOKEN,
-          poolType: 'burn-mint',
-          payer: PAYER,
-          authority: AUTHORITY,
-          remoteChainSelectorsToRemove: [],
-          chainsToAdd: batchChains(),
-        },
-      )
+      const batches = await new ApplyChainUpdates().generateBatch(chain(), {
+        tokenAddress: TOKEN,
+        poolType: 'burn-mint',
+        payer: PAYER,
+        authority: AUTHORITY,
+        remoteChainSelectorsToRemove: [],
+        chainsToAdd: batchChains(),
+      })
 
       assert.equal(batches.length, 2)
       assert.deepEqual(
@@ -191,7 +218,7 @@ describe('ApplyChainUpdates (cct/solana)', () => {
     it('rejects a chain update that cannot fit one transaction', async () => {
       await assert.rejects(
         () =>
-          SolanaTokenManager.fromChain(chain()).generateUnsignedApplyChainUpdates({
+          new ApplyChainUpdates().generateBatch(chain(), {
             tokenAddress: TOKEN,
             poolType: 'burn-mint',
             payer: PAYER,
@@ -340,7 +367,7 @@ describe('ApplyChainUpdates (cct/solana)', () => {
 
   describe('execute', () => {
     it('signs, submits, and returns all tx hashes', async () => {
-      const result = await SolanaTokenManager.fromChain(submitChain()).applyChainUpdates({
+      const result = await new ApplyChainUpdates().executeBatch(submitChain(), {
         tokenAddress: TOKEN,
         poolType: 'burn-mint',
         remoteChainSelectorsToRemove: [SELECTOR],
@@ -361,7 +388,7 @@ describe('ApplyChainUpdates (cct/solana)', () => {
     })
 
     it('submits every safely packed batch and returns all hashes', async () => {
-      const result = await SolanaTokenManager.fromChain(submitChain()).applyChainUpdates({
+      const result = await new ApplyChainUpdates().executeBatch(submitChain(), {
         tokenAddress: TOKEN,
         poolType: 'burn-mint',
         remoteChainSelectorsToRemove: [],
@@ -384,7 +411,7 @@ describe('ApplyChainUpdates (cct/solana)', () => {
 
       await assert.rejects(
         () =>
-          SolanaTokenManager.fromChain(failedChain).applyChainUpdates({
+          new ApplyChainUpdates().executeBatch(failedChain, {
             tokenAddress: TOKEN,
             poolType: 'burn-mint',
             remoteChainSelectorsToRemove: [],
@@ -405,7 +432,7 @@ describe('ApplyChainUpdates (cct/solana)', () => {
     it('rejects a non-wallet authority for signed configuration', async () => {
       await assert.rejects(
         () =>
-          SolanaTokenManager.fromChain(chain()).applyChainUpdates({
+          new ApplyChainUpdates().executeBatch(chain(), {
             tokenAddress: TOKEN,
             poolType: 'burn-mint',
             authority: AUTHORITY,

--- a/ccip-sdk/src/cct/solana/token-pool/operations/configure-allowlist.test.ts
+++ b/ccip-sdk/src/cct/solana/token-pool/operations/configure-allowlist.test.ts
@@ -7,8 +7,8 @@ import { ChainFamily } from '../../../../networks.ts'
 import { tokenPoolCoder } from '../../../../solana/idl/token-pool-coder.ts'
 import type { SolanaChain } from '../../../../solana/index.ts'
 import { CCTParamsInvalidError } from '../../../errors.ts'
-import { SolanaTokenManager } from '../../index.ts'
 import { deriveTokenPoolConfigPda, resolveTokenPoolProgram } from '../../programs/token-pool.ts'
+import { ConfigureAllowlist } from './configure-allowlist.ts'
 
 const TOKEN = Keypair.generate().publicKey.toBase58()
 const PAYER = Keypair.generate().publicKey.toBase58()
@@ -43,7 +43,7 @@ function submitChain(): SolanaChain {
 }
 
 function generate(opts = {}) {
-  return SolanaTokenManager.fromChain(stubChain()).generateUnsignedConfigureAllowlist({
+  return new ConfigureAllowlist().generate(stubChain(), {
     tokenAddress: TOKEN,
     poolType: 'burn-mint',
     payer: PAYER,
@@ -109,9 +109,7 @@ describe('ConfigureAllowlist (cct/solana)', () => {
 
     it('uses a compatible custom pool program', async () => {
       const poolProgramAddress = Keypair.generate().publicKey.toBase58()
-      const unsigned = await SolanaTokenManager.fromChain(
-        stubChain(),
-      ).generateUnsignedConfigureAllowlist({
+      const unsigned = await new ConfigureAllowlist().generate(stubChain(), {
         tokenAddress: TOKEN,
         poolProgramAddress,
         payer: PAYER,
@@ -177,8 +175,20 @@ describe('ConfigureAllowlist (cct/solana)', () => {
   })
 
   describe('execute', () => {
+    it('rejects an invalid wallet', async () => {
+      await assert.rejects(() =>
+        new ConfigureAllowlist().execute(stubChain(), {
+          tokenAddress: TOKEN,
+          poolType: 'burn-mint',
+          add: [ALLOWED],
+          enabled: true,
+          wallet: {} as never,
+        }),
+      )
+    })
+
     it('signs, submits, and returns the tx hash', async () => {
-      const result = await SolanaTokenManager.fromChain(submitChain()).configureAllowlist({
+      const result = await new ConfigureAllowlist().execute(submitChain(), {
         tokenAddress: TOKEN,
         poolType: 'burn-mint',
         add: [ALLOWED],
@@ -192,7 +202,7 @@ describe('ConfigureAllowlist (cct/solana)', () => {
     it('rejects a non-wallet authority for signed configuration', async () => {
       await assert.rejects(
         () =>
-          SolanaTokenManager.fromChain(stubChain()).configureAllowlist({
+          new ConfigureAllowlist().execute(stubChain(), {
             tokenAddress: TOKEN,
             poolType: 'burn-mint',
             authority: AUTHORITY,

--- a/ccip-sdk/src/cct/solana/token-pool/operations/create-token-multisig.test.ts
+++ b/ccip-sdk/src/cct/solana/token-pool/operations/create-token-multisig.test.ts
@@ -7,13 +7,14 @@ import { Keypair, PublicKey, SystemProgram } from '@solana/web3.js'
 import { ChainFamily } from '../../../../networks.ts'
 import type { SolanaChain } from '../../../../solana/index.ts'
 import { CCTParamsInvalidError } from '../../../errors.ts'
-import { SolanaTokenManager } from '../../index.ts'
 import { deriveTokenPoolSignerPda } from '../../programs/token-pool.ts'
+import { CreateTokenMultisig } from './create-token-multisig.ts'
 
 const PAYER = Keypair.generate().publicKey.toBase58()
 const AUTHORITY = Keypair.generate().publicKey.toBase58()
 const MINT = Keypair.generate().publicKey.toBase58()
 const POOL_PROGRAM = '41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB'
+const HASH = Keypair.generate().publicKey.toBase58()
 const WALLET = {
   publicKey: Keypair.generate().publicKey,
   signTransaction: async <T>(tx: T) => tx,
@@ -55,7 +56,7 @@ function stubChain(mintAuthority?: PublicKey | null): SolanaChain {
 }
 
 function generate(opts = {}) {
-  return SolanaTokenManager.fromChain(stubChain()).generateUnsignedCreateTokenMultisig({
+  return new CreateTokenMultisig().generate(stubChain(), {
     tokenAddress: MINT,
     poolType: 'burn-mint',
     threshold: 2,
@@ -107,9 +108,45 @@ describe('CreateTokenMultisig (cct/solana)', () => {
 
       assert.ok(unsigned.instructions[1]!.keys.some((key) => key.pubkey.equals(signer)))
     })
+
+    it('generates a seed when none is supplied', async () => {
+      assert.ok((await generate({ threshold: 1, seed: undefined })).multisigAddress)
+    })
+
+    it('deduplicates a signer that matches the mint authority', async () => {
+      const unsigned = await generate({ threshold: 1, additionalSigners: [AUTHORITY] })
+
+      assert.equal(
+        unsigned.instructions[1]!.keys.filter((key) => key.pubkey.equals(new PublicKey(AUTHORITY)))
+          .length,
+        1,
+      )
+    })
   })
 
   describe('validation', () => {
+    it('rejects non-array additional signers', async () => {
+      await assert.rejects(
+        () => generate({ additionalSigners: 'not-an-array' }),
+        (err: unknown) =>
+          err instanceof CCTParamsInvalidError && err.context.param === 'additionalSigners',
+      )
+    })
+
+    it('rejects too many multisig signers', async () => {
+      await assert.rejects(
+        () =>
+          generate({
+            threshold: 1,
+            additionalSigners: Array.from({ length: 10 }, () =>
+              Keypair.generate().publicKey.toBase58(),
+            ),
+          }),
+        (err: unknown) =>
+          err instanceof CCTParamsInvalidError && err.context.param === 'additionalSigners',
+      )
+    })
+
     it('rejects invalid pool type', async () => {
       await assert.rejects(
         () => generate({ poolType: 'custom' }),
@@ -133,7 +170,7 @@ describe('CreateTokenMultisig (cct/solana)', () => {
     it('rejects mint without mint authority', async () => {
       await assert.rejects(
         () =>
-          SolanaTokenManager.fromChain(stubChain(null)).generateUnsignedCreateTokenMultisig({
+          new CreateTokenMultisig().generate(stubChain(null), {
             tokenAddress: MINT,
             poolType: 'burn-mint',
             threshold: 2,
@@ -148,10 +185,42 @@ describe('CreateTokenMultisig (cct/solana)', () => {
   })
 
   describe('execute', () => {
+    it('signs, submits, and returns the multisig address', async () => {
+      const result = await new CreateTokenMultisig().execute(
+        Object.assign(stubChain(new PublicKey(AUTHORITY)), {
+          connection: {
+            getAccountInfo: async () => ({
+              owner: TOKEN_PROGRAM_ID,
+              data: mintData(new PublicKey(AUTHORITY)),
+              executable: false,
+              lamports: 1,
+            }),
+            getMinimumBalanceForRentExemption: async () => 123,
+            simulateTransaction: async () => ({ value: { err: null, logs: [], unitsConsumed: 1 } }),
+            getLatestBlockhash: async () => ({
+              blockhash: PublicKey.default.toBase58(),
+              lastValidBlockHeight: 1,
+            }),
+            sendTransaction: async () => HASH,
+            confirmTransaction: async () => ({ value: { err: null } }),
+          },
+        }),
+        {
+          tokenAddress: MINT,
+          poolType: 'burn-mint',
+          threshold: 1,
+          wallet: { ...WALLET, publicKey: new PublicKey(AUTHORITY) },
+        },
+      )
+
+      assert.equal(result.hash, HASH)
+      assert.ok(result.multisigAddress)
+    })
+
     it('rejects signed execute when wallet is not mint authority', async () => {
       await assert.rejects(
         () =>
-          SolanaTokenManager.fromChain(stubChain()).createTokenMultisig({
+          new CreateTokenMultisig().execute(stubChain(), {
             tokenAddress: MINT,
             poolType: 'burn-mint',
             threshold: 2,

--- a/ccip-sdk/src/cct/solana/token-pool/operations/delete-chain-remote-config.test.ts
+++ b/ccip-sdk/src/cct/solana/token-pool/operations/delete-chain-remote-config.test.ts
@@ -7,12 +7,12 @@ import { ChainFamily } from '../../../../networks.ts'
 import { tokenPoolCoder } from '../../../../solana/idl/token-pool-coder.ts'
 import type { SolanaChain } from '../../../../solana/index.ts'
 import { CCTParamsInvalidError } from '../../../errors.ts'
-import { SolanaTokenManager } from '../../index.ts'
 import {
   deriveTokenPoolChainConfigPda,
   deriveTokenPoolConfigPda,
   resolveTokenPoolProgram,
 } from '../../programs/token-pool.ts'
+import { DeleteChainRemoteConfig } from './delete-chain-remote-config.ts'
 
 const TOKEN = Keypair.generate().publicKey.toBase58()
 const PAYER = Keypair.generate().publicKey.toBase58()
@@ -46,7 +46,7 @@ function submitChain(): SolanaChain {
 }
 
 function generate(opts = {}) {
-  return SolanaTokenManager.fromChain(chain()).generateUnsignedDeleteChainRemoteConfig({
+  return new DeleteChainRemoteConfig().generate(chain(), {
     tokenAddress: TOKEN,
     poolType: 'burn-mint',
     payer: PAYER,
@@ -127,7 +127,7 @@ describe('DeleteChainRemoteConfig (cct/solana)', () => {
 
   describe('execute', () => {
     it('signs, submits, and returns the tx hash', async () => {
-      const result = await SolanaTokenManager.fromChain(submitChain()).deleteChainRemoteConfig({
+      const result = await new DeleteChainRemoteConfig().execute(submitChain(), {
         tokenAddress: TOKEN,
         poolType: 'burn-mint',
         remoteChainSelector: SELECTOR,
@@ -140,7 +140,7 @@ describe('DeleteChainRemoteConfig (cct/solana)', () => {
     it('rejects a non-wallet authority for signed deletion', async () => {
       await assert.rejects(
         () =>
-          SolanaTokenManager.fromChain(chain()).deleteChainRemoteConfig({
+          new DeleteChainRemoteConfig().execute(chain(), {
             tokenAddress: TOKEN,
             poolType: 'burn-mint',
             authority: AUTHORITY,

--- a/ccip-sdk/src/cct/solana/token-pool/operations/deploy-token-pool.test.ts
+++ b/ccip-sdk/src/cct/solana/token-pool/operations/deploy-token-pool.test.ts
@@ -6,18 +6,16 @@ import { Keypair, PublicKey } from '@solana/web3.js'
 import { ChainFamily } from '../../../../networks.ts'
 import type { SolanaChain } from '../../../../solana/index.ts'
 import { CCTParamsInvalidError } from '../../../errors.ts'
-import {
-  SolanaTokenManager,
-  deriveTokenPoolSignerPda,
-  resolveTokenPoolProgram,
-} from '../../index.ts'
+import { deriveTokenPoolSignerPda, resolveTokenPoolProgram } from '../../index.ts'
 import { deriveTokenPoolConfigPda } from '../../programs/token-pool.ts'
+import { DeployTokenPool } from './deploy-token-pool.ts'
 
 const TOKEN = Keypair.generate().publicKey.toBase58()
 const BURN_MINT_POOL_PROGRAM = '41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB'
 const LOCK_RELEASE_POOL_PROGRAM = '8eqh8wppT9c5rw4ERqNCffvU6cNFJWff9WmkcYtmGiqC'
 const PAYER = Keypair.generate().publicKey.toBase58()
 const AUTHORITY = Keypair.generate().publicKey.toBase58()
+const HASH = Keypair.generate().publicKey.toBase58()
 const WALLET = {
   publicKey: Keypair.generate().publicKey,
   signTransaction: async <T>(tx: T) => tx,
@@ -31,7 +29,7 @@ function stubChain(): SolanaChain {
 }
 
 function generate(opts = {}) {
-  return SolanaTokenManager.fromChain(stubChain()).generateUnsignedDeployTokenPool({
+  return new DeployTokenPool().generate(stubChain(), {
     tokenAddress: TOKEN,
     poolType: 'burn-mint',
     payer: PAYER,
@@ -88,6 +86,13 @@ describe('DeployTokenPool (cct/solana)', () => {
   })
 
   describe('validation', () => {
+    it('rejects a non-array allowlist', async () => {
+      await assert.rejects(
+        () => generate({ allowlist: 'not-an-array' }),
+        (err: unknown) => err instanceof CCTParamsInvalidError && err.context.param === 'allowlist',
+      )
+    })
+
     it('rejects invalid pool types', async () => {
       await assert.rejects(
         () => generate({ poolType: 'custom' }),
@@ -120,10 +125,35 @@ describe('DeployTokenPool (cct/solana)', () => {
   })
 
   describe('execute', () => {
+    it('signs, submits, and returns pool addresses', async () => {
+      const result = await new DeployTokenPool().execute(
+        Object.assign(stubChain(), {
+          connection: {
+            simulateTransaction: async () => ({ value: { err: null, logs: [], unitsConsumed: 1 } }),
+            getLatestBlockhash: async () => ({
+              blockhash: PublicKey.default.toBase58(),
+              lastValidBlockHeight: 1,
+            }),
+            sendTransaction: async () => HASH,
+            confirmTransaction: async () => ({ value: { err: null } }),
+          },
+        }),
+        {
+          tokenAddress: TOKEN,
+          poolType: 'burn-mint',
+          wallet: { ...WALLET, publicKey: new PublicKey(PAYER) },
+        },
+      )
+
+      assert.equal(result.hash, HASH)
+      assert.ok(result.poolAddress)
+      assert.ok(result.poolSignerAddress)
+    })
+
     it('rejects signed deploy when authority is not the wallet', async () => {
       await assert.rejects(
         () =>
-          SolanaTokenManager.fromChain(stubChain()).deployTokenPool({
+          new DeployTokenPool().execute(stubChain(), {
             tokenAddress: TOKEN,
             poolType: 'burn-mint',
             wallet: WALLET,

--- a/ccip-sdk/src/cct/solana/token-pool/operations/edit-chain-remote-config.test.ts
+++ b/ccip-sdk/src/cct/solana/token-pool/operations/edit-chain-remote-config.test.ts
@@ -7,12 +7,12 @@ import { ChainFamily } from '../../../../networks.ts'
 import { tokenPoolCoder } from '../../../../solana/idl/token-pool-coder.ts'
 import type { SolanaChain } from '../../../../solana/index.ts'
 import { CCTParamsInvalidError } from '../../../errors.ts'
-import { SolanaTokenManager } from '../../index.ts'
 import {
   deriveTokenPoolChainConfigPda,
   deriveTokenPoolConfigPda,
   resolveTokenPoolProgram,
 } from '../../programs/token-pool.ts'
+import { EditChainRemoteConfig } from './edit-chain-remote-config.ts'
 
 const TOKEN = Keypair.generate().publicKey.toBase58()
 const PAYER = Keypair.generate().publicKey.toBase58()
@@ -48,7 +48,7 @@ function submitChain(): SolanaChain {
 }
 
 function generate(opts = {}) {
-  return SolanaTokenManager.fromChain(chain()).generateUnsignedEditChainRemoteConfig({
+  return new EditChainRemoteConfig().generate(chain(), {
     tokenAddress: TOKEN,
     poolType: 'burn-mint',
     payer: PAYER,
@@ -153,7 +153,7 @@ describe('EditChainRemoteConfig (cct/solana)', () => {
 
   describe('execute', () => {
     it('signs, submits, and returns the tx hash', async () => {
-      const result = await SolanaTokenManager.fromChain(submitChain()).editChainRemoteConfig({
+      const result = await new EditChainRemoteConfig().execute(submitChain(), {
         tokenAddress: TOKEN,
         poolType: 'burn-mint',
         remoteChainSelector: SELECTOR,
@@ -169,7 +169,7 @@ describe('EditChainRemoteConfig (cct/solana)', () => {
     it('rejects a non-wallet authority for signed editing', async () => {
       await assert.rejects(
         () =>
-          SolanaTokenManager.fromChain(chain()).editChainRemoteConfig({
+          new EditChainRemoteConfig().execute(chain(), {
             tokenAddress: TOKEN,
             poolType: 'burn-mint',
             authority: AUTHORITY,

--- a/ccip-sdk/src/cct/solana/token-pool/operations/get-token-pool-remotes.test.ts
+++ b/ccip-sdk/src/cct/solana/token-pool/operations/get-token-pool-remotes.test.ts
@@ -6,8 +6,8 @@ import { PublicKey } from '@solana/web3.js'
 import type { TokenPoolRemote } from '../../../../chain.ts'
 import type { SolanaChain } from '../../../../solana/index.ts'
 import { CCTParamsInvalidError } from '../../../errors.ts'
-import { SolanaTokenManager } from '../../index.ts'
 import { deriveTokenPoolConfigPda } from '../../programs/token-pool.ts'
+import { GetTokenPoolRemotes } from './get-token-pool-remotes.ts'
 
 function key(byte: number): PublicKey {
   return new PublicKey(Uint8Array.from({ length: 32 }, () => byte))
@@ -39,7 +39,7 @@ describe('GetTokenPoolRemotes (cct/solana)', () => {
 
   describe('query', () => {
     it('delegates selected remote config decoding to the chain reader', async () => {
-      const remotes = await SolanaTokenManager.fromChain(chain()).getTokenPoolRemotes({
+      const remotes = await new GetTokenPoolRemotes().query(chain(), {
         tokenAddress: mint.toBase58(),
         poolProgramAddress: program.toBase58(),
         remoteChainSelector: selector,
@@ -56,7 +56,7 @@ describe('GetTokenPoolRemotes (cct/solana)', () => {
         },
       } as unknown as SolanaChain
 
-      const remotes = await SolanaTokenManager.fromChain(chainWithAll).getTokenPoolRemotes({
+      const remotes = await new GetTokenPoolRemotes().query(chainWithAll, {
         tokenAddress: mint.toBase58(),
         poolProgramAddress: program.toBase58(),
       })
@@ -75,7 +75,7 @@ describe('GetTokenPoolRemotes (cct/solana)', () => {
         ]
       for (const [opts, param] of cases) {
         await assert.rejects(
-          SolanaTokenManager.fromChain(chain()).getTokenPoolRemotes({
+          new GetTokenPoolRemotes().query(chain(), {
             tokenAddress: mint.toBase58(),
             poolProgramAddress: program.toBase58(),
             remoteChainSelector: selector,

--- a/ccip-sdk/src/cct/solana/token-pool/operations/init-chain-remote-config.test.ts
+++ b/ccip-sdk/src/cct/solana/token-pool/operations/init-chain-remote-config.test.ts
@@ -7,12 +7,12 @@ import { ChainFamily } from '../../../../networks.ts'
 import { tokenPoolCoder } from '../../../../solana/idl/token-pool-coder.ts'
 import type { SolanaChain } from '../../../../solana/index.ts'
 import { CCTParamsInvalidError } from '../../../errors.ts'
-import { SolanaTokenManager } from '../../index.ts'
 import {
   deriveTokenPoolChainConfigPda,
   deriveTokenPoolConfigPda,
   resolveTokenPoolProgram,
 } from '../../programs/token-pool.ts'
+import { InitChainRemoteConfig } from './init-chain-remote-config.ts'
 
 const TOKEN = Keypair.generate().publicKey.toBase58()
 const PAYER = Keypair.generate().publicKey.toBase58()
@@ -47,7 +47,7 @@ function submitChain(): SolanaChain {
 }
 
 function generate(opts = {}) {
-  return SolanaTokenManager.fromChain(chain()).generateUnsignedInitChainRemoteConfig({
+  return new InitChainRemoteConfig().generate(chain(), {
     tokenAddress: TOKEN,
     poolType: 'burn-mint',
     payer: PAYER,
@@ -144,7 +144,7 @@ describe('InitChainRemoteConfig (cct/solana)', () => {
 
   describe('execute', () => {
     it('signs, submits, and returns the tx hash', async () => {
-      const result = await SolanaTokenManager.fromChain(submitChain()).initChainRemoteConfig({
+      const result = await new InitChainRemoteConfig().execute(submitChain(), {
         tokenAddress: TOKEN,
         poolType: 'burn-mint',
         remoteChainSelector: SELECTOR,
@@ -159,7 +159,7 @@ describe('InitChainRemoteConfig (cct/solana)', () => {
     it('rejects a non-wallet authority for signed initialization', async () => {
       await assert.rejects(
         () =>
-          SolanaTokenManager.fromChain(chain()).initChainRemoteConfig({
+          new InitChainRemoteConfig().execute(chain(), {
             tokenAddress: TOKEN,
             poolType: 'burn-mint',
             authority: AUTHORITY,

--- a/ccip-sdk/src/cct/solana/token-pool/operations/provide-liquidity.test.ts
+++ b/ccip-sdk/src/cct/solana/token-pool/operations/provide-liquidity.test.ts
@@ -9,12 +9,13 @@ import { ChainFamily } from '../../../../networks.ts'
 import { lockReleaseTokenPoolCoder } from '../../../../solana/idl/token-pool-coder.ts'
 import type { SolanaChain } from '../../../../solana/index.ts'
 import { CCTParamsInvalidError, CCTTxFailedError } from '../../../errors.ts'
-import { SolanaTokenManager } from '../../index.ts'
 import {
   deriveTokenPoolConfigPda,
   deriveTokenPoolSignerPda,
   resolveTokenPoolProgram,
 } from '../../programs/token-pool.ts'
+import { ApproveToken } from '../../token/operations/approve-token.ts'
+import { ProvideLiquidity } from './provide-liquidity.ts'
 
 const TOKEN = Keypair.generate().publicKey.toBase58()
 const PAYER = Keypair.generate().publicKey.toBase58()
@@ -113,7 +114,7 @@ function submitChain(): SolanaChain {
 }
 
 function generate(opts = {}) {
-  return SolanaTokenManager.fromChain(chain()).generateUnsignedProvideLiquidity({
+  return new ProvideLiquidity().generate(chain(), {
     tokenAddress: TOKEN,
     poolType: 'lock-release',
     payer: PAYER,
@@ -186,7 +187,7 @@ describe('ProvideLiquidity (cct/solana)', () => {
       ] as const) {
         await assert.rejects(
           () =>
-            SolanaTokenManager.fromChain(pool).generateUnsignedProvideLiquidity({
+            new ProvideLiquidity().generate(pool, {
               tokenAddress: TOKEN,
               poolType: 'lock-release',
               payer: PAYER,
@@ -199,14 +200,15 @@ describe('ProvideLiquidity (cct/solana)', () => {
     })
 
     it('defaults authority to payer', async () => {
-      const unsigned = await SolanaTokenManager.fromChain(
+      const unsigned = await new ProvideLiquidity().generate(
         chain(resolveTokenPoolProgram('lock-release'), new PublicKey(PAYER)),
-      ).generateUnsignedProvideLiquidity({
-        tokenAddress: TOKEN,
-        poolType: 'lock-release',
-        payer: PAYER,
-        amount: 1_000_000n,
-      })
+        {
+          tokenAddress: TOKEN,
+          poolType: 'lock-release',
+          payer: PAYER,
+          amount: 1_000_000n,
+        },
+      )
 
       assert.equal(unsigned.instructions[0]!.keys[6]!.pubkey.toBase58(), PAYER)
     })
@@ -214,7 +216,7 @@ describe('ProvideLiquidity (cct/solana)', () => {
     it('uses a source account that can be delegated to the pool signer', async () => {
       const poolProgram = resolveTokenPoolProgram('lock-release')
       const poolSigner = deriveTokenPoolSignerPda(poolProgram, new PublicKey(TOKEN))
-      const approval = await SolanaTokenManager.fromChain(chain()).generateUnsignedApproveToken({
+      const approval = await new ApproveToken().generate(chain(), {
         payer: AUTHORITY,
         tokenAddress: TOKEN,
         delegate: poolSigner.toBase58(),
@@ -232,15 +234,16 @@ describe('ProvideLiquidity (cct/solana)', () => {
 
     it('supports a compatible custom pool program', async () => {
       const poolProgramAddress = Keypair.generate().publicKey.toBase58()
-      const unsigned = await SolanaTokenManager.fromChain(
+      const unsigned = await new ProvideLiquidity().generate(
         chain(new PublicKey(poolProgramAddress)),
-      ).generateUnsignedProvideLiquidity({
-        tokenAddress: TOKEN,
-        poolProgramAddress,
-        payer: PAYER,
-        authority: AUTHORITY,
-        amount: 1_000_000n,
-      })
+        {
+          tokenAddress: TOKEN,
+          poolProgramAddress,
+          payer: PAYER,
+          authority: AUTHORITY,
+          amount: 1_000_000n,
+        },
+      )
 
       assert.equal(unsigned.instructions[0]?.programId.toBase58(), poolProgramAddress)
     })
@@ -272,7 +275,7 @@ describe('ProvideLiquidity (cct/solana)', () => {
 
   describe('execute', () => {
     it('signs, submits, and returns the tx hash', async () => {
-      const result = await SolanaTokenManager.fromChain(submitChain()).provideLiquidity({
+      const result = await new ProvideLiquidity().execute(submitChain(), {
         tokenAddress: TOKEN,
         poolType: 'lock-release',
         amount: 1_000_000n,
@@ -285,7 +288,7 @@ describe('ProvideLiquidity (cct/solana)', () => {
     it('rejects a non-wallet authority for signed liquidity provision', async () => {
       await assert.rejects(
         () =>
-          SolanaTokenManager.fromChain(chain()).provideLiquidity({
+          new ProvideLiquidity().execute(chain(), {
             tokenAddress: TOKEN,
             poolType: 'lock-release',
             amount: 1_000_000n,

--- a/ccip-sdk/src/cct/solana/token-pool/operations/remove-from-allowlist.test.ts
+++ b/ccip-sdk/src/cct/solana/token-pool/operations/remove-from-allowlist.test.ts
@@ -8,8 +8,8 @@ import { ChainFamily } from '../../../../networks.ts'
 import { tokenPoolCoder } from '../../../../solana/idl/token-pool-coder.ts'
 import type { SolanaChain } from '../../../../solana/index.ts'
 import { CCTParamsInvalidError } from '../../../errors.ts'
-import { SolanaTokenManager } from '../../index.ts'
 import { deriveTokenPoolConfigPda, resolveTokenPoolProgram } from '../../programs/token-pool.ts'
+import { RemoveFromAllowlist } from './remove-from-allowlist.ts'
 
 const TOKEN = Keypair.generate().publicKey.toBase58()
 const PAYER = Keypair.generate().publicKey.toBase58()
@@ -44,7 +44,7 @@ function submitChain(): SolanaChain {
 }
 
 function generate(opts = {}) {
-  return SolanaTokenManager.fromChain(stubChain()).generateUnsignedRemoveFromAllowlist({
+  return new RemoveFromAllowlist().generate(stubChain(), {
     tokenAddress: TOKEN,
     poolType: 'burn-mint',
     payer: PAYER,
@@ -102,9 +102,7 @@ describe('RemoveFromAllowlist (cct/solana)', () => {
 
     it('uses a compatible custom pool program', async () => {
       const poolProgramAddress = Keypair.generate().publicKey.toBase58()
-      const unsigned = await SolanaTokenManager.fromChain(
-        stubChain(),
-      ).generateUnsignedRemoveFromAllowlist({
+      const unsigned = await new RemoveFromAllowlist().generate(stubChain(), {
         tokenAddress: TOKEN,
         poolProgramAddress,
         payer: PAYER,
@@ -162,7 +160,7 @@ describe('RemoveFromAllowlist (cct/solana)', () => {
 
   describe('execute', () => {
     it('signs, submits, and returns the tx hash', async () => {
-      const result = await SolanaTokenManager.fromChain(submitChain()).removeFromAllowlist({
+      const result = await new RemoveFromAllowlist().execute(submitChain(), {
         tokenAddress: TOKEN,
         poolType: 'burn-mint',
         remove: [ALLOWED],
@@ -175,7 +173,7 @@ describe('RemoveFromAllowlist (cct/solana)', () => {
     it('rejects a non-wallet authority for signed removal', async () => {
       await assert.rejects(
         () =>
-          SolanaTokenManager.fromChain(stubChain()).removeFromAllowlist({
+          new RemoveFromAllowlist().execute(stubChain(), {
             tokenAddress: TOKEN,
             poolType: 'burn-mint',
             authority: AUTHORITY,

--- a/ccip-sdk/src/cct/solana/token-pool/operations/set-can-accept-liquidity.test.ts
+++ b/ccip-sdk/src/cct/solana/token-pool/operations/set-can-accept-liquidity.test.ts
@@ -7,8 +7,8 @@ import { ChainFamily } from '../../../../networks.ts'
 import { lockReleaseTokenPoolCoder } from '../../../../solana/idl/token-pool-coder.ts'
 import type { SolanaChain } from '../../../../solana/index.ts'
 import { CCTParamsInvalidError } from '../../../errors.ts'
-import { SolanaTokenManager } from '../../index.ts'
 import { deriveTokenPoolConfigPda, resolveTokenPoolProgram } from '../../programs/token-pool.ts'
+import { SetCanAcceptLiquidity } from './set-can-accept-liquidity.ts'
 
 const TOKEN = Keypair.generate().publicKey.toBase58()
 const PAYER = Keypair.generate().publicKey.toBase58()
@@ -42,7 +42,7 @@ function submitChain(): SolanaChain {
 }
 
 function generate(opts = {}) {
-  return SolanaTokenManager.fromChain(chain()).generateUnsignedSetCanAcceptLiquidity({
+  return new SetCanAcceptLiquidity().generate(chain(), {
     tokenAddress: TOKEN,
     poolType: 'lock-release',
     payer: PAYER,
@@ -122,7 +122,7 @@ describe('SetCanAcceptLiquidity (cct/solana)', () => {
 
   describe('execute', () => {
     it('signs, submits, and returns the tx hash', async () => {
-      const result = await SolanaTokenManager.fromChain(submitChain()).setCanAcceptLiquidity({
+      const result = await new SetCanAcceptLiquidity().execute(submitChain(), {
         tokenAddress: TOKEN,
         poolType: 'lock-release',
         allow: ALLOW,
@@ -135,7 +135,7 @@ describe('SetCanAcceptLiquidity (cct/solana)', () => {
     it('rejects a non-wallet authority for signed configuration', async () => {
       await assert.rejects(
         () =>
-          SolanaTokenManager.fromChain(chain()).setCanAcceptLiquidity({
+          new SetCanAcceptLiquidity().execute(chain(), {
             tokenAddress: TOKEN,
             poolType: 'lock-release',
             allow: ALLOW,

--- a/ccip-sdk/src/cct/solana/token-pool/operations/set-chain-rate-limit.test.ts
+++ b/ccip-sdk/src/cct/solana/token-pool/operations/set-chain-rate-limit.test.ts
@@ -7,12 +7,12 @@ import { ChainFamily } from '../../../../networks.ts'
 import { tokenPoolCoder } from '../../../../solana/idl/token-pool-coder.ts'
 import type { SolanaChain } from '../../../../solana/index.ts'
 import { CCTParamsInvalidError } from '../../../errors.ts'
-import { SolanaTokenManager } from '../../index.ts'
 import {
   deriveTokenPoolChainConfigPda,
   deriveTokenPoolConfigPda,
   resolveTokenPoolProgram,
 } from '../../programs/token-pool.ts'
+import { SetChainRateLimit } from './set-chain-rate-limit.ts'
 
 const TOKEN = Keypair.generate().publicKey.toBase58()
 const PAYER = Keypair.generate().publicKey.toBase58()
@@ -46,7 +46,7 @@ function submitChain(): SolanaChain {
 }
 
 function generate(opts = {}) {
-  return SolanaTokenManager.fromChain(chain()).generateUnsignedSetChainRateLimit({
+  return new SetChainRateLimit().generate(chain(), {
     tokenAddress: TOKEN,
     poolType: 'burn-mint',
     payer: PAYER,
@@ -193,7 +193,7 @@ describe('SetChainRateLimit (cct/solana)', () => {
 
   describe('execute', () => {
     it('signs, submits, and returns the tx hash', async () => {
-      const result = await SolanaTokenManager.fromChain(submitChain()).setChainRateLimit({
+      const result = await new SetChainRateLimit().execute(submitChain(), {
         tokenAddress: TOKEN,
         poolType: 'burn-mint',
         remoteChainSelector: SELECTOR,
@@ -208,7 +208,7 @@ describe('SetChainRateLimit (cct/solana)', () => {
     it('rejects a non-wallet authority for signed configuration', async () => {
       await assert.rejects(
         () =>
-          SolanaTokenManager.fromChain(chain()).setChainRateLimit({
+          new SetChainRateLimit().execute(chain(), {
             tokenAddress: TOKEN,
             poolType: 'burn-mint',
             authority: AUTHORITY,

--- a/ccip-sdk/src/cct/solana/token-pool/operations/set-rate-limit-admin.test.ts
+++ b/ccip-sdk/src/cct/solana/token-pool/operations/set-rate-limit-admin.test.ts
@@ -7,8 +7,8 @@ import { ChainFamily } from '../../../../networks.ts'
 import { tokenPoolCoder } from '../../../../solana/idl/token-pool-coder.ts'
 import type { SolanaChain } from '../../../../solana/index.ts'
 import { CCTParamsInvalidError } from '../../../errors.ts'
-import { SolanaTokenManager } from '../../index.ts'
 import { deriveTokenPoolConfigPda, resolveTokenPoolProgram } from '../../programs/token-pool.ts'
+import { SetRateLimitAdmin } from './set-rate-limit-admin.ts'
 
 const TOKEN = Keypair.generate().publicKey.toBase58()
 const PAYER = Keypair.generate().publicKey.toBase58()
@@ -42,7 +42,7 @@ function submitChain(): SolanaChain {
 }
 
 function generate(opts = {}) {
-  return SolanaTokenManager.fromChain(chain()).generateUnsignedSetRateLimitAdmin({
+  return new SetRateLimitAdmin().generate(chain(), {
     tokenAddress: TOKEN,
     poolType: 'burn-mint',
     payer: PAYER,
@@ -115,7 +115,7 @@ describe('SetRateLimitAdmin (cct/solana)', () => {
 
   describe('execute', () => {
     it('signs, submits, and returns the tx hash', async () => {
-      const result = await SolanaTokenManager.fromChain(submitChain()).setRateLimitAdmin({
+      const result = await new SetRateLimitAdmin().execute(submitChain(), {
         tokenAddress: TOKEN,
         poolType: 'burn-mint',
         newRateLimitAdmin: NEW_RATE_LIMIT_ADMIN,
@@ -128,7 +128,7 @@ describe('SetRateLimitAdmin (cct/solana)', () => {
     it('rejects a non-wallet authority for signed configuration', async () => {
       await assert.rejects(
         () =>
-          SolanaTokenManager.fromChain(chain()).setRateLimitAdmin({
+          new SetRateLimitAdmin().execute(chain(), {
             tokenAddress: TOKEN,
             poolType: 'burn-mint',
             newRateLimitAdmin: NEW_RATE_LIMIT_ADMIN,

--- a/ccip-sdk/src/cct/solana/token-pool/operations/set-rebalancer.test.ts
+++ b/ccip-sdk/src/cct/solana/token-pool/operations/set-rebalancer.test.ts
@@ -7,8 +7,8 @@ import { ChainFamily } from '../../../../networks.ts'
 import { lockReleaseTokenPoolCoder } from '../../../../solana/idl/token-pool-coder.ts'
 import type { SolanaChain } from '../../../../solana/index.ts'
 import { CCTParamsInvalidError } from '../../../errors.ts'
-import { SolanaTokenManager } from '../../index.ts'
 import { deriveTokenPoolConfigPda, resolveTokenPoolProgram } from '../../programs/token-pool.ts'
+import { SetRebalancer } from './set-rebalancer.ts'
 
 const TOKEN = Keypair.generate().publicKey.toBase58()
 const PAYER = Keypair.generate().publicKey.toBase58()
@@ -42,7 +42,7 @@ function submitChain(): SolanaChain {
 }
 
 function generate(opts = {}) {
-  return SolanaTokenManager.fromChain(chain()).generateUnsignedSetRebalancer({
+  return new SetRebalancer().generate(chain(), {
     tokenAddress: TOKEN,
     poolType: 'lock-release',
     payer: PAYER,
@@ -125,7 +125,7 @@ describe('SetRebalancer (cct/solana)', () => {
 
   describe('execute', () => {
     it('signs, submits, and returns the tx hash', async () => {
-      const result = await SolanaTokenManager.fromChain(submitChain()).setRebalancer({
+      const result = await new SetRebalancer().execute(submitChain(), {
         tokenAddress: TOKEN,
         poolType: 'lock-release',
         rebalancer: REBALANCER,
@@ -138,7 +138,7 @@ describe('SetRebalancer (cct/solana)', () => {
     it('rejects a non-wallet authority for signed configuration', async () => {
       await assert.rejects(
         () =>
-          SolanaTokenManager.fromChain(chain()).setRebalancer({
+          new SetRebalancer().execute(chain(), {
             tokenAddress: TOKEN,
             poolType: 'lock-release',
             rebalancer: REBALANCER,

--- a/ccip-sdk/src/cct/solana/token-pool/operations/transfer-ownership.test.ts
+++ b/ccip-sdk/src/cct/solana/token-pool/operations/transfer-ownership.test.ts
@@ -8,8 +8,8 @@ import { ChainFamily } from '../../../../networks.ts'
 import { tokenPoolCoder } from '../../../../solana/idl/token-pool-coder.ts'
 import type { SolanaChain } from '../../../../solana/index.ts'
 import { CCTParamsInvalidError } from '../../../errors.ts'
-import { SolanaTokenManager } from '../../index.ts'
 import { deriveTokenPoolConfigPda, resolveTokenPoolProgram } from '../../programs/token-pool.ts'
+import { TransferOwnership } from './transfer-ownership.ts'
 
 const TOKEN = Keypair.generate().publicKey.toBase58()
 const PAYER = Keypair.generate().publicKey.toBase58()
@@ -69,7 +69,7 @@ function submitChain(): SolanaChain {
 }
 
 function generate(opts = {}) {
-  return SolanaTokenManager.fromChain(chain()).generateUnsignedTransferOwnership({
+  return new TransferOwnership().generate(chain(), {
     tokenAddress: TOKEN,
     poolType: 'burn-mint',
     payer: PAYER,
@@ -156,7 +156,7 @@ describe('TransferOwnership (cct/solana)', () => {
 
   describe('execute', () => {
     it('signs, submits, and returns the tx hash', async () => {
-      const result = await SolanaTokenManager.fromChain(submitChain()).transferOwnership({
+      const result = await new TransferOwnership().execute(submitChain(), {
         tokenAddress: TOKEN,
         poolType: 'burn-mint',
         newOwner: NEW_OWNER,
@@ -169,7 +169,7 @@ describe('TransferOwnership (cct/solana)', () => {
     it('rejects a non-wallet authority for signed transfer', async () => {
       await assert.rejects(
         () =>
-          SolanaTokenManager.fromChain(chain()).transferOwnership({
+          new TransferOwnership().execute(chain(), {
             tokenAddress: TOKEN,
             poolType: 'burn-mint',
             newOwner: NEW_OWNER,

--- a/ccip-sdk/src/cct/solana/token-pool/operations/withdraw-liquidity.test.ts
+++ b/ccip-sdk/src/cct/solana/token-pool/operations/withdraw-liquidity.test.ts
@@ -9,12 +9,12 @@ import { ChainFamily } from '../../../../networks.ts'
 import { lockReleaseTokenPoolCoder } from '../../../../solana/idl/token-pool-coder.ts'
 import type { SolanaChain } from '../../../../solana/index.ts'
 import { CCTParamsInvalidError, CCTTxFailedError } from '../../../errors.ts'
-import { SolanaTokenManager } from '../../index.ts'
 import {
   deriveTokenPoolConfigPda,
   deriveTokenPoolSignerPda,
   resolveTokenPoolProgram,
 } from '../../programs/token-pool.ts'
+import { WithdrawLiquidity } from './withdraw-liquidity.ts'
 
 const TOKEN = Keypair.generate().publicKey.toBase58()
 const PAYER = Keypair.generate().publicKey.toBase58()
@@ -118,7 +118,7 @@ function submitChain(): SolanaChain {
 }
 
 function generate(opts = {}) {
-  return SolanaTokenManager.fromChain(chain()).generateUnsignedWithdrawLiquidity({
+  return new WithdrawLiquidity().generate(chain(), {
     tokenAddress: TOKEN,
     poolType: 'lock-release',
     payer: PAYER,
@@ -191,7 +191,7 @@ describe('WithdrawLiquidity (cct/solana)', () => {
       ] as const) {
         await assert.rejects(
           () =>
-            SolanaTokenManager.fromChain(pool).generateUnsignedWithdrawLiquidity({
+            new WithdrawLiquidity().generate(pool, {
               tokenAddress: TOKEN,
               poolType: 'lock-release',
               payer: PAYER,
@@ -204,29 +204,31 @@ describe('WithdrawLiquidity (cct/solana)', () => {
     })
 
     it('defaults authority to payer', async () => {
-      const unsigned = await SolanaTokenManager.fromChain(
+      const unsigned = await new WithdrawLiquidity().generate(
         chain(resolveTokenPoolProgram('lock-release'), new PublicKey(PAYER)),
-      ).generateUnsignedWithdrawLiquidity({
-        tokenAddress: TOKEN,
-        poolType: 'lock-release',
-        payer: PAYER,
-        amount: 1_000_000n,
-      })
+        {
+          tokenAddress: TOKEN,
+          poolType: 'lock-release',
+          payer: PAYER,
+          amount: 1_000_000n,
+        },
+      )
 
       assert.equal(unsigned.instructions[0]!.keys[6]!.pubkey.toBase58(), PAYER)
     })
 
     it('supports a compatible custom pool program', async () => {
       const poolProgramAddress = Keypair.generate().publicKey.toBase58()
-      const unsigned = await SolanaTokenManager.fromChain(
+      const unsigned = await new WithdrawLiquidity().generate(
         chain(new PublicKey(poolProgramAddress)),
-      ).generateUnsignedWithdrawLiquidity({
-        tokenAddress: TOKEN,
-        poolProgramAddress,
-        payer: PAYER,
-        authority: AUTHORITY,
-        amount: 1_000_000n,
-      })
+        {
+          tokenAddress: TOKEN,
+          poolProgramAddress,
+          payer: PAYER,
+          authority: AUTHORITY,
+          amount: 1_000_000n,
+        },
+      )
 
       assert.equal(unsigned.instructions[0]?.programId.toBase58(), poolProgramAddress)
     })
@@ -258,7 +260,7 @@ describe('WithdrawLiquidity (cct/solana)', () => {
 
   describe('execute', () => {
     it('signs, submits, and returns the tx hash', async () => {
-      const result = await SolanaTokenManager.fromChain(submitChain()).withdrawLiquidity({
+      const result = await new WithdrawLiquidity().execute(submitChain(), {
         tokenAddress: TOKEN,
         poolType: 'lock-release',
         amount: 1_000_000n,
@@ -271,7 +273,7 @@ describe('WithdrawLiquidity (cct/solana)', () => {
     it('rejects a non-wallet authority for signed liquidity withdrawal', async () => {
       await assert.rejects(
         () =>
-          SolanaTokenManager.fromChain(chain()).withdrawLiquidity({
+          new WithdrawLiquidity().execute(chain(), {
             tokenAddress: TOKEN,
             poolType: 'lock-release',
             amount: 1_000_000n,

--- a/ccip-sdk/src/cct/solana/token/operations/approve-token.test.ts
+++ b/ccip-sdk/src/cct/solana/token/operations/approve-token.test.ts
@@ -16,8 +16,8 @@ import {
 import { ChainFamily } from '../../../../networks.ts'
 import type { SolanaChain } from '../../../../solana/index.ts'
 import { CCTParamsInvalidError } from '../../../errors.ts'
-import { SolanaTokenManager } from '../../index.ts'
 import { U64_MAX } from '../../validate.ts'
+import { ApproveToken } from './approve-token.ts'
 
 const TOKEN = Keypair.generate().publicKey
 const PAYER = Keypair.generate().publicKey.toBase58()
@@ -60,7 +60,7 @@ function submitChain(): SolanaChain {
 }
 
 function generate(opts: Record<string, unknown> = {}, mintOwner?: PublicKey | null) {
-  return SolanaTokenManager.fromChain(chain(mintOwner)).generateUnsignedApproveToken({
+  return new ApproveToken().generate(chain(mintOwner), {
     payer: PAYER,
     tokenAddress: TOKEN.toBase58(),
     delegate: DELEGATE,
@@ -165,14 +165,12 @@ describe('ApproveToken (cct/solana)', () => {
     it('rejects a missing token account before submission', async () => {
       await assert.rejects(
         () =>
-          SolanaTokenManager.fromChain(chain(TOKEN_PROGRAM_ID, false)).generateUnsignedApproveToken(
-            {
-              payer: PAYER,
-              tokenAddress: TOKEN.toBase58(),
-              delegate: DELEGATE,
-              amount: 1n,
-            },
-          ),
+          new ApproveToken().generate(chain(TOKEN_PROGRAM_ID, false), {
+            payer: PAYER,
+            tokenAddress: TOKEN.toBase58(),
+            delegate: DELEGATE,
+            amount: 1n,
+          }),
         (err: unknown) => err instanceof CCIPTokenAccountNotFoundError,
       )
     })
@@ -191,7 +189,7 @@ describe('ApproveToken (cct/solana)', () => {
 
   describe('execute', () => {
     it('signs, submits, and returns the tx hash', async () => {
-      const result = await SolanaTokenManager.fromChain(submitChain()).approveToken({
+      const result = await new ApproveToken().execute(submitChain(), {
         tokenAddress: TOKEN.toBase58(),
         delegate: DELEGATE,
         amount: 1n,
@@ -207,7 +205,7 @@ describe('ApproveToken (cct/solana)', () => {
       ]) {
         await assert.rejects(
           () =>
-            SolanaTokenManager.fromChain(chain()).approveToken({
+            new ApproveToken().execute(chain(), {
               tokenAddress: TOKEN.toBase58(),
               delegate: DELEGATE,
               amount: 1n,

--- a/ccip-sdk/src/cct/solana/token/operations/create-token-account.test.ts
+++ b/ccip-sdk/src/cct/solana/token/operations/create-token-account.test.ts
@@ -7,7 +7,7 @@ import {
   TOKEN_PROGRAM_ID,
   getAssociatedTokenAddressSync,
 } from '@solana/spl-token'
-import { type PublicKey, Keypair } from '@solana/web3.js'
+import { Keypair, PublicKey } from '@solana/web3.js'
 
 import {
   CCIPTokenMintInvalidError,
@@ -16,11 +16,16 @@ import {
 } from '../../../../errors/index.ts'
 import { ChainFamily } from '../../../../networks.ts'
 import type { SolanaChain } from '../../../../solana/index.ts'
-import { SolanaTokenManager } from '../../index.ts'
+import { CreateTokenAccount } from './create-token-account.ts'
 
 const PAYER = Keypair.generate().publicKey.toBase58()
 const MINT = Keypair.generate().publicKey
 const OWNER = Keypair.generate().publicKey
+const HASH = Keypair.generate().publicKey.toBase58()
+const WALLET = {
+  publicKey: Keypair.generate().publicKey,
+  signTransaction: async <T>(tx: T) => tx,
+}
 
 function stubChain(mintOwner: PublicKey | null = TOKEN_2022_PROGRAM_ID): SolanaChain {
   return {
@@ -31,8 +36,23 @@ function stubChain(mintOwner: PublicKey | null = TOKEN_2022_PROGRAM_ID): SolanaC
   } as unknown as SolanaChain
 }
 
+function submitChain(): SolanaChain {
+  return Object.assign(stubChain(), {
+    connection: {
+      getAccountInfo: async () => ({ owner: TOKEN_2022_PROGRAM_ID }),
+      simulateTransaction: async () => ({ value: { err: null, logs: [], unitsConsumed: 1 } }),
+      getLatestBlockhash: async () => ({
+        blockhash: PublicKey.default.toBase58(),
+        lastValidBlockHeight: 1,
+      }),
+      sendTransaction: async () => HASH,
+      confirmTransaction: async () => ({ value: { err: null } }),
+    },
+  })
+}
+
 function generate(opts = {}, mintOwner?: PublicKey | null) {
-  return SolanaTokenManager.fromChain(stubChain(mintOwner)).generateUnsignedCreateTokenAccount({
+  return new CreateTokenAccount().generate(stubChain(mintOwner), {
     payer: PAYER,
     tokenAddress: MINT.toBase58(),
     ownerAddress: OWNER.toBase58(),
@@ -90,9 +110,27 @@ describe('CreateTokenAccount (cct/solana)', () => {
   })
 
   describe('execute', () => {
+    it('signs, submits, and returns the token account address', async () => {
+      const result = await new CreateTokenAccount().execute(submitChain(), {
+        tokenAddress: MINT.toBase58(),
+        ownerAddress: OWNER.toBase58(),
+        wallet: WALLET,
+      })
+
+      assert.deepEqual(result, {
+        hash: HASH,
+        tokenAccountAddress: getAssociatedTokenAddressSync(
+          MINT,
+          OWNER,
+          true,
+          TOKEN_2022_PROGRAM_ID,
+        ).toBase58(),
+      })
+    })
+
     it('rejects an invalid wallet before generating instructions', async () => {
       await assert.rejects(
-        SolanaTokenManager.fromChain(stubChain()).createTokenAccount({
+        new CreateTokenAccount().execute(stubChain(), {
           tokenAddress: MINT.toBase58(),
           ownerAddress: OWNER.toBase58(),
           wallet: {},

--- a/ccip-sdk/src/cct/solana/token/operations/deploy-token.test.ts
+++ b/ccip-sdk/src/cct/solana/token/operations/deploy-token.test.ts
@@ -7,11 +7,16 @@ import { Keypair, PublicKey, SystemProgram } from '@solana/web3.js'
 import { ChainFamily } from '../../../../networks.ts'
 import type { SolanaChain } from '../../../../solana/index.ts'
 import { CCTParamsInvalidError } from '../../../errors.ts'
-import { SolanaTokenManager } from '../../index.ts'
+import { DeployToken } from './deploy-token.ts'
 
 const BLOCKHASH = PublicKey.default.toBase58()
 const PAYER = Keypair.generate().publicKey.toBase58()
 const METAPLEX_PROGRAM = 'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s'
+const HASH = Keypair.generate().publicKey.toBase58()
+const WALLET = {
+  publicKey: Keypair.generate().publicKey,
+  signTransaction: async <T>(tx: T) => tx,
+}
 
 function stubChain(): SolanaChain {
   return {
@@ -25,8 +30,21 @@ function stubChain(): SolanaChain {
   } as unknown as SolanaChain
 }
 
-function generate(opts = {}) {
-  return SolanaTokenManager.fromChain(stubChain()).generateUnsignedDeployToken({
+function submitChain(): SolanaChain {
+  return Object.assign(stubChain(), {
+    connection: {
+      rpcEndpoint: 'http://localhost:8899',
+      getMinimumBalanceForRentExemption: async () => 123,
+      simulateTransaction: async () => ({ value: { err: null, logs: [], unitsConsumed: 1 } }),
+      getLatestBlockhash: async () => ({ blockhash: BLOCKHASH, lastValidBlockHeight: 0 }),
+      sendTransaction: async () => HASH,
+      confirmTransaction: async () => ({ value: { err: null } }),
+    },
+  })
+}
+
+function generate(opts: Record<string, unknown> = {}) {
+  return new DeployToken().generate(stubChain(), {
     decimals: 9,
     withMetaplex: false,
     payer: PAYER,
@@ -53,8 +71,8 @@ describe('DeployToken (cct/solana)', () => {
       assert.equal(initializeMintIx.data[0], 20) // InitializeMint2, not legacy InitializeMint
     })
 
-    it('uses caller seed for reproducible mint address', async () => {
-      const a = await generate({ seed: 'mint_seed' })
+    it('uses caller seed for reproducible mint address and supports no freeze authority', async () => {
+      const a = await generate({ seed: 'mint_seed', freezeAuthority: null })
       const b = await generate({ seed: 'mint_seed' })
 
       assert.equal(a.tokenAddress, b.tokenAddress)
@@ -100,31 +118,39 @@ describe('DeployToken (cct/solana)', () => {
     })
   })
 
-  describe('execute', () => {
-    it('rejects execute when preMint needs a non-wallet mintAuthority signer', async () => {
-      const wallet = {
-        publicKey: Keypair.generate().publicKey,
-        signTransaction: async <T>(tx: T) => tx,
-      }
-
-      await assert.rejects(
-        () =>
-          SolanaTokenManager.fromChain(stubChain()).deployToken({
-            wallet,
-            decimals: 9,
-            tokenProgram: 'spl-token',
-            withMetaplex: false,
-            mintAuthority: Keypair.generate().publicKey.toBase58(),
-            preMint: 100n,
-            preMintRecipient: Keypair.generate().publicKey.toBase58(),
-          }),
-        (err: unknown) =>
-          err instanceof CCTParamsInvalidError && err.context.param === 'mintAuthority',
-      )
-    })
-  })
-
   describe('validation', () => {
+    it('rejects invalid base and pre-mint parameters', async () => {
+      for (const [opts, param] of [
+        [{ decimals: 256 }, 'decimals'],
+        [{ tokenProgram: 'invalid' }, 'tokenProgram'],
+        [{ withMetaplex: 'yes' }, 'withMetaplex'],
+        [{ seed: '' }, 'seed'],
+        [{ mintAuthority: 'invalid' }, 'mintAuthority'],
+        [{ freezeAuthority: 'invalid' }, 'freezeAuthority'],
+        [{ preMint: 0n }, 'preMint'],
+        [{ preMint: 1 }, 'preMint'],
+        [{ preMint: 1n }, 'preMintRecipient'],
+        [{ preMint: 1n, preMintRecipient: 'invalid' }, 'preMintRecipient'],
+      ] as const) {
+        await assert.rejects(
+          () => generate(opts),
+          (err: unknown) => err instanceof CCTParamsInvalidError && err.context.param === param,
+        )
+      }
+    })
+
+    it('rejects invalid Metaplex name and URI parameters', async () => {
+      for (const [opts, param] of [
+        [{ withMetaplex: true, name: '', symbol: 'MTK' }, 'name'],
+        [{ withMetaplex: true, name: 'My Token', symbol: 'MTK', uri: 1 }, 'uri'],
+      ] as const) {
+        await assert.rejects(
+          () => generate(opts),
+          (err: unknown) => err instanceof CCTParamsInvalidError && err.context.param === param,
+        )
+      }
+    })
+
     it('rejects seeds over 32 UTF-8 bytes', async () => {
       await assert.rejects(
         () => generate({ seed: '🚀'.repeat(9) }),
@@ -141,6 +167,54 @@ describe('DeployToken (cct/solana)', () => {
             symbol: '🚀🚀🚀',
           }),
         (err: unknown) => err instanceof CCTParamsInvalidError && err.context.param === 'symbol',
+      )
+    })
+  })
+
+  describe('execute', () => {
+    it('signs, submits, and returns the mint address', async () => {
+      const result = await new DeployToken().execute(submitChain(), {
+        wallet: WALLET,
+        decimals: 9,
+        withMetaplex: false,
+      })
+
+      assert.equal(result.hash, HASH)
+      assert.match(result.tokenAddress, /^[1-9A-HJ-NP-Za-km-z]+$/)
+    })
+
+    it('returns the metadata address when creating Metaplex metadata', async () => {
+      const result = await new DeployToken().execute(submitChain(), {
+        wallet: WALLET,
+        decimals: 9,
+        withMetaplex: true,
+        name: 'My Token',
+        symbol: 'MTK',
+      })
+
+      assert.equal(result.hash, HASH)
+      assert.match(result.metadataAddress!, /^[1-9A-HJ-NP-Za-km-z]+$/)
+    })
+
+    it('rejects execute when preMint needs a non-wallet mintAuthority signer', async () => {
+      const wallet = {
+        publicKey: Keypair.generate().publicKey,
+        signTransaction: async <T>(tx: T) => tx,
+      }
+
+      await assert.rejects(
+        () =>
+          new DeployToken().execute(stubChain(), {
+            wallet,
+            decimals: 9,
+            tokenProgram: 'spl-token',
+            withMetaplex: false,
+            mintAuthority: Keypair.generate().publicKey.toBase58(),
+            preMint: 100n,
+            preMintRecipient: Keypair.generate().publicKey.toBase58(),
+          }),
+        (err: unknown) =>
+          err instanceof CCTParamsInvalidError && err.context.param === 'mintAuthority',
       )
     })
   })

--- a/ccip-sdk/src/cct/solana/token/operations/mint-tokens.test.ts
+++ b/ccip-sdk/src/cct/solana/token/operations/mint-tokens.test.ts
@@ -16,8 +16,8 @@ import {
 import { ChainFamily } from '../../../../networks.ts'
 import type { SolanaChain } from '../../../../solana/index.ts'
 import { CCTParamsInvalidError } from '../../../errors.ts'
-import { SolanaTokenManager } from '../../index.ts'
 import { U64_MAX } from '../../validate.ts'
+import { MintTokens } from './mint-tokens.ts'
 
 const TOKEN = Keypair.generate().publicKey
 const PAYER = Keypair.generate().publicKey.toBase58()
@@ -58,7 +58,7 @@ function submitChain(): SolanaChain {
 }
 
 function generate(opts: Record<string, unknown> = {}, mintOwner?: PublicKey | null) {
-  return SolanaTokenManager.fromChain(chain(mintOwner)).generateUnsignedMintTokens({
+  return new MintTokens().generate(chain(mintOwner), {
     payer: PAYER,
     tokenAddress: TOKEN.toBase58(),
     recipient: RECIPIENT.toBase58(),
@@ -120,7 +120,7 @@ describe('MintTokens (cct/solana)', () => {
 
       await assert.rejects(
         () =>
-          SolanaTokenManager.fromChain(missingAtaChain).generateUnsignedMintTokens({
+          new MintTokens().generate(missingAtaChain, {
             payer: PAYER,
             tokenAddress: TOKEN.toBase58(),
             recipient: RECIPIENT.toBase58(),
@@ -177,7 +177,7 @@ describe('MintTokens (cct/solana)', () => {
 
   describe('execute', () => {
     it('signs, submits, and returns the tx hash', async () => {
-      const result = await SolanaTokenManager.fromChain(submitChain()).mintTokens({
+      const result = await new MintTokens().execute(submitChain(), {
         tokenAddress: TOKEN.toBase58(),
         recipient: RECIPIENT.toBase58(),
         amount: 1n,
@@ -189,7 +189,7 @@ describe('MintTokens (cct/solana)', () => {
     it('requires unsigned generation for SPL multisig authorities', async () => {
       await assert.rejects(
         () =>
-          SolanaTokenManager.fromChain(chain()).mintTokens({
+          new MintTokens().execute(chain(), {
             tokenAddress: TOKEN.toBase58(),
             recipient: RECIPIENT.toBase58(),
             amount: 1n,
@@ -205,7 +205,7 @@ describe('MintTokens (cct/solana)', () => {
     it('rejects a non-wallet authority for signed minting', async () => {
       await assert.rejects(
         () =>
-          SolanaTokenManager.fromChain(chain()).mintTokens({
+          new MintTokens().execute(chain(), {
             tokenAddress: TOKEN.toBase58(),
             recipient: RECIPIENT.toBase58(),
             amount: 1n,

--- a/ccip-sdk/src/cct/solana/token/operations/set-token-authority.test.ts
+++ b/ccip-sdk/src/cct/solana/token/operations/set-token-authority.test.ts
@@ -8,7 +8,7 @@ import { CCIPTokenMintInvalidError, CCIPTokenMintNotFoundError } from '../../../
 import { ChainFamily } from '../../../../networks.ts'
 import type { SolanaChain } from '../../../../solana/index.ts'
 import { CCTParamsInvalidError } from '../../../errors.ts'
-import { SolanaTokenManager } from '../../index.ts'
+import { SetTokenAuthority } from './set-token-authority.ts'
 
 const TOKEN = Keypair.generate().publicKey.toBase58()
 const PAYER = Keypair.generate().publicKey.toBase58()
@@ -48,7 +48,7 @@ function submitChain(): SolanaChain {
 }
 
 function generate(opts: Record<string, unknown> = {}, mintOwner?: PublicKey | null) {
-  return SolanaTokenManager.fromChain(chain(mintOwner)).generateUnsignedSetTokenAuthority({
+  return new SetTokenAuthority().generate(chain(mintOwner), {
     tokenAddress: TOKEN,
     payer: PAYER,
     authority: AUTHORITY,
@@ -195,7 +195,7 @@ describe('SetTokenAuthority (cct/solana)', () => {
 
   describe('execute', () => {
     it('signs, submits, and returns the tx hash', async () => {
-      const result = await SolanaTokenManager.fromChain(submitChain()).setTokenAuthority({
+      const result = await new SetTokenAuthority().execute(submitChain(), {
         tokenAddress: TOKEN,
         newAuthority: NEW_AUTHORITY,
         authorityTypes: ['mint'],
@@ -208,7 +208,7 @@ describe('SetTokenAuthority (cct/solana)', () => {
     it('requires unsigned generation for SPL multisig authorities', async () => {
       await assert.rejects(
         () =>
-          SolanaTokenManager.fromChain(chain()).setTokenAuthority({
+          new SetTokenAuthority().execute(chain(), {
             tokenAddress: TOKEN,
             newAuthority: NEW_AUTHORITY,
             authority: MULTISIG,
@@ -224,7 +224,7 @@ describe('SetTokenAuthority (cct/solana)', () => {
     it('rejects a non-wallet authority for signed updates', async () => {
       await assert.rejects(
         () =>
-          SolanaTokenManager.fromChain(chain()).setTokenAuthority({
+          new SetTokenAuthority().execute(chain(), {
             tokenAddress: TOKEN,
             newAuthority: NEW_AUTHORITY,
             authority: AUTHORITY,

--- a/ccip-sdk/src/cct/solana/token/operations/update-metadata-authority.test.ts
+++ b/ccip-sdk/src/cct/solana/token/operations/update-metadata-authority.test.ts
@@ -6,7 +6,7 @@ import { Keypair, PublicKey } from '@solana/web3.js'
 import { ChainFamily } from '../../../../networks.ts'
 import type { SolanaChain } from '../../../../solana/index.ts'
 import { CCTParamsInvalidError, CCTTxFailedError } from '../../../errors.ts'
-import { SolanaTokenManager } from '../../index.ts'
+import { UpdateMetadataAuthority } from './update-metadata-authority.ts'
 
 const METAPLEX_PROGRAM_ID = new PublicKey('metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s')
 const TOKEN = Keypair.generate().publicKey.toBase58()
@@ -19,11 +19,11 @@ const WALLET = {
   signTransaction: async <T>(tx: T) => tx,
 }
 
-function metadataData(authority = AUTHORITY, isMutable = true): Buffer {
+function metadataData(authority = AUTHORITY, isMutable = true, mint = TOKEN): Buffer {
   return Buffer.concat([
     Buffer.from([4]), // MetadataV1
     new PublicKey(authority).toBuffer(),
-    new PublicKey(TOKEN).toBuffer(),
+    new PublicKey(mint).toBuffer(),
     Buffer.alloc(12), // Empty name, symbol, and URI strings.
     Buffer.alloc(2), // Seller fee basis points.
     Buffer.from([0, 0, isMutable ? 1 : 0, 0, 0, 0, 0, 0]),
@@ -68,7 +68,7 @@ function submitChain(): SolanaChain {
 }
 
 function generate(opts: Record<string, unknown> = {}, metadata?: Buffer | null) {
-  return SolanaTokenManager.fromChain(chain(metadata)).generateUnsignedUpdateMetadataAuthority({
+  return new UpdateMetadataAuthority().generate(chain(metadata), {
     tokenAddress: TOKEN,
     payer: PAYER,
     authority: AUTHORITY,
@@ -114,7 +114,9 @@ describe('UpdateMetadataAuthority (cct/solana)', () => {
     it('requires Metaplex metadata with the current authority', async () => {
       for (const [metadata, param] of [
         [null, 'tokenAddress'],
+        [metadataData(AUTHORITY, true, PAYER), 'tokenAddress'],
         [metadataData(PAYER), 'authority'],
+        [Buffer.alloc(0), 'tokenAddress'],
       ] as const) {
         await assert.rejects(
           () => generate({}, metadata),
@@ -134,7 +136,7 @@ describe('UpdateMetadataAuthority (cct/solana)', () => {
 
   describe('execute', () => {
     it('signs, submits, and returns the tx hash', async () => {
-      const result = await SolanaTokenManager.fromChain(submitChain()).updateMetadataAuthority({
+      const result = await new UpdateMetadataAuthority().execute(submitChain(), {
         tokenAddress: TOKEN,
         newAuthority: NEW_AUTHORITY,
         wallet: WALLET,
@@ -146,7 +148,7 @@ describe('UpdateMetadataAuthority (cct/solana)', () => {
     it('rejects a non-wallet authority for signed updates', async () => {
       await assert.rejects(
         () =>
-          SolanaTokenManager.fromChain(chain()).updateMetadataAuthority({
+          new UpdateMetadataAuthority().execute(chain(), {
             tokenAddress: TOKEN,
             newAuthority: NEW_AUTHORITY,
             authority: PAYER,

--- a/ccip-sdk/src/cct/solana/validate.test.ts
+++ b/ccip-sdk/src/cct/solana/validate.test.ts
@@ -1,16 +1,22 @@
 import assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 
+import { MINT_SIZE, MintLayout, TOKEN_PROGRAM_ID } from '@solana/spl-token'
 import { PublicKey } from '@solana/web3.js'
 
-import { CCTParamsInvalidError } from '../errors.ts'
+import { CCIPTokenAccountNotFoundError } from '../../errors/index.ts'
+import { CCTParamsInvalidError, CCTTxFailedError } from '../errors.ts'
 import { type PoolProgramRef, TOKEN_POOL_PROGRAMS } from './programs/token-pool.ts'
 import {
   parseHexBytes,
   parseNonEmptyHexBytes,
   parsePublicKey,
+  resolveExistingTokenAccount,
+  resolveLockReleasePoolProgram,
   resolvePoolProgram,
+  validateAuthorityMatchesWallet,
   validateBigInt,
+  validateDelegation,
   validateInteger,
   validateNonEmptyString,
   validateOptionalPublicKey,
@@ -19,6 +25,23 @@ import {
   validatePublicKeys,
   validateWritableIndexes,
 } from './validate.ts'
+
+function mintData() {
+  const data = Buffer.alloc(MINT_SIZE)
+  MintLayout.encode(
+    {
+      mintAuthorityOption: 1,
+      mintAuthority: PublicKey.default,
+      supply: 0n,
+      decimals: 6,
+      isInitialized: true,
+      freezeAuthorityOption: 0,
+      freezeAuthority: PublicKey.default,
+    },
+    data,
+  )
+  return data
+}
 
 describe('Validate (cct/solana)', () => {
   it('parses valid public keys', () => {
@@ -108,6 +131,21 @@ describe('Validate (cct/solana)', () => {
     )
   })
 
+  it('validates the executing authority', () => {
+    const authority = PublicKey.default
+
+    assert.doesNotThrow(() => validateAuthorityMatchesWallet('op', authority, authority))
+    assert.throws(
+      () =>
+        validateAuthorityMatchesWallet(
+          'op',
+          authority,
+          new PublicKey(Uint8Array.from({ length: 32 }, () => 1)),
+        ),
+      (err: unknown) => err instanceof CCTParamsInvalidError && err.context.param === 'authority',
+    )
+  })
+
   it('validates pool types', () => {
     assert.doesNotThrow(() => validatePoolType('op', 'poolType', 'burn-mint'))
     assert.doesNotThrow(() => validatePoolType('op', 'poolType', 'lock-release'))
@@ -156,6 +194,14 @@ describe('Validate (cct/solana)', () => {
     )
   })
 
+  it('resolves lock-release pool programs only', () => {
+    assert.ok(resolveLockReleasePoolProgram('op', { poolType: 'lock-release' }))
+    assert.throws(
+      () => resolveLockReleasePoolProgram('op', { poolType: 'burn-mint' }),
+      (err: unknown) => err instanceof CCTParamsInvalidError && err.context.param === 'poolType',
+    )
+  })
+
   it('validates integers', () => {
     assert.doesNotThrow(() => validateInteger('op', 'threshold', 1))
     assert.doesNotThrow(() => validateInteger('op', 'decimals', 255, 0, 255))
@@ -163,6 +209,9 @@ describe('Validate (cct/solana)', () => {
       () => validateInteger('op', 'decimals', 256, 0, 255),
       (err: unknown) => err instanceof CCTParamsInvalidError && err.context.param === 'decimals',
     )
+    assert.throws(() => validateInteger('op', 'threshold', 0, 1), CCTParamsInvalidError)
+    assert.throws(() => validateInteger('op', 'limit', 2, undefined, 1), CCTParamsInvalidError)
+    assert.throws(() => validateInteger('op', 'integer', 1.5), CCTParamsInvalidError)
   })
 
   it('validates bigint bounds with useful errors', () => {
@@ -176,6 +225,57 @@ describe('Validate (cct/solana)', () => {
       () => validateBigInt('op', 'selector', 2n, undefined, 1n),
       (err: unknown) =>
         err instanceof CCTParamsInvalidError && err.context.reason === 'must be a bigint <= 1',
+    )
+  })
+
+  it('validates token delegation', () => {
+    const tokenAccount = PublicKey.default
+    const delegate = new PublicKey(Uint8Array.from({ length: 32 }, () => 1))
+    const otherDelegate = new PublicKey(Uint8Array.from({ length: 32 }, () => 2))
+
+    assert.doesNotThrow(() =>
+      validateDelegation(
+        'op',
+        tokenAccount,
+        { delegate, delegatedAmount: 2n } as never,
+        delegate,
+        2n,
+      ),
+    )
+    for (const account of [
+      { delegate: null, delegatedAmount: 2n },
+      { delegate: otherDelegate, delegatedAmount: 2n },
+      { delegate, delegatedAmount: 1n },
+    ]) {
+      assert.throws(
+        () => validateDelegation('op', tokenAccount, account as never, delegate, 2n),
+        (err: unknown) => err instanceof CCTTxFailedError,
+      )
+    }
+  })
+
+  it('maps missing token accounts and preserves other lookup errors', async () => {
+    const mint = new PublicKey(Uint8Array.from({ length: 32 }, () => 1))
+    const holder = new PublicKey(Uint8Array.from({ length: 32 }, () => 2))
+    const tokenAccount = new PublicKey(Uint8Array.from({ length: 32 }, () => 3))
+    const connection = {
+      getAccountInfo: async (address: PublicKey) =>
+        address.equals(mint) ? { owner: TOKEN_PROGRAM_ID, data: mintData() } : null,
+    }
+
+    await assert.rejects(
+      () => resolveExistingTokenAccount(connection as never, mint, holder, tokenAccount),
+      (err: unknown) => err instanceof CCIPTokenAccountNotFoundError,
+    )
+
+    const invalidConnection = {
+      getAccountInfo: async (address: PublicKey) =>
+        address.equals(mint)
+          ? { owner: TOKEN_PROGRAM_ID, data: mintData() }
+          : { owner: TOKEN_PROGRAM_ID, data: Buffer.alloc(0) },
+    }
+    await assert.rejects(() =>
+      resolveExistingTokenAccount(invalidConnection as never, mint, holder, tokenAccount),
     )
   })
 


### PR DESCRIPTION
## What

- Refactor Solana CCT operation tests and remove importing `SolanaTokenManager` to make it a unit test
- Add facade coverage for unsigned, signed, and read `SolanaTokenManager` operations
- Expand validation and success-path coverage across token, token-admin-registry, token-pool, and Solana validation tests

## Why

- Ensure the supported Solana CCT public API is wired, runnable, and covered
- Keep detailed instruction, validation, and failure coverage at the direct-operation level
