### PR TITLE
fix(cct-sdk): Harden Solana operation validation

### DIFF
--- a/ccip-sdk/src/cct/solana/token-admin-registry/operations/accept-admin.ts
+++ b/ccip-sdk/src/cct/solana/token-admin-registry/operations/accept-admin.ts
@@ -1,9 +1,8 @@
 import { PublicKey } from '@solana/web3.js'
 
-import { CCIPWalletInvalidError } from '../../../../errors/index.ts'
 import { ChainFamily } from '../../../../networks.ts'
 import type { SolanaChain } from '../../../../solana/index.ts'
-import { type UnsignedSolanaTx, isWallet } from '../../../../solana/types.ts'
+import type { UnsignedSolanaTx } from '../../../../solana/types.ts'
 import { CCTParamsInvalidError } from '../../../errors.ts'
 import type { TransactionResult } from '../../../operation.ts'
 import {
@@ -117,12 +116,7 @@ export class AcceptAdmin extends SolanaOperation<
     chain: SolanaChain,
     params: ExecuteAcceptAdminParams,
   ): Promise<ExecuteAcceptAdminResult> {
-    const { wallet, computeUnits, ...rest } = params
-    if (!isWallet(wallet)) throw new CCIPWalletInvalidError(wallet)
-
-    const payer = wallet.publicKey.toBase58()
-    const generateParams: GenerateAcceptAdminParams = { ...rest, payer }
-    const parsed = this.prepare(generateParams)
+    const { wallet, computeUnits, parsed } = this.prepareWalletExecution(params)
 
     if (params.authority !== undefined) {
       validateAuthorityMatchesWallet(

--- a/ccip-sdk/src/cct/solana/token-admin-registry/operations/append-to-lookup-table.test.ts
+++ b/ccip-sdk/src/cct/solana/token-admin-registry/operations/append-to-lookup-table.test.ts
@@ -183,6 +183,24 @@ describe('AppendToLookupTable (cct/solana)', () => {
       )
     })
 
+    it('rejects a partial canonical CCIP address block', async () => {
+      const ccipAddresses = await deriveCcipLookupTableAddresses(stubChain(), {
+        lookupTableAddress: new PublicKey(LOOKUP_TABLE),
+        tokenMint: new PublicKey(TOKEN),
+        poolProgram: new PublicKey(POOL_PROGRAM),
+      })
+
+      await assert.rejects(
+        () =>
+          generate(
+            { tokenAddress: TOKEN, poolProgramAddress: POOL_PROGRAM },
+            stubChain({ addresses: [ccipAddresses[0]!] }),
+          ),
+        (err: unknown) =>
+          err instanceof CCTParamsInvalidError && err.context.param === 'lookupTableAddress',
+      )
+    })
+
     it('defaults omitted additional addresses to an empty list', async () => {
       const unsigned = await generate({
         additionalAddresses: undefined,
@@ -269,6 +287,15 @@ describe('AppendToLookupTable (cct/solana)', () => {
       )
 
       assert.equal(getLookupTableCalls, 0)
+    })
+
+    it('rejects duplicate additional addresses', async () => {
+      const address = Keypair.generate().publicKey.toBase58()
+      await assert.rejects(
+        () => generate({ additionalAddresses: [address, address] }),
+        (err: unknown) =>
+          err instanceof CCTParamsInvalidError && err.context.param === 'additionalAddresses',
+      )
     })
 
     it('requires at least one address source', async () => {

--- a/ccip-sdk/src/cct/solana/token-admin-registry/operations/append-to-lookup-table.ts
+++ b/ccip-sdk/src/cct/solana/token-admin-registry/operations/append-to-lookup-table.ts
@@ -157,6 +157,9 @@ export class AppendToLookupTable extends SolanaOperation<
       )
     }
 
+    const existingAddresses = new Set(
+      lookupTable.value.state.addresses.map((address) => address.toBase58()),
+    )
     const addresses = [...opts.additionalAddresses]
 
     if (opts.tokenMint && poolProgram) {
@@ -166,19 +169,28 @@ export class AppendToLookupTable extends SolanaOperation<
         tokenMint,
         poolProgram,
       })
-      const existingAddresses = new Set(
-        lookupTable.value.state.addresses.map((address) => address.toBase58()),
-      )
-
-      if (ccipAddresses.every((address) => existingAddresses.has(address.toBase58()))) {
+      if (ccipAddresses.some((address) => existingAddresses.has(address.toBase58()))) {
         throw new CCTParamsInvalidError(
           this.name,
           'lookupTableAddress',
-          'lookup table already contains the canonical CCIP address block; only append additionalAddresses or use an empty ALT',
+          'lookup table already contains canonical CCIP addresses; only append additionalAddresses or use an empty ALT',
         )
       }
 
       addresses.unshift(...ccipAddresses)
+    }
+
+    const appendedAddresses = new Set<string>()
+    for (const address of addresses) {
+      const value = address.toBase58()
+      if (existingAddresses.has(value) || appendedAddresses.has(value)) {
+        throw new CCTParamsInvalidError(
+          this.name,
+          'additionalAddresses',
+          'must not contain addresses already in the ALT or duplicate addresses',
+        )
+      }
+      appendedAddresses.add(value)
     }
 
     const totalAddressesAfterAppend = lookupTable.value.state.addresses.length + addresses.length

--- a/ccip-sdk/src/cct/solana/token-pool/operations/apply-chain-updates.test.ts
+++ b/ccip-sdk/src/cct/solana/token-pool/operations/apply-chain-updates.test.ts
@@ -281,6 +281,30 @@ describe('ApplyChainUpdates (cct/solana)', () => {
         [{ chainsToAdd: null }, 'chainsToAdd'],
         [{ chainsToAdd: [], remoteChainSelectorsToRemove: [] }, 'chainsToAdd'],
         [{ chainsToAdd: [null] }, 'chainsToAdd[0]'],
+        [{ remoteChainSelectorsToRemove: [SELECTOR, SELECTOR] }, 'remoteChainSelectorsToRemove[1]'],
+        [
+          {
+            chainsToAdd: [
+              {
+                remoteChainSelector: SELECTOR,
+                remoteTokenAddress: '0x1234567890abcdef1234567890abcdef12345678',
+                remotePoolAddresses: [],
+                remoteTokenDecimals: 18,
+                inboundRateLimiterConfig: { enabled: false },
+                outboundRateLimiterConfig: { enabled: false },
+              },
+              {
+                remoteChainSelector: SELECTOR,
+                remoteTokenAddress: '0xaabbccddeeff00112233445566778899aabbccdd',
+                remotePoolAddresses: [],
+                remoteTokenDecimals: 18,
+                inboundRateLimiterConfig: { enabled: false },
+                outboundRateLimiterConfig: { enabled: false },
+              },
+            ],
+          },
+          'chainsToAdd[1]',
+        ],
         [
           {
             chainsToAdd: [

--- a/ccip-sdk/src/cct/solana/token-pool/operations/apply-chain-updates.ts
+++ b/ccip-sdk/src/cct/solana/token-pool/operations/apply-chain-updates.ts
@@ -24,6 +24,7 @@ import {
   parsePublicKey,
   resolvePoolProgram,
   validateAuthorityMatchesWallet,
+  validateUniqueChainSelectors,
 } from '../../validate.ts'
 import { DeleteChainRemoteConfig } from './delete-chain-remote-config.ts'
 import { EditChainRemoteConfig } from './edit-chain-remote-config.ts'
@@ -227,7 +228,22 @@ export class ApplyChainUpdates extends SolanaOperation<
         'at least one of chainsToAdd or remoteChainSelectorsToRemove must be non-empty',
       )
     }
-    validateRemotePoolAddresses(this.name, params.chainsToAdd)
+    validateUniqueChainSelectors(
+      this.name,
+      'remoteChainSelectorsToRemove',
+      params.remoteChainSelectorsToRemove,
+    )
+    const chainsToAdd: unknown[] = params.chainsToAdd
+    validateUniqueChainSelectors(
+      this.name,
+      'chainsToAdd',
+      chainsToAdd.map((update) =>
+        typeof update === 'object' && update !== null
+          ? (update as { remoteChainSelector?: unknown }).remoteChainSelector
+          : undefined,
+      ),
+    )
+    validateRemotePoolAddresses(this.name, chainsToAdd)
 
     return {
       ...params,

--- a/ccip-sdk/src/cct/solana/token-pool/operations/apply-chain-updates.ts
+++ b/ccip-sdk/src/cct/solana/token-pool/operations/apply-chain-updates.ts
@@ -196,7 +196,8 @@ export type ExecuteApplyChainUpdatesResult = { hashes: string[]; chainSelectors:
  * Applies the EVM `applyChainUpdates` equivalent as Solana instructions.
  *
  * @remarks
- * This preserves EVM ordering: all removals run first, then each added chain is initialized,
+ * Chain selectors to add and remove must not contain duplicates. This preserves EVM ordering: all
+ * removals run first, then each added chain is initialized,
  * configured with remote pools, and assigned both rate-limit configs. EVM-style replacement is
  * supported by listing a selector in both `remoteChainSelectorsToRemove` and `chainsToAdd`;
  * adding an existing selector without removing it fails. Updates are packed into one or more

--- a/ccip-sdk/src/cct/solana/token-pool/operations/configure-allowlist.test.ts
+++ b/ccip-sdk/src/cct/solana/token-pool/operations/configure-allowlist.test.ts
@@ -159,7 +159,7 @@ describe('ConfigureAllowlist (cct/solana)', () => {
         (err: unknown) =>
           err instanceof CCTParamsInvalidError &&
           err.context.operation === 'configureAllowlist' &&
-          err.context.param === 'add',
+          err.context.param === 'add[1]',
       )
     })
 

--- a/ccip-sdk/src/cct/solana/token-pool/operations/configure-allowlist.ts
+++ b/ccip-sdk/src/cct/solana/token-pool/operations/configure-allowlist.ts
@@ -1,9 +1,8 @@
 import { type PublicKey, SystemProgram } from '@solana/web3.js'
 
-import { CCIPWalletInvalidError } from '../../../../errors/index.ts'
 import { ChainFamily } from '../../../../networks.ts'
 import type { SolanaChain } from '../../../../solana/index.ts'
-import { type UnsignedSolanaTx, isWallet } from '../../../../solana/types.ts'
+import type { UnsignedSolanaTx } from '../../../../solana/types.ts'
 import { CCTParamsInvalidError } from '../../../errors.ts'
 import type { TransactionResult } from '../../../operation.ts'
 import {
@@ -21,6 +20,7 @@ import {
   parsePublicKey,
   resolvePoolProgram,
   validateAuthorityMatchesWallet,
+  validateUniquePublicKeys,
 } from '../../validate.ts'
 
 /** Parameters shared by Solana token pool `configureAllowlist` generation and execution. */
@@ -78,9 +78,7 @@ export class ConfigureAllowlist extends SolanaOperation<
     const add = params.add.map((address, index) =>
       parsePublicKey(this.name, `add[${index}]`, address),
     )
-    if (new Set(add.map((address) => address.toBase58())).size !== add.length) {
-      throw new CCTParamsInvalidError(this.name, 'add', 'must not contain duplicate addresses')
-    }
+    validateUniquePublicKeys(this.name, 'add', add)
 
     const payer = parsePublicKey(this.name, 'payer', params.payer)
     return {
@@ -125,14 +123,7 @@ export class ConfigureAllowlist extends SolanaOperation<
     chain: SolanaChain,
     params: ExecuteConfigureAllowlistParams,
   ): Promise<ExecuteConfigureAllowlistResult> {
-    const { wallet, computeUnits, ...rest } = params
-    if (!isWallet(wallet)) throw new CCIPWalletInvalidError(wallet)
-
-    const generateParams: GenerateConfigureAllowlistParams = {
-      ...rest,
-      payer: wallet.publicKey.toBase58(),
-    }
-    const parsed = this.prepare(generateParams)
+    const { wallet, computeUnits, parsed } = this.prepareWalletExecution(params)
 
     if (params.authority !== undefined) {
       validateAuthorityMatchesWallet(

--- a/ccip-sdk/src/cct/solana/token-pool/operations/configure-allowlist.ts
+++ b/ccip-sdk/src/cct/solana/token-pool/operations/configure-allowlist.ts
@@ -56,7 +56,10 @@ export type ExecuteConfigureAllowlistParams = SolanaExecuteParams<ConfigureAllow
 /** Result of executing Solana token pool allowlist configuration. */
 export type ExecuteConfigureAllowlistResult = TransactionResult
 
-/** Adds addresses to and enables or disables a Solana token pool allowlist. */
+/**
+ * Adds addresses to and enables or disables a Solana token pool allowlist.
+ * @remarks Added addresses must not contain duplicates.
+ */
 export class ConfigureAllowlist extends SolanaOperation<
   ConfigureAllowlistParams,
   UnsignedSolanaTx,

--- a/ccip-sdk/src/cct/solana/token-pool/operations/deploy-token-pool.test.ts
+++ b/ccip-sdk/src/cct/solana/token-pool/operations/deploy-token-pool.test.ts
@@ -156,6 +156,14 @@ describe('DeployTokenPool (cct/solana)', () => {
       )
     })
 
+    it('rejects duplicate allowlist addresses', async () => {
+      const address = Keypair.generate().publicKey.toBase58()
+      await assert.rejects(
+        () => generate({ allowlist: [address, address] }),
+        (err: unknown) => err instanceof CCTParamsInvalidError && err.context.param === 'allowlist',
+      )
+    })
+
     it('rejects invalid allowlist addresses', async () => {
       await assert.rejects(
         () => generate({ allowlist: ['not-a-pubkey'] }),

--- a/ccip-sdk/src/cct/solana/token-pool/operations/deploy-token-pool.test.ts
+++ b/ccip-sdk/src/cct/solana/token-pool/operations/deploy-token-pool.test.ts
@@ -160,7 +160,8 @@ describe('DeployTokenPool (cct/solana)', () => {
       const address = Keypair.generate().publicKey.toBase58()
       await assert.rejects(
         () => generate({ allowlist: [address, address] }),
-        (err: unknown) => err instanceof CCTParamsInvalidError && err.context.param === 'allowlist',
+        (err: unknown) =>
+          err instanceof CCTParamsInvalidError && err.context.param === 'allowlist[1]',
       )
     })
 

--- a/ccip-sdk/src/cct/solana/token-pool/operations/deploy-token-pool.ts
+++ b/ccip-sdk/src/cct/solana/token-pool/operations/deploy-token-pool.ts
@@ -90,7 +90,10 @@ export type ExecuteDeployTokenPoolResult = TransactionResult & {
   poolSignerAddress: string
 }
 
-/** Initializes a Solana token pool, optionally configuring an allowlist. */
+/**
+ * Initializes a Solana token pool, optionally configuring an allowlist.
+ * @remarks The allowlist must not contain duplicate addresses.
+ */
 export class DeployTokenPool extends SolanaOperation<
   DeployTokenPoolParams,
   GenerateDeployTokenPoolResult,

--- a/ccip-sdk/src/cct/solana/token-pool/operations/deploy-token-pool.ts
+++ b/ccip-sdk/src/cct/solana/token-pool/operations/deploy-token-pool.ts
@@ -21,7 +21,12 @@ import {
 } from '../../programs/token-pool.ts'
 import { submit } from '../../submit.ts'
 import { CreateTokenAccount } from '../../token/operations/create-token-account.ts'
-import { parsePublicKey, validateAuthorityMatchesWallet, validatePoolType } from '../../validate.ts'
+import {
+  parsePublicKey,
+  validateAuthorityMatchesWallet,
+  validatePoolType,
+  validateUniquePublicKeys,
+} from '../../validate.ts'
 
 /**
  * Parameters for initializing a Solana token pool, optionally with an allowlist.
@@ -106,6 +111,11 @@ export class DeployTokenPool extends SolanaOperation<
       throw new CCTParamsInvalidError(this.name, 'createPoolSignerATA', 'must be a boolean')
     }
 
+    const allowlist = (params.allowlist ?? []).map((address, i) =>
+      parsePublicKey(this.name, `allowlist[${i}]`, address),
+    )
+    validateUniquePublicKeys(this.name, 'allowlist', allowlist)
+
     const payer = parsePublicKey(this.name, 'payer', params.payer)
     return {
       tokenMint: parsePublicKey(this.name, 'tokenAddress', params.tokenAddress),
@@ -115,9 +125,7 @@ export class DeployTokenPool extends SolanaOperation<
         params.authority === undefined
           ? payer
           : parsePublicKey(this.name, 'authority', params.authority),
-      allowlist: (params.allowlist ?? []).map((address, i) =>
-        parsePublicKey(this.name, `allowlist[${i}]`, address),
-      ),
+      allowlist,
       createPoolSignerATA: params.createPoolSignerATA ?? false,
     }
   }

--- a/ccip-sdk/src/cct/solana/token-pool/operations/edit-chain-remote-config.test.ts
+++ b/ccip-sdk/src/cct/solana/token-pool/operations/edit-chain-remote-config.test.ts
@@ -140,6 +140,7 @@ describe('EditChainRemoteConfig (cct/solana)', () => {
         [{ remoteTokenAddress: '0x123' }, 'remoteTokenAddress'],
         [{ remotePoolAddresses: [''] }, 'remotePoolAddresses[0]'],
         [{ remotePoolAddresses: ['0x123'] }, 'remotePoolAddresses[0]'],
+        [{ remotePoolAddresses: ['0x1234', '0x1234'] }, 'remotePoolAddresses'],
         [{ remotePoolAddresses: '0x12' }, 'remotePoolAddresses'],
         [{ remoteTokenDecimals: 256 }, 'remoteTokenDecimals'],
       ] as const) {

--- a/ccip-sdk/src/cct/solana/token-pool/operations/edit-chain-remote-config.test.ts
+++ b/ccip-sdk/src/cct/solana/token-pool/operations/edit-chain-remote-config.test.ts
@@ -140,7 +140,7 @@ describe('EditChainRemoteConfig (cct/solana)', () => {
         [{ remoteTokenAddress: '0x123' }, 'remoteTokenAddress'],
         [{ remotePoolAddresses: [''] }, 'remotePoolAddresses[0]'],
         [{ remotePoolAddresses: ['0x123'] }, 'remotePoolAddresses[0]'],
-        [{ remotePoolAddresses: ['0x1234', '0x1234'] }, 'remotePoolAddresses'],
+        [{ remotePoolAddresses: ['0x1234', '0x1234'] }, 'remotePoolAddresses[1]'],
         [{ remotePoolAddresses: '0x12' }, 'remotePoolAddresses'],
         [{ remoteTokenDecimals: 256 }, 'remoteTokenDecimals'],
       ] as const) {

--- a/ccip-sdk/src/cct/solana/token-pool/operations/edit-chain-remote-config.ts
+++ b/ccip-sdk/src/cct/solana/token-pool/operations/edit-chain-remote-config.ts
@@ -29,6 +29,7 @@ import {
   validateAuthorityMatchesWallet,
   validateBigInt,
   validateInteger,
+  validateUniqueHexBytes,
 } from '../../validate.ts'
 
 /** Parameters shared by Solana token pool remote-config editing generation and execution. */
@@ -107,6 +108,7 @@ export class EditChainRemoteConfig extends SolanaOperation<
     const remotePoolAddresses = params.remotePoolAddresses.map((address, i) =>
       parseNonEmptyHexBytes(this.name, `remotePoolAddresses[${i}]`, address),
     )
+    validateUniqueHexBytes(this.name, 'remotePoolAddresses', remotePoolAddresses)
 
     const payer = parsePublicKey(this.name, 'payer', params.payer)
     return {

--- a/ccip-sdk/src/cct/solana/token-pool/operations/edit-chain-remote-config.ts
+++ b/ccip-sdk/src/cct/solana/token-pool/operations/edit-chain-remote-config.ts
@@ -108,7 +108,12 @@ export class EditChainRemoteConfig extends SolanaOperation<
     const remotePoolAddresses = params.remotePoolAddresses.map((address, i) =>
       parseNonEmptyHexBytes(this.name, `remotePoolAddresses[${i}]`, address),
     )
-    validateUniqueHexBytes(this.name, 'remotePoolAddresses', remotePoolAddresses)
+    validateUniqueHexBytes(
+      this.name,
+      'remotePoolAddresses',
+      remotePoolAddresses,
+      'remote pool addresses',
+    )
 
     const payer = parsePublicKey(this.name, 'payer', params.payer)
     return {

--- a/ccip-sdk/src/cct/solana/token-pool/operations/remove-from-allowlist.test.ts
+++ b/ccip-sdk/src/cct/solana/token-pool/operations/remove-from-allowlist.test.ts
@@ -153,7 +153,7 @@ describe('RemoveFromAllowlist (cct/solana)', () => {
         (err: unknown) =>
           err instanceof CCTParamsInvalidError &&
           err.context.operation === 'removeFromAllowlist' &&
-          err.context.param === 'remove',
+          err.context.param === 'remove[1]',
       )
     })
   })

--- a/ccip-sdk/src/cct/solana/token-pool/operations/remove-from-allowlist.ts
+++ b/ccip-sdk/src/cct/solana/token-pool/operations/remove-from-allowlist.ts
@@ -1,9 +1,8 @@
 import { type PublicKey, SystemProgram } from '@solana/web3.js'
 
-import { CCIPWalletInvalidError } from '../../../../errors/index.ts'
 import { ChainFamily } from '../../../../networks.ts'
 import type { SolanaChain } from '../../../../solana/index.ts'
-import { type UnsignedSolanaTx, isWallet } from '../../../../solana/types.ts'
+import type { UnsignedSolanaTx } from '../../../../solana/types.ts'
 import { CCTParamsInvalidError } from '../../../errors.ts'
 import type { TransactionResult } from '../../../operation.ts'
 import {
@@ -21,6 +20,7 @@ import {
   parsePublicKey,
   resolvePoolProgram,
   validateAuthorityMatchesWallet,
+  validateUniquePublicKeys,
 } from '../../validate.ts'
 
 /** Parameters shared by Solana token pool `removeFromAllowlist` generation and execution. */
@@ -76,9 +76,7 @@ export class RemoveFromAllowlist extends SolanaOperation<
     const remove = params.remove.map((address, index) =>
       parsePublicKey(this.name, `remove[${index}]`, address),
     )
-    if (new Set(remove.map((address) => address.toBase58())).size !== remove.length) {
-      throw new CCTParamsInvalidError(this.name, 'remove', 'must not contain duplicate addresses')
-    }
+    validateUniquePublicKeys(this.name, 'remove', remove)
 
     const payer = parsePublicKey(this.name, 'payer', params.payer)
     return {
@@ -122,14 +120,7 @@ export class RemoveFromAllowlist extends SolanaOperation<
     chain: SolanaChain,
     params: ExecuteRemoveFromAllowlistParams,
   ): Promise<ExecuteRemoveFromAllowlistResult> {
-    const { wallet, computeUnits, ...rest } = params
-    if (!isWallet(wallet)) throw new CCIPWalletInvalidError(wallet)
-
-    const generateParams: GenerateRemoveFromAllowlistParams = {
-      ...rest,
-      payer: wallet.publicKey.toBase58(),
-    }
-    const parsed = this.prepare(generateParams)
+    const { wallet, computeUnits, parsed } = this.prepareWalletExecution(params)
 
     if (params.authority !== undefined) {
       validateAuthorityMatchesWallet(

--- a/ccip-sdk/src/cct/solana/token-pool/operations/remove-from-allowlist.ts
+++ b/ccip-sdk/src/cct/solana/token-pool/operations/remove-from-allowlist.ts
@@ -57,7 +57,10 @@ export type ExecuteRemoveFromAllowlistParams = SolanaExecuteParams<RemoveFromAll
 /** Result of executing Solana token pool allowlist removal. */
 export type ExecuteRemoveFromAllowlistResult = TransactionResult
 
-/** Removes addresses from a Solana token pool allowlist. */
+/**
+ * Removes addresses from a Solana token pool allowlist.
+ * @remarks Removed addresses must not contain duplicates.
+ */
 export class RemoveFromAllowlist extends SolanaOperation<
   RemoveFromAllowlistParams,
   UnsignedSolanaTx,

--- a/ccip-sdk/src/cct/solana/token/operations/deploy-token.test.ts
+++ b/ccip-sdk/src/cct/solana/token/operations/deploy-token.test.ts
@@ -7,6 +7,7 @@ import { Keypair, PublicKey, SystemProgram } from '@solana/web3.js'
 import { ChainFamily } from '../../../../networks.ts'
 import type { SolanaChain } from '../../../../solana/index.ts'
 import { CCTParamsInvalidError } from '../../../errors.ts'
+import { U64_MAX } from '../../validate.ts'
 import { DeployToken } from './deploy-token.ts'
 
 const BLOCKHASH = PublicKey.default.toBase58()
@@ -129,6 +130,7 @@ describe('DeployToken (cct/solana)', () => {
         [{ freezeAuthority: 'invalid' }, 'freezeAuthority'],
         [{ preMint: 0n }, 'preMint'],
         [{ preMint: 1 }, 'preMint'],
+        [{ preMint: U64_MAX + 1n }, 'preMint'],
         [{ preMint: 1n }, 'preMintRecipient'],
         [{ preMint: 1n, preMintRecipient: 'invalid' }, 'preMintRecipient'],
       ] as const) {

--- a/ccip-sdk/src/cct/solana/token/operations/deploy-token.ts
+++ b/ccip-sdk/src/cct/solana/token/operations/deploy-token.ts
@@ -21,7 +21,12 @@ import {
 } from '../../operation.ts'
 import { deriveMetadataAddress } from '../../programs/token.ts'
 import { submit } from '../../submit.ts'
-import { validateOptionalPublicKey, validatePublicKey } from '../../validate.ts'
+import {
+  U64_MAX,
+  validateBigInt,
+  validateOptionalPublicKey,
+  validatePublicKey,
+} from '../../validate.ts'
 
 type BaseDeployTokenParams = {
   /** Mint decimals. Must be an integer between 0 and 255. */
@@ -248,11 +253,8 @@ function validateBaseParams(operation: string, params: GenerateDeployTokenParams
 }
 
 function validatePreMintParams(operation: string, params: GenerateDeployTokenParams): void {
-  if (
-    params.preMint !== undefined &&
-    (typeof params.preMint !== 'bigint' || params.preMint <= 0n)
-  ) {
-    throw new CCTParamsInvalidError(operation, 'preMint', 'must be a positive bigint')
+  if (params.preMint !== undefined) {
+    validateBigInt(operation, 'preMint', params.preMint, 1n, U64_MAX)
   }
   if (params.preMint !== undefined && !params.preMintRecipient) {
     throw new CCTParamsInvalidError(

--- a/ccip-sdk/src/cct/solana/token/operations/deploy-token.ts
+++ b/ccip-sdk/src/cct/solana/token/operations/deploy-token.ts
@@ -37,7 +37,7 @@ type BaseDeployTokenParams = {
   mintAuthority?: string
   /** Freeze authority. Defaults to payer; set null to disable freezing. */
   freezeAuthority?: string | null
-  /** Initial supply in base units. Requires preMintRecipient. */
+  /** Initial supply in base units, between 1 and 2^64 - 1. Requires preMintRecipient. */
   preMint?: bigint
   /** Recipient owner for the initial supply ATA. */
   preMintRecipient?: string

--- a/ccip-sdk/src/cct/solana/validate.test.ts
+++ b/ccip-sdk/src/cct/solana/validate.test.ts
@@ -23,6 +23,8 @@ import {
   validatePoolType,
   validatePublicKey,
   validatePublicKeys,
+  validateUniqueChainSelectors,
+  validateUniqueHexBytes,
   validateWritableIndexes,
 } from './validate.ts'
 
@@ -225,6 +227,27 @@ describe('Validate (cct/solana)', () => {
       () => validateBigInt('op', 'selector', 2n, undefined, 1n),
       (err: unknown) =>
         err instanceof CCTParamsInvalidError && err.context.reason === 'must be a bigint <= 1',
+    )
+  })
+
+  it('rejects duplicate chain selectors', () => {
+    assert.doesNotThrow(() => validateUniqueChainSelectors('op', 'selectors', [1n, 2n]))
+    assert.throws(
+      () => validateUniqueChainSelectors('op', 'selectors', [1n, 1n]),
+      (err: unknown) =>
+        err instanceof CCTParamsInvalidError && err.context.param === 'selectors[1]',
+    )
+  })
+
+  it('rejects duplicate hex byte values', () => {
+    assert.doesNotThrow(() => validateUniqueHexBytes('op', 'addresses', [Buffer.from('01', 'hex')]))
+    assert.throws(
+      () =>
+        validateUniqueHexBytes('op', 'addresses', [
+          Buffer.from('01', 'hex'),
+          Buffer.from('01', 'hex'),
+        ]),
+      (err: unknown) => err instanceof CCTParamsInvalidError && err.context.param === 'addresses',
     )
   })
 

--- a/ccip-sdk/src/cct/solana/validate.test.ts
+++ b/ccip-sdk/src/cct/solana/validate.test.ts
@@ -25,6 +25,7 @@ import {
   validatePublicKeys,
   validateUniqueChainSelectors,
   validateUniqueHexBytes,
+  validateUniquePublicKeys,
   validateWritableIndexes,
 } from './validate.ts'
 
@@ -230,6 +231,15 @@ describe('Validate (cct/solana)', () => {
     )
   })
 
+  it('rejects duplicate public keys', () => {
+    const address = PublicKey.default
+    assert.throws(
+      () => validateUniquePublicKeys('op', 'addresses', [address, address]),
+      (err: unknown) =>
+        err instanceof CCTParamsInvalidError && err.context.param === 'addresses[1]',
+    )
+  })
+
   it('rejects duplicate chain selectors', () => {
     assert.doesNotThrow(() => validateUniqueChainSelectors('op', 'selectors', [1n, 2n]))
     assert.throws(
@@ -247,7 +257,22 @@ describe('Validate (cct/solana)', () => {
           Buffer.from('01', 'hex'),
           Buffer.from('01', 'hex'),
         ]),
-      (err: unknown) => err instanceof CCTParamsInvalidError && err.context.param === 'addresses',
+      (err: unknown) =>
+        err instanceof CCTParamsInvalidError &&
+        err.context.param === 'addresses[1]' &&
+        err.context.reason === 'must not contain duplicate hex values',
+    )
+    assert.throws(
+      () =>
+        validateUniqueHexBytes(
+          'op',
+          'remotePoolAddresses',
+          [Buffer.from('01', 'hex'), Buffer.from('01', 'hex')],
+          'remote pool addresses',
+        ),
+      (err: unknown) =>
+        err instanceof CCTParamsInvalidError &&
+        err.context.reason === 'must not contain duplicate remote pool addresses',
     )
   })
 

--- a/ccip-sdk/src/cct/solana/validate.ts
+++ b/ccip-sdk/src/cct/solana/validate.ts
@@ -94,13 +94,23 @@ export function validateUniquePublicKeys(
   param: string,
   publicKeys: PublicKey[],
 ): void {
-  if (new Set(publicKeys.map((publicKey) => publicKey.toBase58())).size !== publicKeys.length) {
-    throw new CCTParamsInvalidError(operation, param, 'must not contain duplicate addresses')
+  const seen = new Set<string>()
+  for (const [i, publicKey] of publicKeys.entries()) {
+    const address = publicKey.toBase58()
+    if (seen.has(address)) {
+      throw new CCTParamsInvalidError(
+        operation,
+        `${param}[${i}]`,
+        'must not contain duplicate addresses',
+      )
+    }
+    seen.add(address)
   }
 }
 
 /**
  * Asserts bigint chain selectors do not contain duplicates.
+ * @remarks Silently ignores non-bigint entries; relies on downstream `validateBigInt` for type safety.
  * @throws CCTParamsInvalidError if a chain selector is duplicated.
  */
 export function validateUniqueChainSelectors(
@@ -125,9 +135,23 @@ export function validateUniqueChainSelectors(
  * Asserts hex byte values do not contain duplicates.
  * @throws CCTParamsInvalidError if a hex byte value is duplicated.
  */
-export function validateUniqueHexBytes(operation: string, param: string, values: Buffer[]): void {
-  if (new Set(values.map((value) => value.toString('hex'))).size !== values.length) {
-    throw new CCTParamsInvalidError(operation, param, 'must not contain duplicate hex values')
+export function validateUniqueHexBytes(
+  operation: string,
+  param: string,
+  values: Buffer[],
+  label = 'hex values',
+): void {
+  const seen = new Set<string>()
+  for (const [i, value] of values.entries()) {
+    const hex = value.toString('hex')
+    if (seen.has(hex)) {
+      throw new CCTParamsInvalidError(
+        operation,
+        `${param}[${i}]`,
+        `must not contain duplicate ${label}`,
+      )
+    }
+    seen.add(hex)
   }
 }
 
@@ -393,7 +417,11 @@ export async function resolveExistingTokenAccount(
   tokenAddress: PublicKey,
   holder: PublicKey,
   tokenAccount?: PublicKey,
-): Promise<{ tokenAccount: PublicKey; tokenProgram: PublicKey; account: Account }> {
+): Promise<{
+  tokenAccount: PublicKey
+  tokenProgram: PublicKey
+  account: Account
+}> {
   const { ata, tokenProgram } = await resolveATA(connection, tokenAddress, holder)
   const account = tokenAccount ?? ata
   let tokenAccountInfo: Account

--- a/ccip-sdk/src/cct/solana/validate.ts
+++ b/ccip-sdk/src/cct/solana/validate.ts
@@ -86,6 +86,52 @@ export function validatePublicKeys(operation: string, param: string, values: unk
 }
 
 /**
+ * Asserts public keys do not contain duplicates.
+ * @throws CCTParamsInvalidError if a public key is duplicated.
+ */
+export function validateUniquePublicKeys(
+  operation: string,
+  param: string,
+  publicKeys: PublicKey[],
+): void {
+  if (new Set(publicKeys.map((publicKey) => publicKey.toBase58())).size !== publicKeys.length) {
+    throw new CCTParamsInvalidError(operation, param, 'must not contain duplicate addresses')
+  }
+}
+
+/**
+ * Asserts bigint chain selectors do not contain duplicates.
+ * @throws CCTParamsInvalidError if a chain selector is duplicated.
+ */
+export function validateUniqueChainSelectors(
+  operation: string,
+  param: string,
+  selectors: unknown[],
+): void {
+  const seen = new Set<bigint>()
+  for (const [i, selector] of selectors.entries()) {
+    if (typeof selector === 'bigint' && seen.has(selector)) {
+      throw new CCTParamsInvalidError(
+        operation,
+        `${param}[${i}]`,
+        'must not contain duplicate chain selectors',
+      )
+    }
+    if (typeof selector === 'bigint') seen.add(selector)
+  }
+}
+
+/**
+ * Asserts hex byte values do not contain duplicates.
+ * @throws CCTParamsInvalidError if a hex byte value is duplicated.
+ */
+export function validateUniqueHexBytes(operation: string, param: string, values: Buffer[]): void {
+  if (new Set(values.map((value) => value.toString('hex'))).size !== values.length) {
+    throw new CCTParamsInvalidError(operation, param, 'must not contain duplicate hex values')
+  }
+}
+
+/**
  * Asserts `value` is a non-empty string.
  * @throws CCTParamsInvalidError if `value` is not a non-empty string.
  */

--- a/ccip-sdk/src/gas.ts
+++ b/ccip-sdk/src/gas.ts
@@ -196,8 +196,7 @@ export async function getDestTokenAmount({
   let sourceTokenAddress, sourcePoolAddress, destTokenAddress
   if ('destTokenAddress' in tokenAmount) {
     ;({ destTokenAddress, sourcePoolAddress, sourceTokenAddress } = tokenAmount)
-  } else if (!source)
-    return tokenAmount // if we don't have a source, assume we were already given a dest `{token, amount}`
+  } else if (!source) return tokenAmount // if we don't have a source, assume we were already given a dest `{token, amount}`
   else {
     ;({ destTokenAddress, sourceTokenAddress, sourcePoolAddress } =
       await sourceToDestTokenAddresses({

--- a/package-lock.json
+++ b/package-lock.json
@@ -16102,7 +16102,20 @@
       }
     },
     "node_modules/image-size": {
-      "version": "2.0.2",
+      "name": "@localnerve/image-size",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@localnerve/image-size/-/image-size-2.1.2.tgz",
+      "integrity": "sha512-EiIL9ZlEyK32Upr+M5ufBTYCo/eHt8RXHyg09MCB0RVymbpibMZ/PHkrOM26ryM4mQ/MxF+pzYk58lJWTHIPtQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/localnerve"
+        },
+        {
+          "type": "paypal",
+          "url": "https://www.paypal.com/ncp/payment/DHCB5GUYMGX5U"
+        }
+      ],
       "license": "MIT",
       "bin": {
         "image-size": "bin/image-size.js"


### PR DESCRIPTION
## What

- Bound Solana `DeployToken.preMint` to u64 maximum.
- Reused base wallet execution preparation across legacy Solana operations.
- Added duplicate collection validation for token pools, chain updates, and ALT additions
- Added reusable Solana unique-value validators
- Updated image-size lockfile resolution to patched `@localnerve/image-size@2.1.2`

## Why

- Prevent invalid Solana transactions, duplicate configuration entries, and vulnerable dependency resolution.