### PR TITLE
feat(sdk): ctx overrides for secondary indexer endpoints

### DIFF
--- a/ccip-api-ref/docs-sdk/guides/chain-endpoints.mdx
+++ b/ccip-api-ref/docs-sdk/guides/chain-endpoints.mdx
@@ -1,0 +1,94 @@
+---
+id: chain-endpoints
+title: 'Chain Endpoints & Indexers'
+description: 'Secondary indexer endpoints the SDK queries behind the scenes, their ctx overrides, and defaults.'
+sidebar_label: Chain Endpoints & Indexers
+sidebar_position: 11
+---
+
+# Chain Endpoints & Indexers
+
+Besides the primary RPC endpoint you pass to `fromUrl` / `fromClient`, some chain families consult **secondary, "public-indexer-like" endpoints** — fast paths and lookups that otherwise default to a public service. Every one of them can be pointed elsewhere through the chain context (`ctx`), so private deployments never silently depend on a public default.
+
+All of these requests flow through the chain's fetch — a custom `ctx.fetch` applies to them too (see [the note at the end](#fetch-overrides).
+
+## Summary
+
+| Scope | Secondary endpoint | ctx option | Default |
+|-------|--------------------|------------|---------|
+| all families | CCIP REST API — lane info, message lookups by ID, execution inputs, lane latency | `apiClient` | `https://api.ccip.chain.link` |
+| all families | CCIP v2 verifier indexers — commit / CCV lookups via `getVerifications` | `verificationsIndexer` (a per-call `indexer` option wins) | mainnet: `https://indexer-1.ccip.chain.link`, `https://indexer-2.ccip.chain.link`; testnet: `https://indexer-1.testnet.ccip.chain.link`, `https://indexer-2.testnet.ccip.chain.link` |
+| TON | TonCenter v3 index — `getLogs` fast path, indexed tip, raw-hash tx lookups | `v3Url` | probed: derived from the endpoint when it is toncenter-shaped; otherwise the public TonCenter index for the network |
+| Aptos | GraphQL indexer (`queryIndexer`) — `getLogs` fast path and execution-failure scans | `indexerUrl` | Aptos SDK per-network default, e.g. `https://api.mainnet.aptoslabs.com/v1/graphql` |
+| Canton | CCIP CCV indexer service — verifier results and disclosure lookups | `cantonConfig.indexerUrl` | `https://indexer-1.ccip.chain.link` |
+| EVM, Solana, Sui | none — every query rides the single RPC endpoint | — | — |
+
+## All families: CCIP REST API
+
+The shared `ChainContext.apiClient` accepts a URL string, a pre-built `CCIPAPIClient`, or `null` to disable the API entirely (RPC-only mode):
+
+```typescript
+const chain = await EVMChain.fromUrl(rpcUrl, {
+  apiClient: 'https://staging-api.example.com', // or a CCIPAPIClient instance, or null
+})
+```
+
+## All families: CCIP v2 verifier indexers
+
+`getVerifications` races the CCIP API against the CCIP v2 verifier indexers for commit / CCV data. The built-in defaults are selected by the chain's network type; a chain-level override keeps that choice from hitting the public indexers:
+
+```typescript
+const chain = await EVMChain.fromUrl(rpcUrl, {
+  verificationsIndexer: ['https://my-indexer.example.com'],
+})
+```
+
+A per-call `indexer` option (accepted by `getVerifications`) still wins over the ctx default; Canton additionally honors `cantonConfig.indexerUrl` (below).
+
+## TON: TonCenter v3 index
+
+TON's primary API is the v2 JSON-RPC endpoint, but several operations need the separate **v3 index**: the `getLogs` fast path (startTime-only and index-hinted scans), the indexed-tip probe, the bounded-walk metadata oracle, and raw-hash transaction lookups (`getTransaction('0x<64-hex>')`). Point them all at one URL with `v3Url`:
+
+```typescript
+const chain = await TONChain.fromUrl('https://my-v2-proxy.example/jsonRPC', {
+  v3Url: 'https://my-index.example.com/api/v3?api_key=s3cr3t',
+})
+```
+
+When `v3Url` is omitted, the URL is **resolved (once per chain) as follows**:
+
+1. If the endpoint is toncenter-shaped (an `/api/v2` path), the same-origin `/api/v3` is derived (its query — e.g. an `api_key` — is carried over), then **probed** with a v3-only method (`/masterchainInfo`). A host that does not actually serve v3 (a v2-only proxy) falls back to the public TonCenter index for the network, so a bad inference never poisons v3 consumers.
+2. Any other endpoint goes straight to the public TonCenter index (`https://toncenter.com/api/v3` or `https://testnet.toncenter.com/api/v3`).
+
+An explicit `v3Url` is taken on faith and never probed.
+
+## Aptos: GraphQL indexer
+
+Aptos' GraphQL endpoint **is** its indexer: `provider.queryIndexer` backs the `getLogs` fast path and the execution-failure scans. Override it with `indexerUrl`:
+
+```typescript
+const chain = await AptosChain.fromUrl('https://fullnode.example.internal/v1', {
+  indexerUrl: 'https://my-indexer.example.internal/graphql',
+})
+```
+
+When omitted, the Aptos SDK's per-network default applies (`https://api.<network>.aptoslabs.com/v1/graphql`). The fullnode URL is **never** used to infer an indexer URL — a non-standard fullnode pair requires the explicit option (note that a `Network.CUSTOM` Aptos config throws without one).
+
+## Canton: CCIP CCV indexer
+
+Canton's CCV verifier results and disclosure lookups go through the CCIP CCV indexer service, configured as part of the Canton config:
+
+```typescript
+const chain = await CantonChain.fromUrl(ledgerUrl, {
+  cantonConfig: {
+    // ...
+    indexerUrl: 'https://my-ccv-indexer.example.com',
+  },
+})
+```
+
+Default: `https://indexer-1.ccip.chain.link` (the first mainnet verifier indexer).
+
+## Fetch overrides
+
+A custom `ctx.fetch` is used verbatim for every request above (primary and secondary alike). TON and Aptos additionally accept dedicated fetch overrides for their index traffic (`ctx.v3Fetch` for TON — built automatically from the resolved v3 URL when omitted), since the index host's rate-limit profile differs from the RPC host's.

