### PR TITLE
feat(cct-sdk): Add includeApproval option to provide liquidity

### DIFF
--- a/ccip-sdk/src/cct/solana/index.ts
+++ b/ccip-sdk/src/cct/solana/index.ts
@@ -1241,7 +1241,8 @@ export class SolanaTokenManager extends TokenManager<typeof ChainFamily.Solana> 
    *
    * @remarks The pool config must have `canAcceptLiquidity: true` and a `rebalancer` equal to the
    * transaction authority. The authority's ATA for `tokenAddress` must exist, hold at least `amount`,
-   * and delegate at least `amount` to the pool signer PDA; use {@link generateUnsignedApproveToken}.
+   * and delegate at least `amount` to the pool signer PDA. Set `includeApproval: true` to bundle
+   * that approval before the liquidity instruction in this transaction.
    *
    * @see {@link provideLiquidity}
    * @see {@link generateUnsignedApproveToken}
@@ -1254,25 +1255,15 @@ export class SolanaTokenManager extends TokenManager<typeof ChainFamily.Solana> 
    * @throws {@link CCIPTokenPoolStateNotFoundError} If the token pool state is missing.
    * @throws {@link CCIPTokenAccountNotFoundError} If the rebalancer or pool vault ATA is missing; create it first.
    *
-   * @example Prepare and generate liquidity instructions
+   * @example Generate bundled approval and liquidity instructions
    * ```ts
    * const cct = SolanaTokenManager.fromChain(chain)
-   * const amount = 1_000_000n
-   * const { config } = await cct.getTokenPoolState({
-   *   tokenAddress: mint,
-   *   poolType: 'lock-release',
-   * })
-   * const approval = await cct.generateUnsignedApproveToken({
-   *   payer: rebalancer,
-   *   tokenAddress: mint,
-   *   delegate: config.poolSigner,
-   *   amount,
-   * })
    * const liquidity = await cct.generateUnsignedProvideLiquidity({
    *   payer: rebalancer,
    *   tokenAddress: mint,
    *   poolType: 'lock-release',
-   *   amount,
+   *   amount: 1_000_000n,
+   *   includeApproval: true,
    * })
    * ```
    */
@@ -1290,7 +1281,7 @@ export class SolanaTokenManager extends TokenManager<typeof ChainFamily.Solana> 
    *
    * @remarks The pool config must have `canAcceptLiquidity: true` and a `rebalancer` equal to the
    * transaction authority. Before this operation, the rebalancer ATA must delegate at least `amount`
-   * to the pool signer PDA; use {@link approveToken} first.
+   * to the pool signer PDA, unless `includeApproval: true` bundles that approval in this transaction.
    *
    * @see {@link generateUnsignedProvideLiquidity}
    * @see {@link approveToken}
@@ -1305,19 +1296,19 @@ export class SolanaTokenManager extends TokenManager<typeof ChainFamily.Solana> 
    * @throws {@link CCIPTokenPoolStateNotFoundError} If the token pool state is missing.
    * @throws {@link CCIPTokenAccountNotFoundError} If the rebalancer or pool vault ATA is missing; create it first.
    * @throws {@link CCTTxFailedError} If the source ATA does not delegate enough tokens to the pool
-   * signer, the pool rejects the rebalancer, liquidity is disabled, the token account lacks funds,
-   * or simulation/submission fails.
+   * signer and `includeApproval` is false, the pool rejects the rebalancer, liquidity is disabled,
+   * the token account lacks funds, or simulation/submission fails.
    *
