### PR TITLE
fix(canton-auth): stop Okta browser opening twice per ccipSend

### DIFF
--- a/ccip-sdk/src/canton/authentication/authentication.test.ts
+++ b/ccip-sdk/src/canton/authentication/authentication.test.ts
@@ -227,6 +227,19 @@ describe('canton/authentication — token-source primitives', () => {
     assert.equal(fetchCount, 0, 'should not fetch when initial token is still valid')
   })
 
+  it('createMemoizedTokenFetcher keeps returning the initial token on subsequent calls without fetching', async () => {
+    let fetchCount = 0
+    const initial = { accessToken: 'initial-tok', expiresAt: Date.now() + 60_000 }
+    const fetchToken = createMemoizedTokenFetcher(async () => {
+      fetchCount++
+      return { accessToken: `tok-${fetchCount}`, expiresAt: Date.now() + 60_000 }
+    }, initial)
+    assert.equal((await fetchToken()).accessToken, 'initial-tok')
+    assert.equal((await fetchToken()).accessToken, 'initial-tok')
+    assert.equal((await fetchToken()).accessToken, 'initial-tok')
+    assert.equal(fetchCount, 0, 'should not fetch while the initial token is still valid')
+  })
+
   it('generateCodeVerifier produces a non-empty base64url string', () => {
     const v = generateCodeVerifier()
     assert.ok(v.length >= 43, `verifier too short: ${v.length}`)

--- a/ccip-sdk/src/canton/authentication/token-source.ts
+++ b/ccip-sdk/src/canton/authentication/token-source.ts
@@ -128,8 +128,8 @@ export function buildOAuthRequestOptions(opts: OAuthRequestOptions) {
  *
  * @param fetcher - Called when the cached token is missing or expired.
  *   MUST return a fresh {@link AccessToken}.
- * @param initial - Optional initial token (returned on the first call without
- *   fetching, when still valid).
+ * @param initial - Optional initial token (returned without fetching on every
+ *   call while still valid).
  * @returns A memoized `() => Promise<AccessToken>` that caches until the
  *   returned token's `expiresAt` passes (accounting for skew).
  */
@@ -154,19 +154,15 @@ export function createMemoizedTokenFetcher(
     },
   )
 
-  // When an initial token is provided and still valid, short-circuit the first
-  // call to return it without fetching. Subsequent calls delegate to the
-  // memoized fetcher (which will fetch only if the token has since expired).
+  // Return the initial token on every call while valid; only fetch once it
+  // expires. (A single-shot short-circuit would leave the memoize cache empty
+  // and trigger a spurious re-fetch on the next call.)
   if (initial && !isTokenExpired(initial)) {
-    let usedInitial = false
     return async (): Promise<AccessToken> => {
-      if (!usedInitial) {
-        usedInitial = true
-        return initial
+      if (lastToken && !isTokenExpired(lastToken)) {
+        return lastToken
       }
-      if (isTokenExpired(lastToken)) {
-        memoized.cache.clear('token expired')
-      }
+      memoized.cache.clear('token expired')
       return memoized()
     }
   }


### PR DESCRIPTION
The memoized token fetcher's `usedInitial` flag short-circuited only the first `token()` call, leaving the micro-memoize cache empty. The second call (from `showRequests` re-resolving auth) then triggered a real refresh/re-fetch, which fell back to `runAuthorizationCodeFlow` and re-opened the browser.

Return the initial token on every call while it remains valid instead of only the first, so the memoize cache is never reached until expiry. Added a regression test covering repeated calls with a valid initial token.