--- a/ccip-api-ref/docs-sdk/guides/multi-chain.mdx
+++ b/ccip-api-ref/docs-sdk/guides/multi-chain.mdx
@@ -113,6 +113,8 @@ const chain = await EVMChain.fromUrl('https://rpc.sepolia.org', {
 })
 ```
 
+Some chains consult secondary "public-indexer-like" endpoints internally (TON's TonCenter v3 index, Aptos' GraphQL indexer, the CCIP verifier indexers, …) — each has a ctx override with a documented default. See [Chain Endpoints & Indexers](/sdk/guides/chain-endpoints).
+
 ## Unified Interface
 
 All chain classes implement the `Chain` interface, so you can write chain-agnostic code:

--- a/ccip-api-ref/sidebars-sdk.ts
+++ b/ccip-api-ref/sidebars-sdk.ts
@@ -37,6 +37,7 @@ const sidebars: SidebarsConfig = {
         'guides/querying-data',
         'guides/token-pools',
         'guides/multi-chain',
+        'guides/chain-endpoints',
         'guides/viem-integration',
         'guides/browser-setup',
         'guides/error-handling',

--- a/ccip-sdk/src/aptos/fetch-client.test.ts
+++ b/ccip-sdk/src/aptos/fetch-client.test.ts
@@ -10,7 +10,13 @@
 import assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 
-import { type Client, type ClientRequest, AptosConfig, Network } from '@aptos-labs/ts-sdk'
+import {
+  type Client,
+  type ClientRequest,
+  AptosApiType,
+  AptosConfig,
+  Network,
+} from '@aptos-labs/ts-sdk'
 
 import { AptosChain } from './index.ts'
 
@@ -132,6 +138,44 @@ describe('createAptosFetchClient shim (integration via fromAptosConfig)', () => 
     assert.ok(
       fetchCalls.every((c) => !c.method || c.method === 'GET'),
       'getLedgerInfo should be GET',
+    )
+  })
+
+  it('ctx.indexerUrl overrides the indexer endpoint used by queryIndexer', async () => {
+    const spyFetch: typeof fetch = async () =>
+      new Response(JSON.stringify(ledgerInfo()), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+
+    const chain = await AptosChain.fromAptosConfig(
+      { network: Network.MAINNET, fullnode: 'https://fullnode.example.internal' },
+      { fetch: spyFetch, indexerUrl: 'https://indexer.example.internal/graphql' },
+    )
+
+    assert.equal(chain.provider.config.indexer, 'https://indexer.example.internal/graphql')
+    assert.equal(
+      chain.provider.config.getRequestUrl(AptosApiType.INDEXER),
+      'https://indexer.example.internal/graphql',
+    )
+  })
+
+  it('without ctx.indexerUrl, the SDK per-network default indexer applies', async () => {
+    const spyFetch: typeof fetch = async () =>
+      new Response(JSON.stringify(ledgerInfo()), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+
+    const chain = await AptosChain.fromAptosConfig(
+      { network: Network.MAINNET, fullnode: 'https://fullnode.example.internal' },
+      { fetch: spyFetch },
+    )
+
+    assert.equal(chain.provider.config.indexer, undefined)
+    assert.equal(
+      chain.provider.config.getRequestUrl(AptosApiType.INDEXER),
+      'https://api.mainnet.aptoslabs.com/v1/graphql',
     )
   })
 

--- a/ccip-sdk/src/aptos/index.ts
+++ b/ccip-sdk/src/aptos/index.ts
@@ -150,6 +150,24 @@ function createAptosFetchClient(fetchFn: typeof fetch): Client {
 }
 
 /**
+ * Aptos-specific {@link ChainContext} extras. Optional and local to this module on
+ * purpose: the shared ChainContext stays family-agnostic, while Aptos' GraphQL index
+ * (the indexer behind `provider.queryIndexer`, used by the getLogs fast path and the
+ * execution-failure scans) accepts its own URL override.
+ */
+export type AptosChainContext = ChainContext & {
+  /**
+   * Aptos GraphQL indexer base URL, honored verbatim by the provider's
+   * `queryIndexer` calls. Honored when the chain builds its own `AptosConfig`
+   * (i.e. no explicit `client` in the settings); when omitted, the Aptos SDK's
+   * per-network default applies (see `AptosConfig.getRequestUrl` — and note a
+   * `Network.CUSTOM` config throws without one). The fullnode URL is never used
+   * to infer an indexer URL.
+   */
+  indexerUrl?: string
+}
+
+/**
  * Aptos chain implementation supporting Aptos networks.
  */
 export class AptosChain extends Chain<typeof ChainFamily.Aptos> {
@@ -255,12 +273,13 @@ export class AptosChain extends Chain<typeof ChainFamily.Aptos> {
    * `Aptos` instance and want no shim to be installed.
    *
    * @param settings - Aptos configuration settings (AptosSettings or AptosConfig).
-   * @param ctx - context containing logger and optional fetch override.
+   * @param ctx - context containing logger, an optional fetch override, and an
+   *   optional {@link AptosChainContext.indexerUrl} indexer URL override.
    * @returns A new AptosChain instance.
    */
   static async fromAptosConfig(
     settings: AptosSettings | AptosConfig,
-    ctx?: ChainContext,
+    ctx?: AptosChainContext,
   ): Promise<AptosChain> {
     // Detect whether the caller explicitly set a custom HTTP client adapter:
     // - For raw AptosSettings: `client` is undefined unless explicitly set.
@@ -280,7 +299,9 @@ export class AptosChain extends Chain<typeof ChainFamily.Aptos> {
         network: settings.network,
         fullnode: settings.fullnode,
         faucet: settings.faucet,
-        indexer: settings.indexer,
+        // The ctx indexer URL is the authoritative override; otherwise the SDK's
+        // per-network default applies (the fullnode URL is never used to infer one).
+        indexer: ctx?.indexerUrl ?? settings.indexer,
         pepper: settings.pepper,
         prover: settings.prover,
         clientConfig: settings.clientConfig,
@@ -303,7 +324,7 @@ export class AptosChain extends Chain<typeof ChainFamily.Aptos> {
    */
   static async fromUrl(
     url: string | Network | readonly [string, Network],
-    ctx?: ChainContext,
+    ctx?: AptosChainContext,
   ): Promise<AptosChain> {
     let network: Network
     if (Array.isArray(url)) {
@@ -315,10 +336,11 @@ export class AptosChain extends Chain<typeof ChainFamily.Aptos> {
     else throw new CCIPAptosNetworkUnknownError(util.inspect(redactEndpointUrl(url)))
     // Pass raw AptosSettings (not a pre-built AptosConfig) so fromAptosConfig can
     // detect the absence of an explicit `client` and install the fetch shim.
+    // No indexer inference from the fullnode URL: the SDK's per-network default
+    // applies unless ctx.indexerUrl overrides it (wired in fromAptosConfig).
     const settings: AptosSettings = {
       network,
       fullnode: typeof url === 'string' && url.includes('://') ? url : undefined,
-      // indexer: url.includes('://') ? `${url}/v1/graphql` : undefined,
     }
     return this.fromAptosConfig(settings, ctx)
   }

--- a/ccip-sdk/src/chain.ts
+++ b/ccip-sdk/src/chain.ts
@@ -159,6 +159,16 @@ export type ChainContext = WithLogger & {
   apiRetryConfig?: ApiRetryConfig
 
   /**
+   * Default CCIP v2 indexer base URLs for `getVerifications` (commit / CCV verifier
+   * lookups), overriding the built-in public per-network defaults
+   * ({@link MAINNET_INDEXER_URLS} / {@link TESTNET_INDEXER_URLS}). A per-call
+   * `indexer` option still wins over this.
+   *
+   * Default: `undefined` (use the built-in public indexers for the chain's network)
+   */
+  verificationsIndexer?: readonly string[]
+
+  /**
    * Abort signal for cancelling in-flight requests and watch loops on this chain.
    * When the signal fires, the provider is destroyed and all active getLogs watch loops exit.
    */
@@ -840,6 +850,8 @@ export abstract class Chain<F extends ChainFamily = ChainFamily> {
   readonly apiClient: CCIPAPIClient | null
   /** Retry configuration for API fallback operations (null if API client is disabled) */
   readonly apiRetryConfig: Required<ApiRetryConfig> | null
+  /** Default CCIP v2 indexer base URLs for getVerifications (undefined → network defaults) */
+  readonly verificationsIndexer?: readonly string[]
   /**
    * Fires when the chain should tear down: either {@link Chain.destroy} was
    * called, or the ChainContext abort signal fired. Listeners registered with
@@ -855,7 +867,7 @@ export abstract class Chain<F extends ChainFamily = ChainFamily> {
    * @throws {@link CCIPChainFamilyMismatchError} if network family doesn't match the Chain subclass
    */
   constructor(network: NetworkInfo, ctx?: ChainContext) {
-    const { logger = console, apiClient, apiRetryConfig, abort } = ctx ?? {}
+    const { logger = console, apiClient, apiRetryConfig, verificationsIndexer, abort } = ctx ?? {}
 
     if (network.family !== (this.constructor as ChainStatic).family)
       throw new CCIPChainFamilyMismatchError(
@@ -865,6 +877,7 @@ export abstract class Chain<F extends ChainFamily = ChainFamily> {
       )
     this.network = network as NetworkInfo<F>
     this.logger = logger
+    this.verificationsIndexer = verificationsIndexer
 
     const ac = new AbortController()
     // Composite: `destroy()` aborts the inner controller, the context abort

--- a/ccip-sdk/src/evm/index.ts
+++ b/ccip-sdk/src/evm/index.ts
@@ -2564,7 +2564,7 @@ export class EVMChain extends Chain<typeof ChainFamily.EVM> {
       // race API client + indexer URLs
       const verifications = await fetchVerifications(request.message.messageId, {
         apiClient: this.apiClient,
-        indexer: opts.indexer ?? this.network.networkType,
+        indexer: opts.indexer ?? this.verificationsIndexer ?? this.network.networkType,
         watch:
           opts.watch instanceof AbortSignal
             ? AbortSignal.any([opts.watch, this.abort])

--- a/ccip-sdk/src/solana/__tests__/integration.test.ts
+++ b/ccip-sdk/src/solana/__tests__/integration.test.ts
@@ -24,7 +24,6 @@ import { SolanaChain } from '../index.ts'
 // useResourceForDescribe.
 
 const FUJI_RPC = rpcEndpoint('RPC_FUJI')
-const SEPOLIA_RPC = rpcEndpoint('RPC_SEPOLIA')
 const SOLANA_OFFRAMP = 'offqSMQWgQud6WJz694LRzkeN5kMYpCHTpXQr3Rkcjm'
 const SOLANA_V2_SEND_TX =
   '5RrQuDzcwPdVTKTTLVNhz31V5XzNLRZdxaGzLQddqePsu4TYycS6BMKP8V2WtuQ2VS9GdWTZfGt4WjnzKMBZFdM5'
@@ -60,6 +59,27 @@ const solanaDevnetHealthy = (url: string) =>
   })
     .then((res) => res.json() as Promise<{ result?: unknown }>)
     .then((json) => json.result != null)
+
+/**
+ * Sepolia counterpart: prove the fixture send tx is reachable AND complete (tx +
+ * receipt) — the tests here replay the send tx and consume its logs. A throttled
+ * endpoint aborts each EVM op at EVMChain's 90s per-request bound, which is what
+ * blew this suite's 300s ceiling in CI (two ops ≈ one bound + change).
+ */
+const sepoliaHealthy = async (url: string) => {
+  const body = (method: string) =>
+    fetch(url, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method, params: [EVM_TO_SOLANA_V2_TX] }),
+      signal: AbortSignal.timeout(20_000),
+    }).then((res) => res.json() as Promise<{ result?: unknown }>)
+  const [tx, receipt] = await Promise.all([
+    body('eth_getTransactionByHash'),
+    body('eth_getTransactionReceipt'),
+  ])
+  return tx.result != null && receipt.result != null
+}
 
 // Latest v2 messages on the current (post-redeploy) contracts, for both directions.
 const SOLANA_TO_SEPOLIA_V2_TX =
@@ -310,15 +330,23 @@ describe('Solana Devnet CCIP v2 Integration', { skip, timeout: 300_000 }, () => 
   // Sepolia is the EVM counterpart of several fixtures here (v2 both directions)
   useResourceForDescribe(['solana-devnet', 'sepolia'])
   let solanaChain: SolanaChain
+  let sepoliaRpc: string
 
   before(async () => {
-    solanaChain = await SolanaChain.fromUrl(
-      await raceRpcEndpoint('RPC_SOLANA_DEVNET', solanaDevnetHealthy),
-      {
-        apiClient: null,
-        logger: testLogger,
-      },
-    )
+    // CI's shared egress IP trips public endpoints' keyless quotas run to run:
+    // race each network's defaults with a fixture-data probe instead of binding
+    // to the first entry — a throttled endpoint stalled this suite past its 300s
+    // ceiling (each slow EVM op aborts at EVMChain's 90s request bound; devnet
+    // signature scans crawl through pacing retries).
+    const [devnetRpc, sepolia] = await Promise.all([
+      raceRpcEndpoint('RPC_SOLANA_DEVNET', solanaDevnetHealthy),
+      raceRpcEndpoint('RPC_SEPOLIA', sepoliaHealthy),
+    ])
+    sepoliaRpc = sepolia
+    solanaChain = await SolanaChain.fromUrl(devnetRpc, {
+      apiClient: null,
+      logger: testLogger,
+    })
   })
 
   it('should synthesize and decode CCIPMessageSentV2 from Anchor CPI event data', async () => {
@@ -372,7 +400,7 @@ describe('Solana Devnet CCIP v2 Integration', { skip, timeout: 300_000 }, () => 
   it('should fetch EVM to Solana v2 OffRamp executions without verifications', async () => {
     await using disposer = new AsyncDisposableStack()
     const source = disposer.adopt(
-      await EVMChain.fromUrl(SEPOLIA_RPC, { apiClient: null, logger: testLogger }),
+      await EVMChain.fromUrl(sepoliaRpc, { apiClient: null, logger: testLogger }),
       (source) => source.provider.destroy(),
     )
 
@@ -420,7 +448,7 @@ describe('Solana Devnet CCIP v2 Integration', { skip, timeout: 300_000 }, () => 
   it('should resolve v2 verifications policy via get_ccvs_for_msg (RMN accounts) without a simulation panic', async () => {
     await using disposer = new AsyncDisposableStack()
     const source = disposer.adopt(
-      await EVMChain.fromUrl(SEPOLIA_RPC, { apiClient: null, logger: testLogger }),
+      await EVMChain.fromUrl(sepoliaRpc, { apiClient: null, logger: testLogger }),
       (source) => source.provider.destroy(),
     )
     const tx = await source.getTransaction(EVM_TO_SOLANA_V2_TX)
@@ -461,7 +489,7 @@ describe('Solana Devnet CCIP v2 Integration', { skip, timeout: 300_000 }, () => 
     async function runAssertions() {
       await using disposer = new AsyncDisposableStack()
       const dest = disposer.adopt(
-        await EVMChain.fromUrl(SEPOLIA_RPC, { apiClient: null, logger: testLogger }),
+        await EVMChain.fromUrl(sepoliaRpc, { apiClient: null, logger: testLogger }),
         (dest) => dest.provider.destroy(),
       )
 
@@ -485,7 +513,7 @@ describe('Solana Devnet CCIP v2 Integration', { skip, timeout: 300_000 }, () => 
   it('should fetch the latest Sepolia -> Solana v2 execution', async () => {
     await using disposer = new AsyncDisposableStack()
     const source = disposer.adopt(
-      await EVMChain.fromUrl(SEPOLIA_RPC, { apiClient: null, logger: testLogger }),
+      await EVMChain.fromUrl(sepoliaRpc, { apiClient: null, logger: testLogger }),
       (source) => source.provider.destroy(),
     )
 

--- a/ccip-sdk/src/solana/__tests__/integration.test.ts
+++ b/ccip-sdk/src/solana/__tests__/integration.test.ts
@@ -4,7 +4,7 @@ import { after, before, describe, it } from 'node:test'
 
 import { Connection, PublicKey } from '@solana/web3.js'
 
-import { rpcEndpoint } from '../../../../scripts/test-endpoints.ts'
+import { raceRpcEndpoint, rpcEndpoint } from '../../../../scripts/test-endpoints.ts'
 import { useResourceForDescribe } from '../../../../scripts/useResource.ts'
 import { EVMChain } from '../../evm/index.ts'
 import { discoverOffRamp } from '../../execution.ts'
@@ -25,7 +25,6 @@ import { SolanaChain } from '../index.ts'
 
 const FUJI_RPC = rpcEndpoint('RPC_FUJI')
 const SEPOLIA_RPC = rpcEndpoint('RPC_SEPOLIA')
-const SOLANA_DEVNET_RPC = rpcEndpoint('RPC_SOLANA_DEVNET')
 const SOLANA_OFFRAMP = 'offqSMQWgQud6WJz694LRzkeN5kMYpCHTpXQr3Rkcjm'
 const SOLANA_V2_SEND_TX =
   '5RrQuDzcwPdVTKTTLVNhz31V5XzNLRZdxaGzLQddqePsu4TYycS6BMKP8V2WtuQ2VS9GdWTZfGt4WjnzKMBZFdM5'
@@ -39,6 +38,28 @@ const SOLANA_V2_SEND_MESSAGE_ID =
   '0x706918e7a9b62d8592733f7f790c520285661a7ddd0fbeaa6301660c8d32a722'
 const EVM_TO_SOLANA_V2_MESSAGE_ID =
   '0x6aada2cd53b51bd5b4f12cbd01b1e43a092d692e3211dd8a8cb062f28c28144f'
+
+/**
+ * Retention-aware health probe for the public devnet endpoints (passed to
+ * {@link raceRpcEndpoint}): an endpoint only wins the race when it answers the
+ * fixture execution tx — the very data the scans here need — inside the race
+ * timeout, so a fast-but-pruned or hard-429ing public endpoint never binds the
+ * suite (CI's shared egress IP trips keyless quotas run to run).
+ */
+const solanaDevnetHealthy = (url: string) =>
+  fetch(url, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'getTransaction',
+      params: [SOLANA_V2_EXEC_TX, { maxSupportedTransactionVersion: 1, commitment: 'confirmed' }],
+    }),
+    signal: AbortSignal.timeout(20_000),
+  })
+    .then((res) => res.json() as Promise<{ result?: unknown }>)
+    .then((json) => json.result != null)
 
 // Latest v2 messages on the current (post-redeploy) contracts, for both directions.
 const SOLANA_TO_SEPOLIA_V2_TX =
@@ -291,10 +312,13 @@ describe('Solana Devnet CCIP v2 Integration', { skip, timeout: 300_000 }, () => 
   let solanaChain: SolanaChain
 
   before(async () => {
-    solanaChain = await SolanaChain.fromUrl(SOLANA_DEVNET_RPC, {
-      apiClient: null,
-      logger: testLogger,
-    })
+    solanaChain = await SolanaChain.fromUrl(
+      await raceRpcEndpoint('RPC_SOLANA_DEVNET', solanaDevnetHealthy),
+      {
+        apiClient: null,
+        logger: testLogger,
+      },
+    )
   })
 
   it('should synthesize and decode CCIPMessageSentV2 from Anchor CPI event data', async () => {
@@ -501,10 +525,13 @@ describe('Solana Devnet estimateReceiveExecution Tests', { skip }, () => {
   let chain: SolanaChain | undefined
 
   before(async () => {
-    chain = await SolanaChain.fromUrl(SOLANA_DEVNET_RPC, {
-      apiClient: null,
-      logger: testLogger,
-    })
+    chain = await SolanaChain.fromUrl(
+      await raceRpcEndpoint('RPC_SOLANA_DEVNET', solanaDevnetHealthy),
+      {
+        apiClient: null,
+        logger: testLogger,
+      },
+    )
   })
 
   after(async () => {})

--- a/ccip-sdk/src/solana/index.ts
+++ b/ccip-sdk/src/solana/index.ts
@@ -1722,7 +1722,7 @@ export class SolanaChain extends Chain<typeof ChainFamily.Solana> {
       }
       const verifications = await fetchVerifications(request.message.messageId, {
         apiClient: this.apiClient,
-        indexer: opts.indexer ?? this.network.networkType,
+        indexer: opts.indexer ?? this.verificationsIndexer ?? this.network.networkType,
         watch:
           opts.watch instanceof AbortSignal
             ? AbortSignal.any([opts.watch, this.abort])

--- a/ccip-sdk/src/ton/index.test.ts
+++ b/ccip-sdk/src/ton/index.test.ts
@@ -972,6 +972,117 @@ describe('TON index unit tests', () => {
     })
   })
 
+  describe('v3 index url resolution', () => {
+    // A raw-hash tx lookup is the simplest v3 call to observe end-to-end: which index
+    // URL served it (and whether a probe preceded it) is the point of these tests.
+    const TX_RESPONSE = () =>
+      new Response(
+        JSON.stringify({
+          transactions: [{ account: '0:' + '11'.repeat(32), lt: '123', hash: 'def' }],
+        }),
+        { headers: { 'Content-Type': 'application/json' } },
+      )
+
+    function chainCapturingV3Urls(
+      ctx: { v3Url?: string },
+      endpoint: string,
+      handle: (url: URL) => Response,
+    ) {
+      const urls: string[] = []
+      const fetchImpl = (async (input: unknown) => {
+        const url = new URL(String(input instanceof Request ? input.url : input))
+        urls.push(url.href)
+        return handle(url)
+      }) as unknown as typeof fetch
+      const client = {
+        parameters: { endpoint },
+        // Hydration after the index lookup: the lookup's account/lt are synthetic, so
+        // this returns null and getTransaction rejects — the captured URL is the point.
+        getTransaction: async () => null,
+      } as unknown as TonClient
+      return { chain: new TONChain(client, mockNetworkInfo, { ...ctx, fetch: fetchImpl }), urls }
+    }
+
+    it('raw-hash tx lookup honors ctx.v3Url verbatim (no probe)', async () => {
+      const { chain, urls } = chainCapturingV3Urls(
+        { v3Url: 'http://mock-index.example/api/v3?api_key=s3cr3t' },
+        'https://toncenter.com/api/v2/jsonRPC?api_key=rpc-key',
+        (url) =>
+          url.pathname === '/api/v3/transactions'
+            ? TX_RESPONSE()
+            : new Response('', { status: 404 }),
+      )
+
+      await assert.rejects(() => chain.getTransaction('ab'.repeat(32)), /not found/i)
+
+      const v3 = urls.filter((u) => u.includes('/api/v3'))
+      assert.equal(v3.length, 1, `exactly one v3 call expected, got: ${urls.join(', ')}`)
+      const parsed = new URL(v3[0]!)
+      assert.equal(parsed.origin, 'http://mock-index.example')
+      assert.equal(parsed.pathname, '/api/v3/transactions')
+      assert.equal(parsed.searchParams.get('api_key'), 's3cr3t')
+      assert.equal(parsed.searchParams.get('hash'), 'ab'.repeat(32))
+    })
+
+    it('a derived v3 url is probed and kept when the host serves v3', async () => {
+      const { chain, urls } = chainCapturingV3Urls(
+        {},
+        'http://mock-ton-api/api/v2/jsonRPC',
+        (url) =>
+          url.pathname === '/api/v3/masterchainInfo'
+            ? new Response(JSON.stringify({ last: { seqno: 100 } }), {
+                headers: { 'Content-Type': 'application/json' },
+              })
+            : url.pathname === '/api/v3/transactions'
+              ? TX_RESPONSE()
+              : new Response('', { status: 404 }),
+      )
+
+      await assert.rejects(() => chain.getTransaction('ab'.repeat(32)), /not found/i)
+
+      const v3 = urls.filter((u) => u.includes('/api/v3'))
+      assert.ok(
+        v3.every((u) => u.startsWith('http://mock-ton-api/api/v3/')),
+        `every v3 call must target the derived index; got: ${v3.join(', ')}`,
+      )
+      assert.match(v3[0]!, /masterchainInfo/, 'the probe (v3-only method) goes first')
+      assert.match(
+        v3.at(-1)!,
+        /\/api\/v3\/transactions\?/,
+        'the raw-hash lookup then uses the derived index',
+      )
+    })
+
+    it('a failed probe on a v2-only host falls back to the public index', async () => {
+      const { chain, urls } = chainCapturingV3Urls(
+        {},
+        'http://v2-only.example/api/v2/jsonRPC',
+        (url) =>
+          url.host === 'testnet.toncenter.com' && url.pathname === '/api/v3/transactions'
+            ? TX_RESPONSE()
+            : new Response('no v3 here', { status: 404 }),
+      )
+
+      await assert.rejects(() => chain.getTransaction('ab'.repeat(32)), /not found/i)
+
+      assert.match(
+        urls[0]!,
+        /^http:\/\/v2-only\.example\/api\/v3\/masterchainInfo/,
+        'the probe hits the derived host first',
+      )
+      assert.ok(
+        urls.some((u) => u.startsWith('https://testnet.toncenter.com/api/v3/transactions')),
+        `the lookup must fall back to the public index; got: ${urls.join(', ')}`,
+      )
+      assert.ok(
+        urls.every(
+          (u) => !u.startsWith('http://v2-only.example/api/v3/') || u.includes('masterchainInfo'),
+        ),
+        'nothing but the probe ever touches the v2-only host',
+      )
+    })
+  })
+
   describe('fromUrl', () => {
     it('appends the JSON-RPC path while preserving the query string', async () => {
       const chain = await TONChain.fromUrl('https://testnet.toncenter.com/api/v2?api_key=s3cr3t')

--- a/ccip-sdk/src/ton/index.ts
+++ b/ccip-sdk/src/ton/index.ts
@@ -40,7 +40,7 @@ import {
   redactEndpointUrl,
 } from '../fetch.ts'
 import type { LeafHasher } from '../hasher/common.ts'
-import { type NetworkInfo, ChainFamily, networkInfo } from '../networks.ts'
+import { type NetworkInfo, ChainFamily, NetworkType, networkInfo } from '../networks.ts'
 import { buildMessageForDest } from '../requests.ts'
 import { supportedChains } from '../supported-chains.ts'
 import {
@@ -77,6 +77,7 @@ import {
   type TonV3Event,
   fetchV3IndexedTip,
   openV3EventStream,
+  publicTonV3BaseUrl,
   streamTransactionsForAddress,
   streamV3TxMeta,
   tonV3BaseUrl,
@@ -114,11 +115,22 @@ function shardContainsAccount(shardStr: string, acct: Address): boolean {
 /**
  * TON-specific {@link ChainContext} extras. Optional and local to this module on
  * purpose: the shared ChainContext stays family-agnostic, while TON's secondary index
- * API (TonCenter v3, used by the getLogs fast path) accepts its own fetch override.
- * `v3Fetch` defaults to `fetch` verbatim when one is provided; otherwise the chain
- * builds a host-paced, fail-fast instance itself.
+ * API (TonCenter v3, used by the getLogs fast path and raw-hash tx lookups) accepts
+ * its own URL and fetch overrides. `v3Url` is honored verbatim when provided; one is
+ * inferred from the provider endpoint only when it is omitted. `v3Fetch` defaults to
+ * `fetch` verbatim when one is provided; otherwise the chain builds a host-paced,
+ * fail-fast instance from the resolved v3 URL itself.
  */
 export type TONChainContext = ChainContext & {
+  /**
+   * TonCenter v3 index base URL for this chain, honored verbatim (query included,
+   * e.g. an `api_key`) by every v3 index call: the getLogs fast path, the indexed
+   * tip, the bounded-walk metadata oracle and raw-hash tx lookups. NEVER probed —
+   * an explicit URL is taken on faith. When omitted, one is inferred from the
+   * provider endpoint and probed once with a v3-only method; a host that does not
+   * serve v3 falls back to the public toncenter index for this network.
+   */
+  v3Url?: string
   /** Fetch override for the TonCenter v3 index API (see TONChain.v3FetchFor). */
   v3Fetch?: typeof fetch
 }
@@ -163,9 +175,18 @@ export class TONChain extends Chain<typeof ChainFamily.TON> {
       ctx?.fetch ??
       createRateLimitedFetch({ seed: { limit: 1, windowMs: 1500 }, maxRetries: 6 }, ctx)
 
+    // The v3 index base URL is resolved lazily (v3UrlFor): an explicit ctx.v3Url wins
+    // and is taken on faith; otherwise one is inferred from the provider endpoint (a
+    // toncenter v2 path → same-origin /api/v3 with its query) and PROBED with a
+    // v3-only method, falling back to the public index when the host lacks v3. Every
+    // v3 call — getLogs fast path, indexed tip, walk metadata oracle, raw-hash tx
+    // lookups — shares the resolution.
+    this.ctxV3Url_ = ctx?.v3Url
+
     // v3 index fetch: an explicit `v3Fetch` (TON-local ctx extra) wins; a
     // caller-provided `fetch` is reused verbatim (tests, tuned callers); otherwise the
-    // first v3 call lazily installs a host-paced, fail-fast instance (see v3FetchFor).
+    // first v3 call lazily installs a host-paced, fail-fast instance built from the
+    // resolved v3 URL (see v3FetchFor).
     this.v3Fetch_ = ctx?.v3Fetch ?? ctx?.fetch
 
     this.getTransaction = memoize(this.getTransaction.bind(this), {
@@ -272,16 +293,6 @@ export class TONChain extends Chain<typeof ChainFamily.TON> {
       // Resolve the fetch function: user-supplied verbatim, then rate-limited default.
       const fetchFn: typeof fetch =
         ctx?.fetch ?? createRateLimitedFetch(fetchProfileForUrl(url), ctx)
-      // Same provenance for the v3 index fetch (a TON-local ctx extra): a
-      // caller-supplied fetch is reused verbatim; the default path gets a dedicated
-      // paced, fail-fast instance instead of the v2 endpoint's profile (see v3FetchFor).
-      const v3Fetch: typeof fetch | undefined =
-        ctx?.v3Fetch ??
-        ctx?.fetch ??
-        createRateLimitedFetch(
-          { seed: { limit: 1, windowMs: 1500 }, maxRetries: 2, keyBy: 'origin' },
-          ctx,
-        )
 
       // For known public providers, detect network from URL to avoid an API call during init
       // (free-tier endpoints are rate-limited and return transient 5xx errors).
@@ -291,6 +302,25 @@ export class TONChain extends Chain<typeof ChainFamily.TON> {
         // testnet.toncenter.com / testnet.tonapi.io → testnet; bare domain → mainnet
         isMainnetHint = !url.includes('testnet.')
       }
+
+      // Same provenance for the v3 index fetch (a TON-local ctx extra): a
+      // caller-supplied fetch is reused verbatim; the default path gets a dedicated
+      // paced, fail-fast instance profiled for the chain's v3 index host — an explicit
+      // ctx.v3Url when set, else the endpoint-derived/public index (see v3FetchFor).
+      const v3Fetch: typeof fetch | undefined =
+        ctx?.v3Fetch ??
+        ctx?.fetch ??
+        createRateLimitedFetch(
+          {
+            ...fetchProfileForUrl(
+              ctx?.v3Url ??
+                tonV3BaseUrl(url, isMainnetHint ? NetworkType.Mainnet : NetworkType.Testnet),
+            ),
+            maxRetries: 2,
+            keyBy: 'origin',
+          },
+          ctx,
+        )
 
       // Always use the fetch adapter so our fetch function is used for all requests.
       // Also merges ctx.abort into every request signal so raceAc.abort() cancels in-flight sockets.
@@ -504,15 +534,71 @@ export class TONChain extends Chain<typeof ChainFamily.TON> {
   // constructor when the caller supplies `v3Fetch`/`fetch`; lazily created otherwise.
   private v3Fetch_?: typeof fetch
 
+  /** Explicit v3 index base URL from ctx (see TONChainContext.v3Url) — honored
+   * verbatim, never probed. */
+  private readonly ctxV3Url_?: string
+
+  /** The chain's resolved v3 index URL, settled once per chain (see v3UrlFor). */
+  private v3UrlResolved_?: Promise<string>
+
+  /** Whether v3Fetch_ was lazily built (vs caller-provided) — a failed probe may
+   * rebuild it for the fallback host's profile. */
+  private v3FetchLazilyBuilt_ = false
+
+  /**
+   * The chain's v3 index base URL: ctx.v3Url is honored verbatim (never probed);
+   * otherwise a same-origin /api/v3 derived from a toncenter-shaped endpoint is
+   * probed once with a v3-only method, falling back to the public toncenter index
+   * when the host does not serve v3 (see probeV3Url).
+   */
+  private v3UrlFor(): Promise<string> {
+    if (this.ctxV3Url_) return Promise.resolve(this.ctxV3Url_)
+    return (this.v3UrlResolved_ ??= this.probeV3Url())
+  }
+
+  /**
+   * Probes the endpoint-derived v3 index with a v3-only method (`/masterchainInfo`):
+   * a host serving v2 only — e.g. a private proxy with a toncenter-shaped path —
+   * must not poison v3 consumers, so a failed probe permanently falls back to the
+   * public toncenter index for this network (a chain restart re-probes). A
+   * non-toncenter-shaped endpoint resolves to the public default without probing.
+   */
+  private async probeV3Url(): Promise<string> {
+    const derived = tonV3BaseUrl(this.provider.parameters.endpoint, this.network.networkType)
+    const fallbackUrl = publicTonV3BaseUrl(this.network.networkType)
+    if (derived === fallbackUrl) return derived // nothing endpoint-derived to verify
+    try {
+      const seqno = await fetchV3IndexedTip({
+        rateLimitedFetch: this.v3FetchFor(derived),
+        v3BaseUrl: derived,
+      })
+      // The probe just paid the tip call — warm the 30s cache with it.
+      this.v3Tip_ = { at: Date.now(), seqno }
+      return derived
+    } catch (error) {
+      this.logger.warn(
+        `TON v3 index probe failed on ${redactEndpointUrl(derived)}; falling back to the public index for this network`,
+        error,
+      )
+      // Rebuild the lazy fetch for the fallback host's profile; a caller-provided
+      // fetch stays untouched.
+      if (this.v3FetchLazilyBuilt_) this.v3Fetch_ = undefined
+      return fallbackUrl
+    }
+  }
+
   /** The dedicated v3-index fetch (see the note above); lazily created when unset. */
   private v3FetchFor(baseUrl: string): typeof fetch {
+    if (this.v3Fetch_) return this.v3Fetch_
     // keyBy origin: the index's keyless quota (~1 RPS per egress IP) is shared
     // across /messages, /transactions and /masterchainInfo — per-path limiters
     // would each pace independently and re-burst the host, tripping 429s.
-    return (this.v3Fetch_ ??= createRateLimitedFetch(
+    this.v3Fetch_ = createRateLimitedFetch(
       { ...fetchProfileForUrl(baseUrl), maxRetries: 2, keyBy: 'origin' },
       { logger: this.logger },
-    ))
+    )
+    this.v3FetchLazilyBuilt_ = true
+    return this.v3Fetch_
   }
 
   // The v3 index's masterchain tip, cached 30s: the lag guard is network-global, so a
@@ -542,12 +628,13 @@ export class TONChain extends Chain<typeof ChainFamily.TON> {
   }
 
   /** The v3 index's masterchain tip, cached 30s (network-global, not per-scan). */
-  private async getV3IndexedTip(baseUrl: string): Promise<number> {
+  private async getV3IndexedTip(): Promise<number> {
     const cached = this.v3Tip_
     if (cached && Date.now() - cached.at < 30_000) return cached.seqno
+    const v3BaseUrl = await this.v3UrlFor()
     const seqno = await fetchV3IndexedTip({
-      rateLimitedFetch: this.v3FetchFor(baseUrl),
-      v3BaseUrl: baseUrl,
+      rateLimitedFetch: this.v3FetchFor(v3BaseUrl),
+      v3BaseUrl,
     })
     this.v3Tip_ = { at: Date.now(), seqno }
     return seqno
@@ -642,11 +729,16 @@ export class TONChain extends Chain<typeof ChainFamily.TON> {
             'hash',
             `Invalid TON transaction hash format: "${tx}". Expected "workchain:address:lt:hash" or 64-char hex hash`,
           )
+        // Same provenance as the getLogs index paths: the chain's resolved v3 index
+        // base (ctx.v3Url, else probed endpoint-inference with a public-index
+        // fallback) and the dedicated paced, fail-fast v3 fetch — not the v2
+        // endpoint's fetch profile.
+        const v3BaseUrl = await this.v3UrlFor()
         const txInfo = await lookupTxByRawHash(
           cleanHash,
           this.network.networkType,
-          this.rateLimitedFetch,
-          this,
+          this.v3FetchFor(v3BaseUrl),
+          { logger: this.logger, baseUrl: v3BaseUrl },
         )
 
         tx = `${txInfo.account}:${txInfo.lt}:${cleanHash}`
@@ -1082,14 +1174,14 @@ export class TONChain extends Chain<typeof ChainFamily.TON> {
       userStartBlock == null &&
       ((opts.startTime != null && sinceLt == null) || sinceIndexLt != null)
     ) {
-      const v3BaseUrl = tonV3BaseUrl(this.provider.parameters.endpoint, this.network.networkType)
+      const v3BaseUrl = await this.v3UrlFor()
       const v3 = await openV3EventStream(
         opts_,
         {
           provider: this.provider,
           v3BaseUrl,
           rateLimitedFetch: this.v3FetchFor(v3BaseUrl),
-          getIndexedTip: () => this.getV3IndexedTip(v3BaseUrl),
+          getIndexedTip: () => this.getV3IndexedTip(),
           getTransaction: (tx, seqno) => this.buildChainTransaction(tx, acct, seqno),
           logger: this.logger,
         },
@@ -1131,8 +1223,10 @@ export class TONChain extends Chain<typeof ChainFamily.TON> {
     // first yield, the walk degrades to the legacy collect-then-drain pagination with
     // per-tx seqno resolution. An index/RPC disagreement mid-stream truncates like a
     // chain gap.
-    const v3Base = tonV3BaseUrl(this.provider.parameters.endpoint, this.network.networkType)
     const deep = (await this.windowAgeSeconds(acct, sinceLtFloor)) >= TONChain.WALK_META_MIN_AGE_S
+    // Resolving the v3 URL probes the index once per chain — skipped entirely on
+    // shallow scans, so a v2-only chain doing steady-state polls never touches v3.
+    const v3Url = deep ? await this.v3UrlFor() : undefined
     const walkCtx = {
       provider: this.provider,
       getTransaction: (tx: Transaction, seqno?: number): Promise<ChainTransaction> =>
@@ -1140,7 +1234,7 @@ export class TONChain extends Chain<typeof ChainFamily.TON> {
       ...(deep && {
         v3Meta: (afterLt: bigint) =>
           streamV3TxMeta(
-            { rateLimitedFetch: this.v3FetchFor(v3Base), v3BaseUrl: v3Base },
+            { rateLimitedFetch: this.v3FetchFor(v3Url!), v3BaseUrl: v3Url! },
             acct,
             0,
             afterLt,

--- a/ccip-sdk/src/ton/logs.ts
+++ b/ccip-sdk/src/ton/logs.ts
@@ -320,11 +320,21 @@ export type TonV3Context = {
   logger?: Pick<Logger, 'debug' | 'warn'>
 }
 
+/** The public TonCenter v3 index for a network — the terminal fallback when no
+ * endpoint-derived index is usable (or none was derivable). */
+export function publicTonV3BaseUrl(networkType: NetworkType): string {
+  return networkType === NetworkType.Mainnet
+    ? 'https://toncenter.com/api/v3'
+    : 'https://testnet.toncenter.com/api/v3'
+}
+
 /**
  * The TonCenter v3 index base URL for a chain: derived from the v2 RPC endpoint when
  * it has an `/api/v2` path (`https://toncenter.com/api/v2/jsonRPC` →
  * `https://toncenter.com/api/v3`); otherwise the public TonCenter index for the
  * chain's network — the same fallback `lookupTxByRawHash` uses for hash lookups.