-   * @example Prepare and provide liquidity
+   * @example Approve and provide liquidity in one transaction
    * ```ts
    * const cct = SolanaTokenManager.fromChain(chain)
-   * const amount = 1_000_000n
-   * const { config } = await cct.getTokenPoolState({
+   * await cct.provideLiquidity({
+   *   wallet,
    *   tokenAddress: mint,
    *   poolType: 'lock-release',
+   *   amount: 1_000_000n,
+   *   includeApproval: true,
    * })
-   * await cct.approveToken({ wallet, tokenAddress: mint, delegate: config.poolSigner, amount })
-   * await cct.provideLiquidity({ wallet, tokenAddress: mint, poolType: 'lock-release', amount })
    * ```
    */
   provideLiquidity(opts: ExecuteProvideLiquidityParams): Promise<ExecuteProvideLiquidityResult> {

--- a/ccip-sdk/src/cct/solana/token-pool/operations/provide-liquidity.test.ts
+++ b/ccip-sdk/src/cct/solana/token-pool/operations/provide-liquidity.test.ts
@@ -14,7 +14,6 @@ import {
   deriveTokenPoolSignerPda,
   resolveTokenPoolProgram,
 } from '../../programs/token-pool.ts'
-import { ApproveToken } from '../../token/operations/approve-token.ts'
 import { ProvideLiquidity } from './provide-liquidity.ts'
 
 const TOKEN = Keypair.generate().publicKey.toBase58()
@@ -75,6 +74,7 @@ function chain(
   rebalancer = new PublicKey(AUTHORITY),
   acceptsLiquidity = true,
   sourceBalance = 1_000_000n,
+  delegatedAmount = 1_000_000n,
 ): SolanaChain {
   const poolSigner = deriveTokenPoolSignerPda(poolProgram, new PublicKey(TOKEN))
   const state = deriveTokenPoolConfigPda(poolProgram, new PublicKey(TOKEN))
@@ -84,7 +84,7 @@ function chain(
       getAccountInfo: async (address: PublicKey) =>
         address.equals(state)
           ? { owner: poolProgram, data: poolState(poolProgram, rebalancer, acceptsLiquidity) }
-          : tokenAccount(poolSigner, 1_000_000n, sourceBalance),
+          : tokenAccount(poolSigner, delegatedAmount, sourceBalance),
     },
   } as unknown as SolanaChain
 }
@@ -213,23 +213,29 @@ describe('ProvideLiquidity (cct/solana)', () => {
       assert.equal(unsigned.instructions[0]!.keys[6]!.pubkey.toBase58(), PAYER)
     })
 
