### PR TITLE
fix(cct-sdk): Prevent partial Solana CCT commits

### DIFF
--- a/ccip-sdk/src/cct/errors.ts
+++ b/ccip-sdk/src/cct/errors.ts
@@ -45,7 +45,9 @@ export class CCTParamsInvalidError extends CCIPError {
  * Thrown when a CCT write fails before broadcast, the transaction reverts after mining,
  * or it mines without the expected effect (e.g. a deployment that produced no contract
  * address). Pre-broadcast failures (signing/RPC) may set `isTransient: true` for network
- * errors; reverts and post-mining anomalies are permanent and include `context.txHash`.
+ * errors; reverts and post-mining anomalies are permanent and include `context.txHash`. For a
+ * split Solana operation, `context.committedHashes` contains confirmed prior transaction hashes;
+ * state is partially applied and those transactions are permanent.
  *
  * @example
  * ```typescript
@@ -62,17 +64,23 @@ export class CCTTxFailedError extends CCIPError {
   override readonly name = 'CCTTxFailedError'
   /** Creates a tx-failed error. */
   constructor(operation: string, reason: string, options?: CCIPErrorOptions) {
-    super(CCIPErrorCode.CCT_TX_FAILED, `${operation} failed: ${reason}`, {
-      ...options,
-      isTransient: options?.isTransient ?? false,
-      context: { ...options?.context, operation, reason },
-    })
+    super(
+      CCIPErrorCode.CCT_TX_FAILED,
+      `${partialApplicationPrefix(options?.context)}${operation} failed: ${reason}`,
+      {
+        ...options,
+        isTransient: options?.isTransient ?? false,
+        context: { ...options?.context, operation, reason },
+      },
+    )
   }
 }
 
 /**
  * Thrown when a transaction was broadcast but not confirmed within the timeout.
- * Transient — it may still mine; check `context.txHash` before resubmitting.
+ * Transient — it may still mine; check `context.txHash` before resubmitting. For a split Solana
+ * operation, `context.committedHashes` contains confirmed prior transaction hashes; state is
+ * partially applied and those transactions are permanent.
  *
  * @example
  * ```typescript
@@ -91,7 +99,7 @@ export class CCTTxNotConfirmedError extends CCIPError {
   constructor(operation: string, txHash: string, options?: CCIPErrorOptions) {
     super(
       CCIPErrorCode.CCT_TX_NOT_CONFIRMED,
-      `${operation} transaction not confirmed within timeout: ${txHash}`,
+      `${partialApplicationPrefix(options?.context)}${operation} transaction not confirmed within timeout: ${txHash}`,
       {
         ...options,
         isTransient: true,
@@ -100,6 +108,13 @@ export class CCTTxNotConfirmedError extends CCIPError {
       },
     )
   }
+}
+
+function partialApplicationPrefix(context?: Record<string, unknown>): string {
+  const committedHashes = context?.committedHashes
+  return Array.isArray(committedHashes) && committedHashes.length
+    ? `partially applied: ${committedHashes.length} transaction(s) confirmed; `
+    : ''
 }
 
 // Contract version dispatch

--- a/ccip-sdk/src/cct/solana/submit.test.ts
+++ b/ccip-sdk/src/cct/solana/submit.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 
 import {
+  AddressLookupTableAccount,
   ComputeBudgetProgram,
   Keypair,
   SendTransactionError,
@@ -125,15 +126,30 @@ describe('Submit error mapping (cct/solana)', () => {
   it('reports confirmed slices when a later slice fails', async () => {
     const hash = 'confirmed-slice'
     let simulations = 0
+    const simulationLookupCounts: number[] = []
+    const lookupAddress = Keypair.generate().publicKey
+    const lookupTable = new AddressLookupTableAccount({
+      key: Keypair.generate().publicKey,
+      state: {
+        deactivationSlot: 0xffff_ffff_ffff_ffffn,
+        lastExtendedSlot: 0,
+        lastExtendedSlotStartIndex: 0,
+        authority: undefined,
+        addresses: [lookupAddress],
+      },
+    })
     const chain = {
       logger: { debug() {}, info() {}, warn() {}, error() {} },
       connection: {
-        simulateTransaction: async () => ({
-          value: {
-            err: ++simulations === 1 ? null : { InstructionError: [1, { Custom: 4 }] },
-            logs: [],
-          },
-        }),
+        simulateTransaction: async (tx: { message: { addressTableLookups: unknown[] } }) => {
+          simulationLookupCounts.push(tx.message.addressTableLookups.length)
+          return {
+            value: {
+              err: ++simulations === 1 ? null : { InstructionError: [1, { Custom: 4 }] },
+              logs: [],
+            },
+          }
+        },
         getLatestBlockhash: async () => ({
           blockhash: Keypair.generate().publicKey.toBase58(),
           lastValidBlockHeight: 1,
@@ -149,7 +165,7 @@ describe('Submit error mapping (cct/solana)', () => {
     const instruction = () =>
       new TransactionInstruction({
         programId: Keypair.generate().publicKey,
-        keys: [],
+        keys: [{ pubkey: lookupAddress, isSigner: false, isWritable: false }],
         data: Buffer.alloc(700),
       })
 
@@ -160,14 +176,17 @@ describe('Submit error mapping (cct/solana)', () => {
         {
           family: ChainFamily.Solana,
           instructions: [instruction(), instruction()],
+          lookupTables: [lookupTable],
           mainIndex: 0,
         },
         OP,
       ),
       (error: unknown) =>
         error instanceof CCTTxFailedError &&
+        error.message.startsWith('partially applied: 1 transaction(s) confirmed;') &&
         Array.isArray(error.context.committedHashes) &&
         error.context.committedHashes[0] === hash,
     )
+    assert.deepEqual(simulationLookupCounts, [1, 1])
   })
 })

--- a/ccip-sdk/src/cct/solana/submit.test.ts
+++ b/ccip-sdk/src/cct/solana/submit.test.ts
@@ -1,16 +1,26 @@
 import assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 
-import { SendTransactionError, TransactionExpiredTimeoutError } from '@solana/web3.js'
+import {
+  ComputeBudgetProgram,
+  Keypair,
+  SendTransactionError,
+  TransactionExpiredTimeoutError,
+  TransactionInstruction,
+} from '@solana/web3.js'
 
+import { ChainFamily } from '../../networks.ts'
+import type { SolanaChain } from '../../solana/index.ts'
 import { CCTTxFailedError, CCTTxNotConfirmedError } from '../errors.ts'
-import { createCCTSubmitError } from './submit.ts'
+import { createCCTSubmitError, submit } from './submit.ts'
 
 const OP = 'setPool'
 
 describe('Submit error mapping (cct/solana)', () => {
   it('maps post-broadcast confirmation errors with a signature to not-confirmed', () => {
-    const cause = Object.assign(new Error('transaction was not confirmed'), { signature: 'abc' })
+    const cause = Object.assign(new Error('transaction was not confirmed'), {
+      signature: 'abc',
+    })
     const err = createCCTSubmitError(OP, cause)
 
     assert.ok(err instanceof CCTTxNotConfirmedError)
@@ -38,7 +48,9 @@ describe('Submit error mapping (cct/solana)', () => {
   })
 
   it('maps signed on-chain failures to permanent tx failed', () => {
-    const cause = Object.assign(new Error('custom program error: 0x1'), { signature: 'jkl' })
+    const cause = Object.assign(new Error('custom program error: 0x1'), {
+      signature: 'jkl',
+    })
     const err = createCCTSubmitError(OP, cause)
 
     assert.ok(err instanceof CCTTxFailedError)
@@ -70,5 +82,92 @@ describe('Submit error mapping (cct/solana)', () => {
 
     assert.ok(err instanceof CCTTxFailedError)
     assert.equal(err.isTransient, false)
+  })
+
+  it('does not submit a slice when its simulation rejects', async () => {
+    let sends = 0
+    const chain = {
+      logger: { debug() {}, info() {}, warn() {}, error() {} },
+      connection: {
+        simulateTransaction: async () => ({
+          value: { err: { InstructionError: [2, { Custom: 4 }] }, logs: [] },
+        }),
+        sendTransaction: async () => {
+          sends++
+          return 'unused'
+        },
+      },
+    } as unknown as SolanaChain
+    const wallet = {
+      publicKey: Keypair.generate().publicKey,
+      signTransaction: async <T>(tx: T) => tx,
+    }
+
+    await assert.rejects(
+      submit(
+        chain,
+        wallet,
+        {
+          family: ChainFamily.Solana,
+          instructions: [
+            ComputeBudgetProgram.setComputeUnitLimit({ units: 1 }),
+            ComputeBudgetProgram.setComputeUnitLimit({ units: 2 }),
+          ],
+          mainIndex: 0,
+        },
+        OP,
+      ),
+      CCTTxFailedError,
+    )
+    assert.equal(sends, 0)
+  })
+
+  it('reports confirmed slices when a later slice fails', async () => {
+    const hash = 'confirmed-slice'
+    let simulations = 0
+    const chain = {
+      logger: { debug() {}, info() {}, warn() {}, error() {} },
+      connection: {
+        simulateTransaction: async () => ({
+          value: {
+            err: ++simulations === 1 ? null : { InstructionError: [1, { Custom: 4 }] },
+            logs: [],
+          },
+        }),
+        getLatestBlockhash: async () => ({
+          blockhash: Keypair.generate().publicKey.toBase58(),
+          lastValidBlockHeight: 1,
+        }),
+        sendTransaction: async () => hash,
+        confirmTransaction: async () => ({ value: { err: null } }),
+      },
+    } as unknown as SolanaChain
+    const wallet = {
+      publicKey: Keypair.generate().publicKey,
+      signTransaction: async <T>(tx: T) => tx,
+    }
+    const instruction = () =>
+      new TransactionInstruction({
+        programId: Keypair.generate().publicKey,
+        keys: [],
+        data: Buffer.alloc(700),
+      })
+
+    await assert.rejects(
+      submit(
+        chain,
+        wallet,
+        {
+          family: ChainFamily.Solana,
+          instructions: [instruction(), instruction()],
+          mainIndex: 0,
+        },
+        OP,
+      ),
+      (error: unknown) =>
+        error instanceof CCTTxFailedError &&
+        Array.isArray(error.context.committedHashes) &&
+        error.context.committedHashes[0] === hash,
+    )
   })
 })

--- a/ccip-sdk/src/cct/solana/submit.ts
+++ b/ccip-sdk/src/cct/solana/submit.ts
@@ -65,12 +65,13 @@ function getTransactionSlice(unsigned: UnsignedSolanaTx, start: number, end: num
   return {
     includesMain,
     instructions: unsigned.instructions.slice(start, end),
-    lookupTables: includesMain ? unsigned.lookupTables : undefined,
+    // Lookup tables may be needed by instructions in any slice.
+    lookupTables: unsigned.lookupTables,
   }
 }
 
 /**
- * Submits CCT instruction slices, shrinking only locally oversized slices.
+ * Submits CCT instruction slices, splitting only after local size-overflow detection.
  *
  * A simulation failure aborts its slice without submitting it. Confirmed earlier slices are
  * attached as `committedHashes` when a later slice fails. Set `requireSingleTransaction` for

--- a/ccip-sdk/src/cct/solana/submit.ts
+++ b/ccip-sdk/src/cct/solana/submit.ts
@@ -8,31 +8,177 @@
  */
 
 import {
+  ComputeBudgetProgram,
+  PACKET_DATA_SIZE,
+  PublicKey,
   TransactionExpiredBlockheightExceededError,
   TransactionExpiredNonceInvalidError,
   TransactionExpiredTimeoutError,
+  TransactionMessage,
+  VersionedTransaction,
 } from '@solana/web3.js'
 
 import { CCIPWalletInvalidError, shouldRetry } from '../../errors/index.ts'
 import type { SolanaChain } from '../../solana/index.ts'
-import { type UnsignedSolanaTx, isWallet } from '../../solana/types.ts'
-import { simulateAndSendTxs } from '../../solana/utils.ts'
+import { type UnsignedSolanaTx, type Wallet, isWallet } from '../../solana/types.ts'
+import { simulateTransaction } from '../../solana/utils.ts'
 import { CCTTxFailedError, CCTTxNotConfirmedError } from '../errors.ts'
 import type { TransactionResult } from '../operation.ts'
 
-/** Signs, simulates, sends, and confirms a Solana CCT transaction. */
+const MAX_COMPUTE_UNITS = 1_400_000
+
+function buildTransaction(
+  payer: PublicKey,
+  instructions: UnsignedSolanaTx['instructions'],
+  lookupTables: UnsignedSolanaTx['lookupTables'],
+  computeUnits?: number,
+  recentBlockhash = PublicKey.default.toBase58(),
+): VersionedTransaction {
+  return new VersionedTransaction(
+    new TransactionMessage({
+      payerKey: payer,
+      recentBlockhash,
+      instructions: [
+        ...(computeUnits === undefined
+          ? []
+          : [ComputeBudgetProgram.setComputeUnitLimit({ units: computeUnits })]),
+        ...instructions,
+      ],
+    }).compileToV0Message(lookupTables),
+  )
+}
+
+function exceedsTransactionSize(tx: VersionedTransaction): boolean {
+  try {
+    return tx.serialize().length > PACKET_DATA_SIZE
+  } catch (error) {
+    if (error instanceof Error && error.message.includes('encoding overruns Uint8Array')) {
+      return true
+    }
+    throw error
+  }
+}
+
+function getTransactionSlice(unsigned: UnsignedSolanaTx, start: number, end: number) {
+  const includesMain =
+    unsigned.mainIndex != null && start <= unsigned.mainIndex && unsigned.mainIndex < end
+  return {
+    includesMain,
+    instructions: unsigned.instructions.slice(start, end),
+    lookupTables: includesMain ? unsigned.lookupTables : undefined,
+  }
+}
+
+/**
+ * Submits CCT instruction slices, shrinking only locally oversized slices.
+ *
+ * A simulation failure aborts its slice without submitting it. Confirmed earlier slices are
+ * attached as `committedHashes` when a later slice fails. Set `requireSingleTransaction` for
+ * operations that must never be split.
+ */
+async function simulateAndSendCCTTxs(
+  chain: SolanaChain,
+  wallet: Wallet,
+  unsigned: UnsignedSolanaTx,
+  operation: string,
+  computeUnits?: number,
+  requireSingleTransaction = false,
+): Promise<string> {
+  let mainHash: string | undefined
+  const committedHashes: string[] = []
+  try {
+    for (let start = 0; start < unsigned.instructions.length;) {
+      let end = unsigned.instructions.length
+      let slice = getTransactionSlice(unsigned, start, end)
+
+      while (
+        exceedsTransactionSize(
+          buildTransaction(
+            wallet.publicKey,
+            slice.instructions,
+            slice.lookupTables,
+            MAX_COMPUTE_UNITS,
+          ),
+        )
+      ) {
+        if (requireSingleTransaction || --end === start) {
+          throw new CCTTxFailedError(
+            operation,
+            `transaction exceeds Solana's ${PACKET_DATA_SIZE}-byte limit`,
+          )
+        }
+        slice = getTransactionSlice(unsigned, start, end)
+      }
+
+      const simulated = await simulateTransaction(chain, {
+        payerKey: wallet.publicKey,
+        instructions: slice.instructions,
+        addressLookupTableAccounts: slice.lookupTables,
+      })
+      const units = simulated.unitsConsumed || 0
+      const limit = computeUnits ?? (units > 200_000 ? Math.ceil(units * 1.1) : undefined)
+
+      const blockhash = await chain.connection.getLatestBlockhash('confirmed')
+      const tx = buildTransaction(
+        wallet.publicKey,
+        slice.instructions,
+        slice.lookupTables,
+        limit,
+        blockhash.blockhash,
+      )
+      const signed = await wallet.signTransaction(tx)
+      const hash = await chain.connection.sendTransaction(signed)
+      await chain.connection.confirmTransaction({ signature: hash, ...blockhash }, 'confirmed')
+      committedHashes.push(hash)
+      if (slice.includesMain) mainHash = hash
+      start = end
+    }
+    if (!mainHash) throw new CCTTxFailedError(operation, 'transaction has no main instruction')
+    return mainHash
+  } catch (error) {
+    if (!committedHashes.length) throw error
+    throw createCCTSubmitError(operation, error, { committedHashes })
+  }
+}
+
+/**
+ * Signs, simulates, sends, and confirms a Solana CCT operation.
+ *
+ * Oversized instruction lists are split only after a local serialized-size check. Each slice is
+ * simulated before submission; program and simulation failures are rethrown without shrinking the
+ * slice. When a later slice fails, `CCTTxFailedError.context.committedHashes` lists prior slices
+ * that were confirmed.
+ *
+ * @param requireSingleTransaction Reject an oversized instruction list instead of splitting it.
+ * Use this for operations that promise atomicity.
+ * @throws {@link CCIPWalletInvalidError} If `wallet` cannot sign Solana transactions.
+ * @throws {@link CCTTxFailedError} If size validation, simulation, submission, or confirmation fails.
+ * For split operations, its context may include `committedHashes`.
+ * @throws {@link CCTTxNotConfirmedError} If a broadcast transaction is not confirmed.
+ */
 export async function submit(
   chain: SolanaChain,
   wallet: unknown,
   unsigned: UnsignedSolanaTx,
   operation: string,
   computeUnits?: number,
+  requireSingleTransaction?: boolean,
 ): Promise<TransactionResult> {
   if (!isWallet(wallet)) throw new CCIPWalletInvalidError(wallet)
 
   try {
-    return { hash: await simulateAndSendTxs(chain, wallet, unsigned, computeUnits) }
+    return {
+      hash: await simulateAndSendCCTTxs(
+        chain,
+        wallet,
+        unsigned,
+        operation,
+        computeUnits,
+        requireSingleTransaction,
+      ),
+    }
   } catch (error) {
+    if (error instanceof CCTTxFailedError || error instanceof CCTTxNotConfirmedError) throw error
     throw createCCTSubmitError(operation, error)
   }
 }
@@ -41,17 +187,20 @@ export async function submit(
 export function createCCTSubmitError(
   operation: string,
   error: unknown,
+  context?: Record<string, unknown>,
 ): CCTTxFailedError | CCTTxNotConfirmedError {
   const signature = getSignature(error)
   if (signature && isNotConfirmedError(error)) {
     return new CCTTxNotConfirmedError(operation, signature, {
       cause: error instanceof Error ? error : undefined,
+      context,
     })
   }
 
   return new CCTTxFailedError(operation, getReason(error), {
     cause: error instanceof Error ? error : undefined,
     isTransient: isTransientSubmitError(error),
+    context,
   })
 }
 

--- a/ccip-sdk/src/cct/solana/token-pool/operations/apply-chain-updates.test.ts
+++ b/ccip-sdk/src/cct/solana/token-pool/operations/apply-chain-updates.test.ts
@@ -420,8 +420,8 @@ describe('ApplyChainUpdates (cct/solana)', () => {
           }),
         (error: unknown) =>
           CCIPError.isCCIPError(error) &&
-          error.context.committedHashes instanceof Array &&
-          error.context.committedHashes[0] === HASH &&
+          error.context.committedBatchHashes instanceof Array &&
+          error.context.committedBatchHashes[0] === HASH &&
           error.context.committedChainSelectors instanceof Array &&
           error.context.committedChainSelectors[0]?.join() === '0x3,0x4' &&
           error.context.failedBatchIndex === 1 &&

--- a/ccip-sdk/src/cct/solana/token-pool/operations/apply-chain-updates.ts
+++ b/ccip-sdk/src/cct/solana/token-pool/operations/apply-chain-updates.ts
@@ -371,7 +371,7 @@ export class ApplyChainUpdates extends SolanaOperation<
       } catch (error) {
         if (CCIPError.isCCIPError(error)) {
           Object.assign(error.context, {
-            committedHashes: hashes,
+            committedBatchHashes: hashes,
             committedChainSelectors: chainSelectors,
             failedBatchIndex,
             totalBatches: batches.length,

--- a/ccip-sdk/src/cct/solana/token/operations/set-token-authority.test.ts
+++ b/ccip-sdk/src/cct/solana/token/operations/set-token-authority.test.ts
@@ -28,19 +28,19 @@ const WALLET = {
 }
 
 function mintData(
-  mintAuthority = new PublicKey(AUTHORITY),
-  freezeAuthority = mintAuthority,
+  mintAuthority: PublicKey | null = new PublicKey(AUTHORITY),
+  freezeAuthority: PublicKey | null = mintAuthority,
 ): Buffer {
   const data = Buffer.alloc(MINT_SIZE)
   MintLayout.encode(
     {
-      mintAuthorityOption: 1,
-      mintAuthority,
+      mintAuthorityOption: mintAuthority ? 1 : 0,
+      mintAuthority: mintAuthority ?? PublicKey.default,
       supply: 0n,
       decimals: 6,
       isInitialized: true,
-      freezeAuthorityOption: 1,
-      freezeAuthority,
+      freezeAuthorityOption: freezeAuthority ? 1 : 0,
+      freezeAuthority: freezeAuthority ?? PublicKey.default,
     },
     data,
   )
@@ -49,8 +49,8 @@ function mintData(
 
 function chain(
   mintOwner: PublicKey | null = TOKEN_PROGRAM_ID,
-  mintAuthority = new PublicKey(AUTHORITY),
-  freezeAuthority = mintAuthority,
+  mintAuthority: PublicKey | null = new PublicKey(AUTHORITY),
+  freezeAuthority: PublicKey | null = mintAuthority,
 ): SolanaChain {
   return {
     logger: { debug() {}, info() {}, warn() {}, error() {} },
@@ -79,8 +79,8 @@ function submitChain(): SolanaChain {
 function generate(
   opts: Record<string, unknown> = {},
   mintOwner?: PublicKey | null,
-  mintAuthority?: PublicKey,
-  freezeAuthority?: PublicKey,
+  mintAuthority?: PublicKey | null,
+  freezeAuthority?: PublicKey | null,
 ) {
   return new SetTokenAuthority().generate(chain(mintOwner, mintAuthority, freezeAuthority), {
     tokenAddress: TOKEN,
@@ -229,7 +229,9 @@ describe('SetTokenAuthority (cct/solana)', () => {
         (err: unknown) =>
           err instanceof CCTParamsInvalidError &&
           err.context.param === 'authority' &&
-          err.message.includes('mint authority'),
+          err.context.authorityType === 'mint' &&
+          err.context.currentAuthority === PAYER &&
+          err.message.includes(`mint authority (${PAYER})`),
       )
       await assert.rejects(
         () =>
@@ -242,7 +244,19 @@ describe('SetTokenAuthority (cct/solana)', () => {
         (err: unknown) =>
           err instanceof CCTParamsInvalidError &&
           err.context.param === 'authority' &&
-          err.message.includes('freeze authority'),
+          err.context.authorityType === 'freeze' &&
+          err.context.currentAuthority === PAYER &&
+          err.message.includes(`freeze authority (${PAYER})`),
+      )
+    })
+
+    it('identifies a revoked authority', async () => {
+      await assert.rejects(
+        () => generate({ authorityTypes: ['mint'] }, TOKEN_PROGRAM_ID, null),
+        (err: unknown) =>
+          err instanceof CCTParamsInvalidError &&
+          err.context.currentAuthority === null &&
+          err.message.includes('mint authority (already revoked)'),
       )
     })
 

--- a/ccip-sdk/src/cct/solana/token/operations/set-token-authority.test.ts
+++ b/ccip-sdk/src/cct/solana/token/operations/set-token-authority.test.ts
@@ -1,10 +1,14 @@
 import assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 
-import { TOKEN_2022_PROGRAM_ID, TOKEN_PROGRAM_ID } from '@solana/spl-token'
+import { MINT_SIZE, MintLayout, TOKEN_2022_PROGRAM_ID, TOKEN_PROGRAM_ID } from '@solana/spl-token'
 import { Keypair, PublicKey } from '@solana/web3.js'
 
-import { CCIPTokenMintInvalidError, CCIPTokenMintNotFoundError } from '../../../../errors/index.ts'
+import {
+  CCIPTokenDataParseError,
+  CCIPTokenMintInvalidError,
+  CCIPTokenMintNotFoundError,
+} from '../../../../errors/index.ts'
 import { ChainFamily } from '../../../../networks.ts'
 import type { SolanaChain } from '../../../../solana/index.ts'
 import { CCTParamsInvalidError } from '../../../errors.ts'
@@ -23,19 +27,44 @@ const WALLET = {
   signTransaction: async <T>(tx: T) => tx,
 }
 
-function chain(mintOwner: PublicKey | null = TOKEN_PROGRAM_ID): SolanaChain {
+function mintData(
+  mintAuthority = new PublicKey(AUTHORITY),
+  freezeAuthority = mintAuthority,
+): Buffer {
+  const data = Buffer.alloc(MINT_SIZE)
+  MintLayout.encode(
+    {
+      mintAuthorityOption: 1,
+      mintAuthority,
+      supply: 0n,
+      decimals: 6,
+      isInitialized: true,
+      freezeAuthorityOption: 1,
+      freezeAuthority,
+    },
+    data,
+  )
+  return data
+}
+
+function chain(
+  mintOwner: PublicKey | null = TOKEN_PROGRAM_ID,
+  mintAuthority = new PublicKey(AUTHORITY),
+  freezeAuthority = mintAuthority,
+): SolanaChain {
   return {
     logger: { debug() {}, info() {}, warn() {}, error() {} },
     connection: {
-      getAccountInfo: async () => (mintOwner ? { owner: mintOwner } : null),
+      getAccountInfo: async () =>
+        mintOwner ? { owner: mintOwner, data: mintData(mintAuthority, freezeAuthority) } : null,
     },
   } as unknown as SolanaChain
 }
 
 function submitChain(): SolanaChain {
-  return Object.assign(chain(), {
+  return Object.assign(chain(TOKEN_PROGRAM_ID, WALLET.publicKey), {
     connection: {
-      getAccountInfo: async () => ({ owner: TOKEN_PROGRAM_ID }),
+      getAccountInfo: async () => ({ owner: TOKEN_PROGRAM_ID, data: mintData(WALLET.publicKey) }),
       simulateTransaction: async () => ({ value: { err: null, logs: [], unitsConsumed: 1 } }),
       getLatestBlockhash: async () => ({
         blockhash: PublicKey.default.toBase58(),
@@ -47,8 +76,13 @@ function submitChain(): SolanaChain {
   })
 }
 
-function generate(opts: Record<string, unknown> = {}, mintOwner?: PublicKey | null) {
-  return new SetTokenAuthority().generate(chain(mintOwner), {
+function generate(
+  opts: Record<string, unknown> = {},
+  mintOwner?: PublicKey | null,
+  mintAuthority?: PublicKey,
+  freezeAuthority?: PublicKey,
+) {
+  return new SetTokenAuthority().generate(chain(mintOwner, mintAuthority, freezeAuthority), {
     tokenAddress: TOKEN,
     payer: PAYER,
     authority: AUTHORITY,
@@ -102,11 +136,15 @@ describe('SetTokenAuthority (cct/solana)', () => {
     })
 
     it('includes SPL multisig member signers', async () => {
-      const unsigned = await generate({
-        authority: MULTISIG,
-        authorityTypes: ['mint'],
-        multisigSigners: [MULTISIG_SIGNER_1, MULTISIG_SIGNER_2],
-      })
+      const unsigned = await generate(
+        {
+          authority: MULTISIG,
+          authorityTypes: ['mint'],
+          multisigSigners: [MULTISIG_SIGNER_1, MULTISIG_SIGNER_2],
+        },
+        TOKEN_PROGRAM_ID,
+        new PublicKey(MULTISIG),
+      )
 
       assert.deepEqual(
         unsigned.instructions[0]!.keys.map(({ pubkey, isSigner, isWritable }) => ({
@@ -135,7 +173,11 @@ describe('SetTokenAuthority (cct/solana)', () => {
     })
 
     it('defaults authority to payer', async () => {
-      const unsigned = await generate({ authority: undefined })
+      const unsigned = await generate(
+        { authority: undefined },
+        TOKEN_PROGRAM_ID,
+        new PublicKey(PAYER),
+      )
 
       assert.equal(unsigned.instructions[0]!.keys[1]!.pubkey.toBase58(), PAYER)
     })
@@ -179,6 +221,49 @@ describe('SetTokenAuthority (cct/solana)', () => {
             err.message.includes(message),
         )
       }
+    })
+
+    it('requires the authority for every selected role', async () => {
+      await assert.rejects(
+        () => generate({ authorityTypes: ['mint'] }, TOKEN_PROGRAM_ID, new PublicKey(PAYER)),
+        (err: unknown) =>
+          err instanceof CCTParamsInvalidError &&
+          err.context.param === 'authority' &&
+          err.message.includes('mint authority'),
+      )
+      await assert.rejects(
+        () =>
+          generate(
+            { authorityTypes: ['mint', 'freeze'] },
+            TOKEN_PROGRAM_ID,
+            new PublicKey(AUTHORITY),
+            new PublicKey(PAYER),
+          ),
+        (err: unknown) =>
+          err instanceof CCTParamsInvalidError &&
+          err.context.param === 'authority' &&
+          err.message.includes('freeze authority'),
+      )
+    })
+
+    it('reports malformed mint data', async () => {
+      const malformedChain = Object.assign(chain(), {
+        connection: {
+          getAccountInfo: async () => ({ owner: TOKEN_PROGRAM_ID, data: Buffer.alloc(1) }),
+        },
+      })
+
+      await assert.rejects(
+        () =>
+          new SetTokenAuthority().generate(malformedChain, {
+            tokenAddress: TOKEN,
+            payer: PAYER,
+            authority: AUTHORITY,
+            newAuthority: NEW_AUTHORITY,
+            authorityTypes: ['mint'],
+          }),
+        CCIPTokenDataParseError,
+      )
     })
 
     it('rejects missing and non-token mints', async () => {

--- a/ccip-sdk/src/cct/solana/token/operations/set-token-authority.ts
+++ b/ccip-sdk/src/cct/solana/token/operations/set-token-authority.ts
@@ -1,10 +1,11 @@
-import { AuthorityType, createSetAuthorityInstruction } from '@solana/spl-token'
+import { AuthorityType, createSetAuthorityInstruction, unpackMint } from '@solana/spl-token'
 import type { PublicKey, TransactionInstruction } from '@solana/web3.js'
 
+import { CCIPTokenDataParseError } from '../../../../errors/index.ts'
 import { ChainFamily } from '../../../../networks.ts'
 import type { SolanaChain } from '../../../../solana/index.ts'
 import type { UnsignedSolanaTx } from '../../../../solana/types.ts'
-import { resolveTokenProgram } from '../../../../solana/utils.ts'
+import { resolveTokenMint } from '../../../../solana/utils.ts'
 import { CCTParamsInvalidError } from '../../../errors.ts'
 import type { TransactionResult } from '../../../operation.ts'
 import {
@@ -128,7 +129,29 @@ export class SetTokenAuthority extends SolanaOperation<
     chain: SolanaChain,
     opts: ParsedSetTokenAuthorityParams,
   ): Promise<UnsignedSolanaTx> {
-    const tokenProgram = await resolveTokenProgram(chain.connection, opts.tokenAddress)
+    const mintAccount = await resolveTokenMint(chain.connection, opts.tokenAddress)
+    let mint
+
+    try {
+      mint = unpackMint(opts.tokenAddress, mintAccount, mintAccount.owner)
+    } catch (cause) {
+      throw new CCIPTokenDataParseError(opts.tokenAddress.toBase58(), {
+        cause: cause instanceof Error ? cause : undefined,
+      })
+    }
+
+    for (const authorityType of opts.authorityTypes) {
+      const currentAuthority =
+        authorityType === TOKEN_AUTHORITY_TYPES.MINT ? mint.mintAuthority : mint.freezeAuthority
+      if (!currentAuthority?.equals(opts.authority)) {
+        throw new CCTParamsInvalidError(
+          this.name,
+          'authority',
+          `must match the token ${authorityType} authority`,
+        )
+      }
+    }
+
     const instructions: TransactionInstruction[] = opts.authorityTypes.map((authorityType) =>
       createSetAuthorityInstruction(
         opts.tokenAddress,
@@ -136,12 +159,16 @@ export class SetTokenAuthority extends SolanaOperation<
         SPL_AUTHORITY_TYPES[authorityType],
         opts.newAuthority,
         opts.multisigSigners,
-        tokenProgram,
+        mintAccount.owner,
       ),
     )
 
     chain.logger.debug(
-      `${this.name}: token = ${opts.tokenAddress.toBase58()}, authorityTypes = ${opts.authorityTypes.join(',')}, newAuthority = ${opts.newAuthority?.toBase58() ?? 'revoked'}`,
+      `${
+        this.name
+      }: token = ${opts.tokenAddress.toBase58()}, authorityTypes = ${opts.authorityTypes.join(
+        ',',
+      )}, newAuthority = ${opts.newAuthority?.toBase58() ?? 'revoked'}`,
     )
     return { family: ChainFamily.Solana, instructions, mainIndex: 0 }
   }
@@ -170,6 +197,13 @@ export class SetTokenAuthority extends SolanaOperation<
       )
     }
 
-    return submit(chain, wallet, await this.buildUnsigned(chain, parsed), this.name, computeUnits)
+    return submit(
+      chain,
+      wallet,
+      await this.buildUnsigned(chain, parsed),
+      this.name,
+      computeUnits,
+      true,
+    )
   }
 }

--- a/ccip-sdk/src/cct/solana/token/operations/set-token-authority.ts
+++ b/ccip-sdk/src/cct/solana/token/operations/set-token-authority.ts
@@ -144,10 +144,19 @@ export class SetTokenAuthority extends SolanaOperation<
       const currentAuthority =
         authorityType === TOKEN_AUTHORITY_TYPES.MINT ? mint.mintAuthority : mint.freezeAuthority
       if (!currentAuthority?.equals(opts.authority)) {
+        const currentAuthorityAddress = currentAuthority?.toBase58()
         throw new CCTParamsInvalidError(
           this.name,
           'authority',
-          `must match the token ${authorityType} authority`,
+          `authority ${opts.authority.toBase58()} is not the current ${authorityType} authority (${
+            currentAuthorityAddress ?? 'already revoked'
+          })`,
+          {
+            context: {
+              authorityType,
+              currentAuthority: currentAuthorityAddress ?? null,
+            },
+          },
         )
       }
     }
@@ -173,7 +182,15 @@ export class SetTokenAuthority extends SolanaOperation<
     return { family: ChainFamily.Solana, instructions, mainIndex: 0 }
   }
 
-  /** Generate, sign, simulate, send, and confirm with the current authority wallet. */
+  /**
+   * Generate, sign, simulate, send, and confirm with the current authority wallet.
+   *
+   * @throws {CCTParamsInvalidError} If authority types or authority validation is invalid, or
+   * multisig signers are supplied for signed execution.
+   * @throws {CCIPTokenDataParseError} If mint data cannot be parsed.
+   * @throws CCTTxFailedError If simulation or on-chain execution fails.
+   * @throws CCTTxNotConfirmedError If the submitted transaction is not confirmed in time.
+   */
   override async execute(
     chain: SolanaChain,
     params: ExecuteSetTokenAuthorityParams,
@@ -203,7 +220,7 @@ export class SetTokenAuthority extends SolanaOperation<
       await this.buildUnsigned(chain, parsed),
       this.name,
       computeUnits,
-      true,
+      /* requireSingleTransaction */ true,
     )
   }
 }

--- a/ccip-sdk/src/gas.ts
+++ b/ccip-sdk/src/gas.ts
@@ -196,8 +196,7 @@ export async function getDestTokenAmount({
   let sourceTokenAddress, sourcePoolAddress, destTokenAddress
   if ('destTokenAddress' in tokenAmount) {
     ;({ destTokenAddress, sourcePoolAddress, sourceTokenAddress } = tokenAmount)
-  } else if (!source)
-    return tokenAmount // if we don't have a source, assume we were already given a dest `{token, amount}`
+  } else if (!source) return tokenAmount // if we don't have a source, assume we were already given a dest `{token, amount}`
   else {
     ;({ destTokenAddress, sourceTokenAddress, sourcePoolAddress } =
       await sourceToDestTokenAddresses({


### PR DESCRIPTION
## What

- For more info: [DAPP-11383](https://smartcontract-it.atlassian.net/browse/DAPP-11383)
- Add CCT-local Solana submission that splits only locally oversized transaction slices
- Rethrow simulation/program errors without truncating instructions
- Preserve `setTokenAuthority` atomicity and validate selected mint/freeze authorities before submission
- Report confirmed split transaction hashes in `CCTTxFailedError.context.committedHashes`

## Why

- Prevent a failed multi-instruction CCT operation from committing an earlier instruction while returning an error

## Notes

- CCT uses a local `simulateAndSendTxs` helper because shared Solana version treats every simulation failure as a size failure and splits instructions. The local path splits only after a deterministic size check, preserving CCT operation semantics without changing shared SDK behavior.
- Operations can pass requireSingleTransaction to reject oversize rather than split when they require atomic execution.

[DAPP-11383]: https://smartcontract-it.atlassian.net/browse/DAPP-11383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