+ * Note the derivation alone does not guarantee the derived host actually SERVES v3
+ * (a v2-only proxy does not) — callers probe before trusting it.
  * StartTime-only scans are rare (cold backfills), so leaning on the public index for
  * them is acceptable even for chains otherwise served by a private endpoint.
  * @internal
@@ -338,9 +348,7 @@ export function tonV3BaseUrl(endpoint: string, networkType: NetworkType): string
   } catch {
     // not a parseable URL — fall through to the network-type default
   }
-  return networkType === NetworkType.Mainnet
-    ? 'https://toncenter.com/api/v3'
-    : 'https://testnet.toncenter.com/api/v3'
+  return publicTonV3BaseUrl(networkType)
 }
 
 /** Builds a v3 request URL from the base, preserving the base's query (e.g. toncenter's `?api_key=`). */

--- a/ccip-sdk/src/ton/utils.test.ts
+++ b/ccip-sdk/src/ton/utils.test.ts
@@ -131,6 +131,28 @@ describe('TON utils unit tests', () => {
       assert.equal(parsed.hostname, 'toncenter.com', 'Should use mainnet URL')
     })
 
+    it('should prefer a provided baseUrl, carrying its query (api_key)', async () => {
+      let capturedUrl = ''
+      const mockFetch = (async (url: string) => {
+        capturedUrl = url
+        return {
+          json: async () => ({
+            transactions: [{ account: '0:abc', lt: '123', hash: 'def' }],
+          }),
+        }
+      }) as unknown as typeof fetch
+
+      await lookupTxByRawHash('abcd', NetworkType.Mainnet, mockFetch, {
+        baseUrl: 'https://private-index.example/api/v3?api_key=s3cr3t',
+      })
+
+      const parsed = new URL(capturedUrl)
+      assert.equal(parsed.origin, 'https://private-index.example')
+      assert.equal(parsed.pathname, '/api/v3/transactions')
+      assert.equal(parsed.searchParams.get('api_key'), 's3cr3t')
+      assert.equal(parsed.searchParams.get('hash'), 'abcd')
+    })
+
     it('should throw CCIPTransactionNotFoundError when no transactions found', async () => {
       const mockFetch = (async () => ({
         json: async () => ({ transactions: [] }),

--- a/ccip-sdk/src/ton/utils.ts
+++ b/ccip-sdk/src/ton/utils.ts
@@ -411,30 +411,38 @@ export async function parseJettonContent(
  * @param networkType - Network type (mainnet or testnet)
  * @param fetch - Rate-limited fetch function
  * @param logger - Logger instance
+ * @param baseUrl - TonCenter v3 index base URL to override the network's public
+ *   default with (e.g. one derived from the chain's endpoint via `tonV3BaseUrl`, so
+ *   a private endpoint and its `?api_key=` are honored). Any query on it is carried
+ *   over to the lookup, as in the index paths in `logs.ts`.
  * @returns Transaction identifier components needed for V4 API lookup
  */
 export async function lookupTxByRawHash(
   hash: string,
   networkType: NetworkType,
   fetch = globalThis.fetch,
-  { logger = console }: WithLogger = {},
+  { logger = console, baseUrl: v3BaseUrl }: WithLogger & { baseUrl?: string } = {},
 ): Promise<{
   account: string
   lt: string
   hash: string
 }> {
-  const baseUrl =
-    networkType === NetworkType.Mainnet
-      ? 'https://toncenter.com/api/v3/transactions'
-      : 'https://testnet.toncenter.com/api/v3/transactions'
-
   // TonCenter V3 accepts hex directly
   const cleanHash = bytesToBuffer(hash).toString('hex')
-  const url = `${baseUrl}?hash=${cleanHash}`
+
+  const base = new URL(
+    v3BaseUrl ??
+      (networkType === NetworkType.Mainnet
+        ? 'https://toncenter.com/api/v3'
+        : 'https://testnet.toncenter.com/api/v3'),
+  )
+  const url = new URL(`${base.pathname.replace(/\/+$/, '')}/transactions`, base)
+  for (const [key, value] of base.searchParams) url.searchParams.append(key, value)
+  url.searchParams.append('hash', cleanHash)
 
   let response: Response
   try {
-    response = await fetch(url, {
+    response = await fetch(url.href, {
       headers: { Accept: 'application/json' },
     })
   } catch (error) {

--- a/scripts/test-endpoints.ts
+++ b/scripts/test-endpoints.ts
@@ -55,12 +55,12 @@ export type RpcEnvName = (typeof RPC_ENV)[keyof typeof RPC_ENV]
  */
 export const DEFAULT_RPC_ENDPOINTS: Record<RpcEnvName, string> = {
   RPC_SEPOLIA:
-    // raced where it matters (the solana devnet suites probe a fixture tx before
-    // binding); ethpandaops leads for first-entry suites.
-    // ethereum-sepolia-rpc.publicnode.com / sepolia.drpc.org added 2026-09:
-    // ethpandaops throttles hard from CI's shared egress IP (90s per-request
-    // aborts inside EVM ops → suite timeouts).
-    'https://rpc.sepolia.ethpandaops.io,https://ethereum-sepolia-rpc.publicnode.com,https://0xrpc.io/sep,https://gateway.tenderly.co/public/sepolia,https://sepolia.drpc.org',
+    // ethpandaops leads for first-entry suites. Do NOT add drpc (or other
+    // first-answer-fast but call-unsafe) endpoints: the CLI e2e races these by
+    // chainId, and drpc's pattern (wins the race, then fails half of every
+    // batched eth_call with empty revert data — seen on its bsc endpoint)
+    // breaks the show/lane e2e suites the same way (observed 2026-09).
+    'https://rpc.sepolia.ethpandaops.io,https://0xrpc.io/sep,https://gateway.tenderly.co/public/sepolia',
   RPC_BASE_SEPOLIA: 'https://gateway.tenderly.co/public/base-sepolia,https://sepolia.base.org',
   RPC_ARBITRUM_SEPOLIA: 'https://sepolia-rollup.arbitrum.io/rpc',
   RPC_OPTIMISM_SEPOLIA: 'https://gateway.tenderly.co/public/optimism-sepolia',

--- a/scripts/test-endpoints.ts
+++ b/scripts/test-endpoints.ts
@@ -55,7 +55,12 @@ export type RpcEnvName = (typeof RPC_ENV)[keyof typeof RPC_ENV]
  */
 export const DEFAULT_RPC_ENDPOINTS: Record<RpcEnvName, string> = {
   RPC_SEPOLIA:
-    'https://rpc.sepolia.ethpandaops.io,https://0xrpc.io/sep,https://gateway.tenderly.co/public/sepolia',
+    // raced where it matters (the solana devnet suites probe a fixture tx before
+    // binding); ethpandaops leads for first-entry suites.
+    // ethereum-sepolia-rpc.publicnode.com / sepolia.drpc.org added 2026-09:
+    // ethpandaops throttles hard from CI's shared egress IP (90s per-request
+    // aborts inside EVM ops → suite timeouts).
+    'https://rpc.sepolia.ethpandaops.io,https://ethereum-sepolia-rpc.publicnode.com,https://0xrpc.io/sep,https://gateway.tenderly.co/public/sepolia,https://sepolia.drpc.org',
   RPC_BASE_SEPOLIA: 'https://gateway.tenderly.co/public/base-sepolia,https://sepolia.base.org',
   RPC_ARBITRUM_SEPOLIA: 'https://sepolia-rollup.arbitrum.io/rpc',
   RPC_OPTIMISM_SEPOLIA: 'https://gateway.tenderly.co/public/optimism-sepolia',

--- a/scripts/test-endpoints.ts
+++ b/scripts/test-endpoints.ts
@@ -78,16 +78,17 @@ export const DEFAULT_RPC_ENDPOINTS: Record<RpcEnvName, string> = {
     // per-family race would otherwise let a pruned fullnode win the chain).
     'https://archive.testnet.aptoslabs.com/v1',
   RPC_SOLANA_DEVNET: [
-    // raced: first endpoint to resolve wins, so a throttled one doesn't stall
-    // the suite; retention varies over time (as of 2026-08: onfinality prunes
-    // signature history around ~1 month, api.devnet.solana.com/devnet.rpcpool.com
-    // retain longer but 429 harder from cold starts) — keep fixtures fresher
-    // than the shortest observed retention horizon. devnet.rpcpool.com leads:
-    // public, holds at least ~1 week of txs and doesn't 429 as aggressively as
-    // onfinality's free tier.
+    // raced via raceRpcEndpoint (the suites probe a fixture tx): first endpoint to
+    // answer wins, so a throttled one doesn't stall the suite. Retention varies over
+    // time (as of 2026-08: onfinality prunes signature history around ~1 month,
+    // api.devnet.solana.com/devnet.rpcpool.com retain longer but 429 harder from cold
+    // starts) — keep fixtures fresher than the shortest observed retention horizon.
+    // devnet.rpcpool.com leads: public, holds at least ~1 week of txs and doesn't 429
+    // as aggressively as the others; onfinality trails (429s hard from cold/shared
+    // egress IPs, observed 2026-09).
     'https://devnet.rpcpool.com',
-    'https://solana-devnet.api.onfinality.io/public',
     'https://api.devnet.solana.com',
+    'https://solana-devnet.api.onfinality.io/public',
   ].join(','),
   RPC_TON_TESTNET: 'https://testnet.toncenter.com/api/v2',
   RPC_SUI_TESTNET: 'https://sui-testnet-endpoint.blockvision.org',
@@ -146,4 +147,38 @@ export function rpcEndpoints(envName: RpcEnvName): string[] {
  */
 export function rpcEndpoint(envName: RpcEnvName): string {
   return rpcEndpoints(envName)[0]!
+}
+
+/**
+ * Races every endpoint configured for `envName` with a probe and returns the
+ * first one that passes — for suites that construct a single chain, which
+ * would otherwise bind to the first entry and stall when that endpoint is
+ * throttled (CI's shared egress IP trips public endpoints' keyless quotas
+ * run-to-run; see the Solana devnet v2 suite's 300s CI timeout).
+ *
+ * The probe should be cheap but REPRESENTATIVE of what the suite needs: for
+ * retention-sensitive scans, probe the fixture data itself (e.g. a
+ * `getTransaction` on a fixture tx) — a fast-but-pruned endpoint that wins the
+ * race stalls the suite just the same. Each probe is bounded by `timeoutMs`;
+ * when every probe fails or times out, falls back to {@link rpcEndpoint} (the
+ * previous first-entry behavior) so the suite still runs as it used to.
+ */
+export async function raceRpcEndpoint(
+  envName: RpcEnvName,
+  probe: (url: string) => Promise<boolean>,
+  { timeoutMs = 20_000 }: { timeoutMs?: number } = {},
+): Promise<string> {
+  const attempts = rpcEndpoints(envName).map(async (url) => {
+    const ok = await Promise.race([
+      Promise.resolve(probe(url)).catch(() => false),
+      new Promise<false>((resolve) => setTimeout(() => resolve(false), timeoutMs)),
+    ])
+    if (!ok) throw new Error(`probe failed for ${url}`)
+    return url
+  })
+  try {
+    return await Promise.any(attempts)
+  } catch {
+    return rpcEndpoint(envName)
+  }
 }


### PR DESCRIPTION
## Summary

Several SDK operations quietly consult **secondary, "public-indexer-like" endpoints** whose URLs were hardcoded or inferred from the primary RPC endpoint, with no way for callers to redirect them. This gives every one of them a chain-context (`ctx`) override with a documented default, and documents the whole set in a new guide.

| Scope | Secondary endpoint | ctx option | Default |
|---|---|---|---|
| all | CCIP REST API (lane info, message lookups, execution inputs) | `apiClient` *(existing)* | `https://api.ccip.chain.link` |
| all | CCIP v2 verifier indexers (`getVerifications`) | `verificationsIndexer` **(new)** — per-call `indexer` still wins | `indexer-{1,2}(.testnet).ccip.chain.link` |
| TON | TonCenter v3 index | `v3Url` **(new)** | probed endpoint inference → public TonCenter fallback |
| Aptos | GraphQL indexer | `indexerUrl` **(new)** | SDK per-network default (`https://api.<network>.aptoslabs.com/v1/graphql`) |
| Canton | CCIP CCV indexer service | `cantonConfig.indexerUrl` *(existing)* | `https://indexer-1.ccip.chain.link` |
| EVM, Solana, Sui | none — every query rides the single RPC endpoint | — | — |

## TON — `ctx.v3Url` with probed inference

Every v3 index consumer (the `getLogs` fast path, the indexed-tip probe, the deep-walk metadata oracle, and raw-hash tx lookups) previously hardcoded the public toncenter URLs or re-derived one from the endpoint — an inference that silently 404s on v2-only hosts. Resolution is now one lazily-settled, chain-cached value:

1. Explicit `ctx.v3Url` is honored verbatim, **never probed**.
2. A toncenter-shaped endpoint (`/api/v2` path) derives its same-origin `/api/v3` (query carried over, e.g. `api_key`), then **probes once** with a v3-only method (`/masterchainInfo`). A failed probe (v2-only proxy) permanently falls back to the public TonCenter index for the network, so bad inference never poisons v3 consumers. The probe's answer warms the 30s tip cache.
3. Any other endpoint goes straight to the public index without probing.

`lookupTxByRawHash` rides the resolved URL and the dedicated paced, fail-fast v3 fetch (`keyBy: origin`) instead of the v2 endpoint's fetch profile, and accepts an explicit base whose query is carried over. Shallow `getLogs` scans skip resolution entirely; on probe failure a lazily-built fetch is rebuilt for the fallback host's profile (caller-provided `v3Fetch`/`fetch` untouched).

## Aptos — `ctx.indexerUrl`

Aptos' GraphQL endpoint *is* its indexer: `queryIndexer` backs the `getLogs` fast path and the execution-failure scans. `AptosChainContext.indexerUrl` wins over `settings.indexer` when the chain builds its own `AptosConfig` (no explicit `client`); the SDK's per-network default applies otherwise. The fullnode URL is never used to infer an indexer URL (a previously commented-out `${url}/v1/graphql` derivation is removed).

## Shared — `ctx.verificationsIndexer`

EVM/Solana `getVerifications` raced the public `ccip.chain.link` verifier indexers with no chain-level override; the ctx default applies when the per-call `indexer` option is absent. Canton already had `cantonConfig.indexerUrl`.

## Docs

New SDK guide **Chain Endpoints & Indexers** (`ccip-api-ref/docs-sdk/guides/chain-endpoints.mdx`): summary table, per-family sections with examples, resolution semantics, and the `ctx.fetch` interplay. Registered in the sidebar and linked from the Multi-Chain guide.

## Test plan

- [x] Full unit suite: 1245/1245 pass (all families except sandbox-blocked local-socket suites)
- [x] `tsc --noEmit` + `oxlint`/`oxfmt` clean in `ccip-sdk` and `ccip-api-ref`
- [x] New unit tests: TON v3 resolution (explicit / probe-success / probe-fallback), `lookupTxByRawHash` base override with query carry-over, Aptos `indexerUrl` override + SDK default
- [ ] Live integration tests not run (require live endpoints)