-    it('uses a source account that can be delegated to the pool signer', async () => {
+    it('bundles approval before liquidity when requested', async () => {
       const poolProgram = resolveTokenPoolProgram('lock-release')
       const poolSigner = deriveTokenPoolSignerPda(poolProgram, new PublicKey(TOKEN))
-      const approval = await new ApproveToken().generate(chain(), {
-        payer: AUTHORITY,
-        tokenAddress: TOKEN,
-        delegate: poolSigner.toBase58(),
-        amount: 1_000_000n,
-      })
-      const liquidity = await generate()
-
-      assert.equal(approval.instructions[0]!.keys[1]!.pubkey.toBase58(), poolSigner.toBase58())
-      assert.equal(
-        approval.instructions[0]!.keys[0]!.pubkey.toBase58(),
-        liquidity.instructions[0]!.keys[5]!.pubkey.toBase58(),
+      const unsigned = await new ProvideLiquidity().generate(
+        chain(poolProgram, new PublicKey(AUTHORITY), true, 1_000_000n, 0n),
+        {
+          payer: PAYER,
+          tokenAddress: TOKEN,
+          poolType: 'lock-release',
+          authority: AUTHORITY,
+          amount: 1_000_000n,
+          includeApproval: true,
+        },
       )
-      assert.equal(approval.instructions[0]!.data.readBigUInt64LE(1), 1_000_000n)
+
+      assert.equal(unsigned.instructions.length, 2)
+      assert.equal(unsigned.mainIndex, 1)
+      assert.equal(unsigned.instructions[0]!.keys[1]!.pubkey.toBase58(), poolSigner.toBase58())
+      assert.equal(unsigned.instructions[0]!.data.readBigUInt64LE(1), 1_000_000n)
+      assert.equal(
+        lockReleaseTokenPoolCoder.instruction.decode(unsigned.instructions[1]!.data)?.name,
+        'provideLiquidity',
+      )
     })
 
     it('supports a compatible custom pool program', async () => {

--- a/ccip-sdk/src/cct/solana/token-pool/operations/provide-liquidity.ts
+++ b/ccip-sdk/src/cct/solana/token-pool/operations/provide-liquidity.ts
@@ -19,6 +19,7 @@ import {
   deriveTokenPoolSignerPda,
 } from '../../programs/token-pool.ts'
 import { submit } from '../../submit.ts'
+import { ApproveToken } from '../../token/operations/approve-token.ts'
 import {
   U64_MAX,
   parsePublicKey,
@@ -37,8 +38,10 @@ type ProvideLiquidityParams = PoolProgramRef & {
   tokenAddress: string
   /** Amount to deposit in base units. Must be a positive u64. */
   amount: bigint
-  /** Pool rebalancer whose ATA for `tokenAddress` must hold `amount` and delegate it to the pool signer. Defaults to `payer`. */
+  /** Pool rebalancer whose ATA for `tokenAddress` must hold `amount`. Defaults to `payer`. */
   authority?: string
+  /** Add an SPL Token approval for the pool signer before providing liquidity in the same transaction. */
+  includeApproval?: boolean
 }
 
 type ParsedProvideLiquidityParams = {
@@ -47,6 +50,7 @@ type ParsedProvideLiquidityParams = {
   poolProgram: PublicKey
   payer: PublicKey
   authority: PublicKey
+  includeApproval: boolean
 }
 
 /** Parameters for unsigned Solana lock-release pool liquidity provision. */
@@ -85,6 +89,7 @@ export class ProvideLiquidity extends SolanaOperation<
         params.authority === undefined
           ? payer
           : parsePublicKey(this.name, 'authority', params.authority),
+      includeApproval: params.includeApproval ?? false,
     }
   }
 
@@ -120,13 +125,15 @@ export class ProvideLiquidity extends SolanaOperation<
       )
 
     // The pool signer transfers from the rebalancer ATA as its SPL Token delegate.
-    validateDelegation(
-      this.name,
-      remoteTokenAccount,
-      remoteTokenAccountInfo,
-      poolSigner,
-      opts.amount,
-    )
+    if (!opts.includeApproval) {
+      validateDelegation(
+        this.name,
+        remoteTokenAccount,
+        remoteTokenAccountInfo,
+        poolSigner,
+        opts.amount,
+      )
+    }
 
     // The pool vault ATA must have been created during pool initialization.
     const { tokenAccount: poolTokenAccount } = await resolveExistingTokenAccount(
@@ -135,7 +142,11 @@ export class ProvideLiquidity extends SolanaOperation<
       poolSigner,
     )
 
-    const instruction = await createLockReleaseTokenPoolProgram(chain, opts.poolProgram, opts.payer)
+    const provideLiquidityInstruction = await createLockReleaseTokenPoolProgram(
+      chain,
+      opts.poolProgram,
+      opts.payer,
+    )
       .methods.provideLiquidity(new BN(opts.amount.toString()))
       .accountsStrict({
         state: deriveTokenPoolConfigPda(opts.poolProgram, opts.tokenAddress),
@@ -148,6 +159,16 @@ export class ProvideLiquidity extends SolanaOperation<
       })
       .instruction()
 
+    const approval = opts.includeApproval
+      ? await new ApproveToken().generate(chain, {
+          payer: opts.payer.toBase58(),
+          tokenAddress: opts.tokenAddress.toBase58(),
+          delegate: poolSigner.toBase58(),
+          amount: opts.amount,
+          authority: opts.authority.toBase58(),
+        })
+      : undefined
+
     chain.logger.debug(
       `${
         this.name
@@ -155,10 +176,11 @@ export class ProvideLiquidity extends SolanaOperation<
         opts.amount
       }`,
     )
+
     return {
       family: ChainFamily.Solana,
-      instructions: [instruction],
-      mainIndex: 0,
+      instructions: [...(approval?.instructions ?? []), provideLiquidityInstruction],
+      mainIndex: approval ? 1 : 0,
     }
   }
 


### PR DESCRIPTION
## What

- [DAPP-11329](https://smartcontract-it.atlassian.net/browse/DAPP-11329)
- Add `includeApproval` to Solana `provideLiquidity` to bundle SPL approval and liquidity instructions
- Update TSDoc and examples for the bundled flow

## Why

- Allow rebalancers to approve and provide liquidity in one signed transaction

[DAPP-11329]: https://smartcontract-it.atlassian.net/browse/DAPP-11329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